### PR TITLE
feat(core): ✨ Load a code as local plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,3 @@
 {
-  "conventionalCommits.scopes": ["core", "docs", "general", "workspace"],
-  "markdownlint.config": {
-    "default": true,
-    "MD003": false,
-    "MD033": false,
-    "no-hard-tabs": false
-  }
+  "conventionalCommits.scopes": ["core", "docs", "general", "workspace"]
 }

--- a/lib/_zi
+++ b/lib/_zi
@@ -23,6 +23,7 @@ commands=(
   delete:"Delete plugin"
   unload:"Unload plugin"
   snippet:"Source (or add to PATH with --command) local or remote file (-f: force - do not use cache)"
+  codeload:"Load a code as local plugin from a specified user, repository and branch"
   update:"Git update plugin (or all plugins and snippets if --all passed)"
   status:"Git status for plugin (or all plugins if --all passed)"
   report:"Show plugins report (or all plugins if --all passed)"
@@ -81,6 +82,9 @@ case $state in
           _message "Hit enter to get commands list" && ret=0
           ;;
         icemods)
+          _message "Hit enter to get commands list" && ret=0
+          ;;
+        codeload)
           _message "Hit enter to get commands list" && ret=0
           ;;
         analytics)

--- a/lib/_zi
+++ b/lib/_zi
@@ -82,7 +82,7 @@ case $state in
           _message "Hit enter to get commands list" && ret=0
           ;;
         icemods)
-          _message "Hit enter to get commands list" && ret=0
+          _message "Hit enter to get ice-modifiers list" && ret=0
           ;;
         codeload)
           _message "Hit enter to get commands list" && ret=0

--- a/lib/zsh/additional.zsh
+++ b/lib/zsh/additional.zsh
@@ -72,24 +72,28 @@
     builtin read -t 1 ___tmp <>"${___fle:r}.fifo2"
   done >>! "$ZSRV_WORK_DIR/$ZSRV_ID".log 2>&1
 } # ]]]
-# FUNCTION: .zi-wrap-track-functions [[[
-.zi-wrap-track-functions() {
+# FUNCTION: .zi-wrap-functions [[[
+# Handles the wrap'…' ice-modifier which allows to extend the tracking (e.g: gathering of report and unload data) of a plugin
+# beyond the moment of sourcing it's main file(s). It works by wrapping the given functions with a tracking-enabling
+# and disabling snippet of code.This is useful especially with prompts, as they very often do their
+# initialization in the first call to their precmd hook function.
+.zi-wrap-functions() {
   local user="$1" plugin="$2" id_as="$3" f
   local -a wt
-  wt=( ${(@s.;.)ICE[wrap-track]} )
+  wt=( ${(@s.;.)ICE[wrap]} )
   for f in ${wt[@]}; do
     functions[${f}-zi-bkp]="${functions[$f]}"
     eval "
 function $f {
   ZI[CUR_USR]=\"$user\" ZI[CUR_PLUGIN]=\"$plugin\" ZI[CUR_USPL2]=\"$id_as\"
-  .zi-add-report \"\${ZI[CUR_USPL2]}\" \"Note: === Starting to track function: $f ===\"
+  .zi-add-report \"\${ZI[CUR_USPL2]}\" \"Note: Starting to track function: $f \"
   .zi-diff \"\${ZI[CUR_USPL2]}\" begin
   .zi-tmp-subst-on load
   functions[${f}]=\${functions[${f}-zi-bkp]}
   ${f} \"\$@\"
   .zi-tmp-subst-off load
   .zi-diff \"\${ZI[CUR_USPL2]}\" end
-  .zi-add-report \"\${ZI[CUR_USPL2]}\" \"Note: === Ended tracking function: $f ===\"
+  .zi-add-report \"\${ZI[CUR_USPL2]}\" \"Note: Ended tracking function: $f \"
   ZI[CUR_USR]= ZI[CUR_PLUGIN]= ZI[CUR_USPL2]=
 }"
   done

--- a/lib/zsh/git-process-output.zsh
+++ b/lib/zsh/git-process-output.zsh
@@ -1,8 +1,7 @@
 #!/usr/bin/env zsh
 
-emulate -LR zsh
-
-setopt typesetsilent extendedglob warncreateglobal
+builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 { typeset -g COLS="$(tput cols)" } 2>/dev/null
 if (( COLS < 10 )) {
@@ -14,13 +13,6 @@ progress_frames=(
   '0.08 ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏'
   '0.08 ⣾ ⣽ ⣻ ⢿ ⡿ ⣟ ⣯ ⣷'
   '0.08 ⢹ ⢺ ⢼ ⣸ ⣇ ⡧ ⡗ ⡏'
-#  '0.2 ▹▹▹▹▹ ▸▹▹▹▹ ▹▸▹▹▹ ▹▹▸▹▹ ▹▹▹▸▹ ▹▹▹▹▸'
-#  '0.2 ▁ ▃ ▄ ▅ ▆ ▇ ▆ ▅ ▄ ▃'
-#  '0.2 ▏ ▎ ▍ ▌ ▋ ▊ ▉ ▊ ▋ ▌ ▍ ▎'
-#  '0.2 ▖ ▘ ▝ ▗'
-#  '0.2 ◢ ◣ ◤ ◥'
-#  '0.2 ▌ ▀ ▐ ▄'
-#  '0.2 ✶ ✸ ✹ ✺ ✹ ✷'
 )
 
 integer -g progress_style=$(( RANDOM % 2 + 1 )) cur_frame=1
@@ -151,9 +143,9 @@ while read -r line; do
   if (( loop_count >= 2 )); then
     integer pr
     (( pr = have_4_deltas ? deltas_4 / 10 : (
-        have_3_receiving ? receiving_3 / 10 : (
-        have_5_compress ? compress_5 / 10 : ( ( ( loop_count - 1 ) / 14 ) % 10 ) + 1 ) ) ))
-  timeline "" $pr 11
+      have_3_receiving ? receiving_3 / 10 : (
+      have_5_compress ? compress_5 / 10 : ( ( ( loop_count - 1 ) / 14 ) % 10 ) + 1 ) ) ))
+    timeline "" $pr 11
     if (( have_5_compress )); then
       print_my_line_compress "${${${(M)have_1_counting:#1}:+$counting_1}:-...}" \
       "${${${(M)have_2_total:#1}:+$total_packed_2}:-0}" \

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -118,8 +118,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
-  local user=$1 pkg=$2 plugin=$2 id_as=$3 dir=$4 profile=$5 local_path=${ZI[PLUGINS_DIR]}/${3//\//---} pkgjson tmpfile=${$(mktemp):-${TMPDIR:-/tmp}/zsh.xYzAbc123}
-  local URL=https://raw.githubusercontent.com/z-shell/$2/HEAD/package.json
+  local user=$1 pkg=$2 plugin=$2 id_as=$3 dir=$4 profile=$5 local_path=${ZI[PLUGINS_DIR]}/${3//\//---}
+  local pkgjson tmpfile=${$(mktemp):-${TMPDIR:-/tmp}/zsh.xYzAbc123}
+  local URL=https://raw.githubusercontent.com/${ZI[PKG_OWNER]}/${2}/HEAD/package.json
   local pro_sep="{rst}, {profile}" epro_sep="{error}, {profile}" tool_sep="{rst}, {cmd}" lhi_hl="{lhi}" profile_hl="{profile}"
 
   trap "rmdir ${(qqq)local_path} 2>/dev/null; return 1" INT TERM QUIT HUP

--- a/lib/zsh/rpm2cpio.zsh
+++ b/lib/zsh/rpm2cpio.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-emulate -R zsh -o extendedglob
+builtin emulate -R zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
 
 local pkg=$1
 if [[ -z $pkg || ! -e $pkg ]] {

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -2,7 +2,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 #
 # Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
-# Copyright (c) 2021 Salvydas Lukosius and Z-Shell Community.
+# Copyright (c) 2021 Z-Shell Community.
 
 # FUNCTION: .zi-exists-physically [[[
 # Checks if directory of given plugin exists in PLUGIN_DIR.
@@ -44,8 +44,8 @@
     }
     .zi-any-colorify-as-uspl2 "$1" "$2"
 
-    +zi-message "{error}No such (plugin or snippet){rst}: $REPLY."
-    [[ $nospec -eq 0 && $spec1 != $spec2 ]] && +zi-message "(expands to: {file}${spec2#%}{rst})."
+    +zi-message "{error}No such (plugin or snippet){ehi}:{rst} $REPLY."
+    [[ $nospec -eq 0 && $spec1 != $spec2 ]] && +zi-message "({p}expands to{ehi}: {file}${spec2#%}{rst})."
     return 1
   fi
   return 0
@@ -136,7 +136,7 @@
   .zi-get-object-path snippet "$url2"
   local_dirB=$reply[-3] dirnameB=$reply[-2]
   [[ -z $svn_dirA ]] && \
-    fileB_there=( "$local_dirB/$dirnameB"/*~*.(zwc|md|js|html)(.-DOnN[1]) )
+  fileB_there=( "$local_dirB/$dirnameB"/*~*.(zwc|md|js|html)(.-DOnN[1]) )
   reply=( "$local_dirA/$dirnameA" "$svn_dirA" "$local_dirB/$dirnameB" "${fileB_there[1]##$local_dirB/$dirnameB/#}" )
 } # ]]]
 # FUNCTION: .zi-compute-ice [[[

--- a/lib/zsh/single-line.zsh
+++ b/lib/zsh/single-line.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
-emulate -R zsh
-setopt extendedglob warncreateglobal typesetsilent rcquotes noshortloops
+builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 local zero=$'\0' r=$'\r' n=$'\n' IFS=
 { command perl -pe 'BEGIN { $|++; $/ = \1 }; tr/\r\n/\n\0/' || gstdbuf -o0 gtr '\r\n' '\n\0' || \


### PR DESCRIPTION
Pick and drop files from a specified user, repository, and branch.

![Screenshot_20220606_160217](https://user-images.githubusercontent.com/59910950/172188170-c7e24611-9205-4486-b731-6aa6c780b4ac.png)

- [ ] CI
- [x] Bugfix
- [x] Feature
- [ ] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving performance of the project (not introducing new features)
- [ ] Other (please describe):

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Provides subcommand: `zi codeload`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- https://github.com/z-shell/zw/commit/fddf9b284ce114b43772f0a01da9166dd75a7c71
- https://github.com/z-shell/zw/commit/b086adfed8bebe3fafb85619744d31c043f920b7
- https://github.com/z-shell/F-Sy-H/commit/d3b8b24a68f61b15dd797e722e0c1493c8e4f866
- https://github.com/z-shell/zi-vim-syntax/commit/489f4f4e9972ea0ad6deac4c226c74842bb10e40

---

Example repository structure: https://github.com/ss-o/dotfiles/tree/pick
Command to pick files from `codeload/_local---config`:

```shell
zi codeload ss-o dotfiles pick
```

The files will be quietly dropped to: `~/.zi/plugins/_local---config`

