### PR TITLE
perf(core): 🚸 Respect current user branch.

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -627,9 +627,9 @@ ZI[EXTENDED_GLOB]=""
   emulate -LR zsh
   setopt extendedglob typesetsilent warncreateglobal
   [[ $1 = -q ]] && +zi-message "{info2}Updating »»» ❮ ZI ❯ {…}{rst}"
-  local nl=$'\n' escape=$'\x1b['
+  local nl=$'\n' escape=$'\x1b[' current_branch=$(command git rev-parse --abbrev-ref HEAD 2>/dev/null)
   local -a lines
-  (   builtin cd -q "$ZI[BIN_DIR]" && command git checkout HEAD &>/dev/null && command git fetch --quiet && \
+  (   builtin cd -q "$ZI[BIN_DIR]" && command git checkout $current_branch &>/dev/null && command git fetch --quiet && \
   lines=( ${(f)"$(command git log --color --abbrev-commit --date=short --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset || %b' ..FETCH_HEAD)"} )
   if (( ${#lines} > 0 )); then
     # Remove the (origin/master ...) segments, to expect only tags to appear
@@ -646,9 +646,9 @@ ZI[EXTENDED_GLOB]=""
     builtin print
   fi
   if [[ $1 != -q ]] {
-    command git pull --no-stat --ff-only origin main
+    command git pull --no-stat --ff-only origin $current_branch
   } else {
-    command git pull --no-stat --quiet --ff-only origin main
+    command git pull --no-stat --quiet --ff-only origin $current_branch
   }
   )
   if [[ $1 != -q ]] {


### PR DESCRIPTION
Running `zi self-update` will checkout to the current local HEAD branch and pull updates from it if any. This allows users to maintain their own repo/branch/tags or avoid changes being made to the local files. 

<!--- Please provide a general summary of your changes in the title above -->
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
<!-- Please check the type of change your PR introduces: -->

- [ ] CI
- [ ] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [x] Improving performance of the project (not introducing new features)
- [ ] Other (please describe):

## What is the current behavior?

Currently, only the main branch checkout/pulled.

<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

1. When self-update will get branch with: `command git rev-parse --abbrev-ref HEAD 2>/dev/null`.
2. Will checkout to the output of the above command.
3. Will pull the update from the output of the above command. Will show local branch diffrences if any:

![snip](https://i.imgur.com/nBAkg34.png)

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No