### PR TITLE
Update wiki links + REFACTOR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,8 @@
   ·
   <a href="https://github.com/orgs/z-shell/discussions"><strong>《 Ask a Question 》</strong></a>
   </p><p>
-    <a href="https://z.digitalclouds.dev/search/"><strong>《💡》Search Wiki </strong></a>
-    <a href="https://z.digitalclouds.dev/docs/getting_started/installation/"><strong>《⚡️》 Install </strong></a>
+    <a href="https://wiki.zshell.dev/search/"><strong>《💡》Search Wiki </strong></a>
+    <a href="https://wiki.zshell.dev/docs/getting_started/installation/"><strong>《⚡️》 Install </strong></a>
     <a
       href="https://github.com/z-shell/community/issues/new?assignees=&labels=%F0%9F%91%A5+member&template=membership.yml&title=team%3A+"><strong>《💜》Join
       </strong></a>

--- a/lib/_zi
+++ b/lib/_zi
@@ -187,7 +187,9 @@ case $state in
               p="${p:t}"
               user="${p%%---*}"
               plugin="${p#*---}"
-              [[ "${user}" = "${plugin}" && "${user}---${plugin}" != "${p}" ]] && user=""
+              if [[ "${user}" = "${plugin}" && "${user}---${plugin}" != "${p}" ]]; then
+                user=""
+              fi
               plugins+=( "${user:+${user}/}${plugin}" )
               break
             done
@@ -208,7 +210,9 @@ case $state in
                 p="${p:t}"
                 user="${p%%---*}"
                 plugin="${p#*---}"
-                [[ "${user}" = "${plugin}" && "${user}---${plugin}" != "${p}" ]] && user=""
+                if [[ "${user}" = "${plugin}" && "${user}---${plugin}" != "${p}" ]]; then
+                  user=""
+                fi
                 plugins+=( "${user:+${user}/}${plugin}" )
                 break
               fi

--- a/lib/templates/example-script
+++ b/lib/templates/example-script
@@ -10,43 +10,43 @@ setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 # Run as script? ZSH_SCRIPT is a Zsh 5.3 addition
 if [[ $0 != example-script || -n $ZSH_SCRIPT ]]; then
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟘 - https://z.digitalclouds.dev/community/zsh_plugin_standard
+# 𝟘 - https://wiki.zshell.dev/community/zsh_plugin_standard
 # Standardized $0 Handling - [ zero-handling ]
 0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟙 - # https://z.digitalclouds.dev/community/zsh_plugin_standard#funtions-directory
+# 𝟙 - # https://wiki.zshell.dev/community/zsh_plugin_standard#funtions-directory
 # The below snippet added to the plugin.zsh file will add the directory
 # to the $fpath with the compatibility with any new plugin managers preserved.
 if [[ $PMSPEC != *f* ]] {
   fpath+=( "${0:h}/functions" )
 }
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟚 - # https://z.digitalclouds.dev/community/zsh_plugin_standard#unload-function
+# 𝟚 - # https://wiki.zshell.dev/community/zsh_plugin_standard#unload-function
 # If a plugin is named kalc* and is available via any-user/kalc_plugin_ID,
 # then it can provide a function, kalc_plugin_unload, that can be called by a
 # plugin manager to undo the effects of loading that plugin.
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟛 - https://z.digitalclouds.dev/community/zsh_plugin_standard#run-on-unload-call
+# 𝟛 - https://wiki.zshell.dev/community/zsh_plugin_standard#run-on-unload-call
 # RUN ON UNLOAD CALL
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟜 - https://z.digitalclouds.dev/community/zsh_plugin_standard#run-on-update-call
+# 𝟜 - https://wiki.zshell.dev/community/zsh_plugin_standard#run-on-update-call
 # RUN ON UPDATE CALL
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟝 - https://z.digitalclouds.dev/community/zsh_plugin_standard#activity-indicator
+# 𝟝 - https://wiki.zshell.dev/community/zsh_plugin_standard#activity-indicator
 # ZI will set the $zsh_loaded_plugins array to contain all previously loaded plugins
 # and the plugin currently being loaded, as the last element.
 if [[ ${zsh_loaded_plugins[-1]} != */kalc && -z ${fpath[(r)${0:h}]} ]] {
   fpath+=( "${0:h}" )
 }
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟞 - https://z.digitalclouds.dev/community/zsh_plugin_standard#global-parameter-with-prefix
+# 𝟞 - https://wiki.zshell.dev/community/zsh_plugin_standard#global-parameter-with-prefix
 # Global Parameter With PREFIX For Make, Configure, Etc
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟟 - https://z.digitalclouds.dev/community/zsh_plugin_standard#global-parameter-with-capabilities
+# 𝟟 - https://wiki.zshell.dev/community/zsh_plugin_standard#global-parameter-with-capabilities
 # PMSPEC
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
-# 𝟠 - https://z.digitalclouds.dev/community/zsh_plugin_standard#zsh-plugin-programming-best-practices
+# 𝟠 - https://wiki.zshell.dev/community/zsh_plugin_standard#zsh-plugin-programming-best-practices
 # Zsh Plugin-Programming Best practices
 # #̶ =̶=̶=̶ =̶=̶=̶ =̶=̶=̶ #̶
 # Such global variable is expected to be typeset'd -g in the plugin.zsh

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -2687,7 +2687,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # -*- mode: sh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # Copyright (c) $year $user_name
 # According to the Zsh Plugin Standard:
-# https://z.digitalclouds.dev/community/zsh_plugin_standard
+# https://wiki.zshell.dev/community/zsh_plugin_standard
 0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 # Then \${0:h} to get plugin's directory
@@ -3057,7 +3057,7 @@ sleep 0.08 && +zi-message "❯ recall        {p}[plugin]{rst}|{url}[url]{rst} {m
 sleep 0.08 && +zi-message "❯ srv           {p}[service]{rst}|{cmd}[cmd]{rst} {mdsh}{rst} Control a service{ehi}:{rst} {auto}'stop,start,restart,next,quit'"
 sleep 0.09 && +zi-message "❯ create        {p}[plugin]{rst} {mdsh}{rst} {auto}Create a plugin"
 sleep 0.09 && +zi-message "❯ edit          {p}[plugin]{rst} {mdsh}{rst} Edit plugin's file with{var} \$EDITOR{rst}{nl}"
-sleep 0.09 && +zi-message "{mmdsh}{rst} ❮ {happy}Zi{rst} ❯ {mmdsh}{info} Wiki{ehi}:{rst} {url}https://z.digitalclouds.dev{rst}{nl}"
+sleep 0.09 && +zi-message "{mmdsh}{rst} ❮ {happy}Zi{rst} ❯ {mmdsh}{info} Wiki{ehi}:{rst} {url}https://wiki.zshell.dev{rst}{nl}"
 } # ]]]
 # FUNCTION: .zi-analytics-menu [[[
 # Statistics, benchmarks and information.

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -23,7 +23,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     if [[ -n ${match[3]} ]] {
       ___idx+=${mbegin[1]}
 
-      [[ $___quoting = \' ]] && \
+      if [[ $___quoting = \' ]] && \
         { ___workbuf=${match[3]}; } || \
         { ___workbuf=${match[3]:1}; (( ++ ___idx )); }
     } else {
@@ -521,7 +521,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $3 - if 1, then reinstall, otherwise only install completions that aren't there
 .zi-install-completions() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt nullglob extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt nullglob exteUndedglob warncreateglobal typesetsilent noshortloops
 
   local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}}
   local reinstall=${3:-0} quiet=${${4:+1}:-0}
@@ -544,9 +544,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   typeset -a completions already_symlinked backup_comps
   local c cfile bkpfile
   # The plugin == . is a semi-hack/trick to handle `creinstall .' properly
-  [[ $user == % || ( -z $user && $plugin == . ) &]] & \
-  completions=( "${plugin}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) ) || \
-  completions=( "${ZI[PLUGINS_DIR]}/${id_as//\//---}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) )
+  if [[ $user == % || ( -z $user && $plugin == . ) ]]; then
+    completions=( "${plugin}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) ) || \
+    completions=( "${ZI[PLUGINS_DIR]}/${id_as//\//---}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) )
+  fi
   already_symlinked=( "${ZI[COMPLETIONS_DIR]}"/_[^_.]*~*.zwc(DN) )
   backup_comps=( "${ZI[COMPLETIONS_DIR]}"/[^_.]*~*.zwc(DN) )
 

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -8,7 +8,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
 # FUNCTION: .zi-parse-json [[[
 # Retrievies the ice-list from given profile from the JSON of the package.json.
-.zi-parse-json() {
+function .zi-parse-json() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent
 
@@ -115,7 +115,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 }
 # ]]]
 # FUNCTION: .zi-get-package [[[
-.zi-get-package() {
+function .zi-get-package() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
@@ -296,7 +296,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 #
 # $1 - user
 # $2 - plugin
-.zi-setup-plugin-dir() {
+function .zi-setup-plugin-dir() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal noshortloops rcquotes
 
@@ -520,7 +520,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 # $3 - if 1, then reinstall, otherwise only install completions that aren't there
-.zi-install-completions() {
+function .zi-install-completions() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt nullglob exteUndedglob warncreateglobal typesetsilent noshortloops
 
@@ -598,7 +598,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # After that it runs normal `compinit', which should more easily detect ❮ ZI ❯ completions.
 #
 # No arguments.
-.zi-compinit() {
+function .zi-compinit() {
   if [[ -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]]; then
     return
   fi
@@ -638,7 +638,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # Downloads file to stdout.
 # Supports following backend commands: curl, wget, lftp, lynx.
 # Used by snippet loading.
-.zi-download-file-stdout() {
+function .zi-download-file-stdout() {
   local url="$1" restart="$2" progress="${(M)3:#1}"
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt localtraps extendedglob
@@ -688,7 +688,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 } # ]]]
 # FUNCTION: .zi-get-url-mtime [[[
 # For the given URL returns the date in the Last-Modified header as a time stamp
-.zi-get-url-mtime() {
+function .zi-get-url-mtime() {
   local url="$1" IFS line header
   local -a cmd
 
@@ -733,7 +733,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - URL
 # $2 - mode, "" - normal, "-u" - update, "-t" - test
 # $3 - subdirectory (not path) with working copy, needed for -t and -u
-.zi-mirror-using-svn() {
+function .zi-mirror-using-svn() {
   builtin setopt localoptions extendedglob warncreateglobal
   local url="$1" update="$2" directory="$3"
 
@@ -770,7 +770,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # completion stops being visible to Zsh.
 #
 # $1 - completion function name, e.g. "_cp"; can also be "cp"
-.zi-forget-completion() {
+function .zi-forget-completion() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob typesetsilent warncreateglobal
 
@@ -799,7 +799,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 #
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
-.zi-compile-plugin() {
+function .zi-compile-plugin() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
@@ -887,7 +887,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # Downloads snippet – either a file – with curl, wget, lftp or lynx, or a directory,
 # with Subversion – when svn-ICE is active. Github supports Subversion protocol and allows
 # to clone subdirectories. This is used to provide a layer of support for Oh-My-Zsh and Prezto.
-.zi-download-snippet() {
+function .zi-download-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent
 
@@ -1301,7 +1301,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 }
 # ]]]
 # FUNCTION: .zi-update-snippet [[[
-.zi-update-snippet() {
+function .zi-update-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
@@ -1400,7 +1400,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # FUNCTION: .zi-get-latest-gh-r-url-part [[[
 # Gets version string of latest release of given Github package.
 # Connects to Github releases page.
-.zi-get-latest-gh-r-url-part() {
+function .zi-get-latest-gh-r-url-part() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
 
@@ -1519,7 +1519,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 #
 # $1 - url
 # $2 - file
-ziextract() {
+function ziextract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob typesetsilent noshortloops # warncreateglobal
 
@@ -1802,7 +1802,7 @@ ziextract() {
   return 0
 } # ]]]
 # FUNCTION: .zi-extract() [[[
-.zi-extract() {
+function .zi-extract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent
   local tpe=$1 extract=$2 local_dir=$3
@@ -1830,10 +1830,10 @@ ziextract() {
 }
 # ]]]
 # FUNCTION: zpextract [[[
-zpextract() { ziextract "$@"; }
+function zpextract() { ziextract "$@"; }
 # ]]]
 # FUNCTION: .zi-at-eval [[[
-.zi-at-eval() {
+function .zi-at-eval() {
   local atpull="$1" atclone="$2"
   integer retval
   @zi-substitute atclone atpull
@@ -1845,7 +1845,7 @@ zpextract() { ziextract "$@"; }
   return "$?"f
 } # ]]]
 # FUNCTION: .zi-get-cygwin-package [[[
-.zi-get-cygwin-package() {
+function .zi-get-cygwin-package() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
@@ -1935,7 +1935,7 @@ zpextract() { ziextract "$@"; }
 }
 # ]]]
 # FUNCTION zicp [[[
-zicp() {
+function zicp() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
@@ -1975,7 +1975,7 @@ zicp() {
 }
 # ]]]
 # FUNCTION zimv [[[
-zimv() {
+function zimv() {
   local dir
   if [[ $1 = (-d|--dir) ]]; then
     dir=$2; shift 2;
@@ -1984,7 +1984,7 @@ zimv() {
 }
 # ]]]
 # FUNCTION: ∞zi-reset-opt-hook [[[
-∞zi-reset-hook() {
+function ∞zi-reset-hook() {
   # File
   if [[ "$1" = plugin ]]; then
     local type="$1" user="$2" plugin="$3" id_as="$4" dir="${5#%}" hook="$6"
@@ -2064,7 +2064,7 @@ zimv() {
   fi
 } # ]]]
 # FUNCTION: ∞zi-make-ee-hook [[[
-∞zi-make-ee-hook() {
+function ∞zi-make-ee-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2077,7 +2077,7 @@ zimv() {
   .zi-countdown make && command make -C "$dir" ${(@s; ;)${make#\!\!}}
 } # ]]]
 # FUNCTION: ∞zi-make-e-hook [[[
-∞zi-make-e-hook() {
+function ∞zi-make-e-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2090,7 +2090,7 @@ zimv() {
   .zi-countdown make && command make -C "$dir" ${(@s; ;)${make#\!}}
 } # ]]]
 # FUNCTION: ∞zi-make-hook [[[
-∞zi-make-hook() {
+function ∞zi-make-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2102,7 +2102,7 @@ zimv() {
   .zi-countdown make && command make -C "$dir" ${(@s; ;)make}
 } # ]]]
 # FUNCTION: ∞zi-atclone-hook [[[
-∞zi-atclone-hook() {
+function ∞zi-atclone-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2127,7 +2127,7 @@ zimv() {
   return "$rc"
 } # ]]]
 # FUNCTION: ∞zi-extract-hook [[[
-∞zi-extract-hook() {
+function ∞zi-extract-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2137,7 +2137,7 @@ zimv() {
   .zi-extract plugin "$extract" "$dir"
 } # ]]]
 # FUNCTION: ∞zi-mv-hook [[[
-∞zi-mv-hook() {
+function ∞zi-mv-hook() {
   if [[ -z $ICE[mv] ]]; then
     return 0
   fi
@@ -2170,7 +2170,7 @@ zimv() {
     )
 } # ]]]
 # FUNCTION: ∞zi-cp-hook [[[
-∞zi-cp-hook() {
+function ∞zi-cp-hook() {
   if [[ -z $ICE[cp] ]]; then
     return
   fi
@@ -2201,7 +2201,7 @@ zimv() {
   )
 } # ]]]
 # FUNCTION: ∞zi-compile-plugin-hook [[[
-∞zi-compile-plugin-hook() {
+function ∞zi-compile-plugin-hook() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
@@ -2222,7 +2222,7 @@ zimv() {
     fi
 } # ]]]
 # FUNCTION: ∞zi-atpull-e-hook [[[
-∞zi-atpull-e-hook() {
+function ∞zi-atpull-e-hook() {
   (( ${+ICE[atpull]} )) || return 0
   [[ -n ${ICE[atpull]} ]] || return 0
   # Only process atpull"!cmd"
@@ -2245,7 +2245,7 @@ zimv() {
   return "$rc"
 } # ]]]
 # FUNCTION: ∞zi-atpull-hook [[[
-∞zi-atpull-hook() {
+function ∞zi-atpull-hook() {
   (( ${+ICE[atpull]} )) || return 0
   [[ -n ${ICE[atpull]} ]] || return 0
   # Exit early if atpull"!cmd" -> this is done by zi-atpull-e-hook
@@ -2269,7 +2269,7 @@ zimv() {
   return "$rc"
 } # ]]]
 # FUNCTION: ∞zi-ps-on-update-hook [[[
-∞zi-ps-on-update-hook() {
+function ∞zi-ps-on-update-hook() {
   if [[ -z $ICE[ps-on-update] ]]; then
     return 0
   fi

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -20,13 +20,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   ___pair_map=( "{" "}" "[" "]" )
 
   while [[ $___workbuf = (#b)[^"{}[]\\\"'":,]#((["{[]}\"'":,])|[\\](*))(*) ]]; do
-    if [[ -n ${match[3]} ]] {
+    if [[ -n ${match[3]} ]]; then
       ___idx+=${mbegin[1]}
 
-      if [[ $___quoting = \' ]] && \
+      if [[ $___quoting = \' ]]; then
         { ___workbuf=${match[3]}; } || \
         { ___workbuf=${match[3]:1}; (( ++ ___idx )); }
-    } else {
+      fi
+    else
       ___idx+=${mbegin[1]}
       if [[ -z $___quoting ]]; then
         if [[ ${match[1]} = ["({["] ]]; then
@@ -89,28 +90,28 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         fi
       fi
       ___workbuf=${match[4]}
-    }
+    fi
   done
 
   local ___text ___found
-  if (( ___nest != 2 )) {
+  if (( ___nest != 2 )); then
     integer ___pair_a ___pair_b
-    for ___pair_a ( "${___pair_order[@]}" ) {
+    for ___pair_a ( "${___pair_order[@]}" ); do
       ___pair_b="${___final_pairs[$___pair_a]}"
       ___text="${___input[___pair_b,___pair_a]}"
       if [[ $___text = [[:space:]]#\{[[:space:]]#[\"\']${___key}[\"\']* ]]; then
         ___found="$___text"
       fi
-    }
-  }
+    done
+  fi
 
   if [[ -n $___found && $___nest -lt 2 ]]; then
     .zi-parse-json "$___found" "$___key" "$___varname" 2
   fi
 
-  if (( ___nest == 2 )) {
+  if (( ___nest == 2 )); then
     : ${(PAA)___varname::="${(kv)___Strings[@]}"}
-  }
+  fi
 }
 # ]]]
 # FUNCTION: .zi-get-package [[[
@@ -126,14 +127,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   trap "rmdir ${(qqq)local_path} 2>/dev/null; return 1" INT TERM QUIT HUP
   trap "rmdir ${(qqq)local_path} 2>/dev/null" EXIT
 
-  if [[ $profile != ./* ]] {
-    if { ! .zi-download-file-stdout $URL 0 1 2>/dev/null > $tmpfile } {
+  if [[ $profile != ./* ]]; then
+    if { ! .zi-download-file-stdout $URL 0 1 2>/dev/null > $tmpfile }; then
       rm -f $tmpfile; .zi-download-file-stdout $URL 1 1 2>/dev/null >1 $tmpfile
-    }
-  } else {
+    fi
+  else
     tmpfile=${profile%:*}
     profile=${${${(M)profile:#*:*}:+${profile#*:}}:-default}
-  }
+  fi
 
   # load json from file
   if [[ -e $tmpfile ]]; then
@@ -156,14 +157,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   profiles=( ${(@Q)${(@z)Strings[2/2]}} )
   profiles=( ${profiles[@]:#$'\0'--object--$'\0'} )
   pos=${${(@Q)${(@z)Strings[2/2]}}[(I)$profile]}
-  if (( pos )) {
-    for key value ( "${(@Q)${(@z)Strings[3/$(( (pos + 1) / 2 ))]}}" ) {
+  if (( pos )); then
+    for key value ( "${(@Q)${(@z)Strings[3/$(( (pos + 1) / 2 ))]}}" ); do
       (( ${+ICE[$key]} )) && \
       if [[ ${ICE[$key]} != +* ]]; then
         continue
       fi
       ICE[$key]=$value${ICE[$key]#+}
-    }
+    done
     ICE=( "${(kv)ICE[@]//\\\"/\"}" )
     if [[ ${ICE[as]} = program ]]; then
       ICE[as]="command"
@@ -174,17 +175,17 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     if [[ -n ${ICE[pick]} ]]; then
       ICE[pick]="${ICE[pick]//\$ZPFX/${ZPFX%/}}"
     fi
-    if [[ -n ${ICE[id-as]} ]] {
+    if [[ -n ${ICE[id-as]} ]]; then
       @zi-substitute 'ICE[id-as]'
       local -A map
       map=( "\"" "\\\"" "\\" "\\" )
       eval "ICE[id-as]=\"${ICE[id-as]//(#m)[\"\\]/${map[$MATCH]}}\""
-    }
-  } else {
+    fi
+  else
     # Assumption: the default profile is the first in the table (see another color).
     +zi-message "{u-warn}Error{b-warn}:{error} the profile {apo}\`{hi}$profile{apo}\` {error}couldn't be found, aborting. Available profiles are: {lhi}${(pj:$epro_sep:)profiles[@]}{error}.{rst}"
     return 1
-  }
+  fi
 
   +zi-message "{info3}Package{ehi}:{rst} {pid}$pkg{rst}. Selected" "profile{ehi}:{rst} {hi}$profile{rst}. \
   Available profiles:${${${(M)profile:#default}:+$lhi_hl}:-$profile_hl}" "${(pj:$pro_sep:)profiles[@]}{rst}."
@@ -196,7 +197,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   ICE[required]=${ICE[required]:-$ICE[requires]}
   local -a req
   req=( ${(s.;.)${:-${required:+$required\;}${ICE[required]}}} )
-  for required ( $req ) {
+  for required ( $req ); do
     if [[ $required == (bgn|dl|rdl) ]]; then
       if [[ ( $required == bgn && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-bin-gem-node *]} ) || ( $required == dl && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-patch-dl *]} ) || ( $required == rdl && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-readurl *]} ) ]]; then
         local -A namemap
@@ -227,7 +228,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         return 1
       fi
     fi
-  }
+  done
 
   if [[ -n ${ICE[dl]} && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-patch-dl *]} ]]; then
     +zi-message "{nl}{u-warn}WARNING{b-warn}:{rst} the profile uses" \
@@ -241,13 +242,13 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message "{info}${jsondata1[message]}{rst}"
   fi
 
-  if (( ${+ICE[is-snippet]} )) {
+  if (( ${+ICE[is-snippet]} )); then
     reply=( "" "$url" )
     REPLY=snippet
     return 0
-  }
+  fi
 
-  if (( !${+ICE[git]} && !${+ICE[from]} )) {
+  if (( !${+ICE[git]} && !${+ICE[from]} )); then
     (
       .zi-parse-json "$pkgjson" "_from" Strings
       local -A jsondata
@@ -264,27 +265,27 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
       +zi-message "Downloading tarball for {pid}$plugin{rst}{…}"
 
-      if { ! .zi-download-file-stdout "$URL" 0 1 >! "$fname" } {
-        if { ! .zi-download-file-stdout "$URL" 1 1 >! "$fname" } {
+      if { ! .zi-download-file-stdout "$URL" 0 1 >! "$fname" }; then
+        if { ! .zi-download-file-stdout "$URL" 1 1 >! "$fname" }; then
           command rm -f "$fname"
           +zi-message "Download of the file {apo}\`{file}$fname{apo}\`{rst} failed. No available download tool? One of{ehi}:{rst}" "{cmd}${(pj:$tool_sep:)${=:-curl wget lftp lynx}}{rst}."
           return 1
-        }
-      }
+        fi
+      fi
       ziextract "$fname" ${ICE[extract]---move} ${${(M)ICE[extract]:#!([^!]|(#e))*}:+--move} ${${(M)ICE[extract]:#!!*}:+--move2}
       return 0
     ) && {
       reply=( "$user" "$plugin" )
       REPLY=tarball
     }
-  } else {
+  else
       reply=( "${ICE[user]:-$user}" "${ICE[plugin]:-$plugin}" )
       if [[ ${ICE[from]} = (|gh-r|github-rel) ]]; then
         REPLY=github
       else
         REPLY=unknown
       fi
-  }
+  fi
 
   return $?
 } # ]]]
@@ -358,7 +359,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   fi
 
   (
-    if [[ $site = */releases ]] {
+    if [[ $site = */releases ]]; then
       local url=$site/${ICE[ver]}
 
       .zi-get-latest-gh-r-url-part "$user" "$plugin" "$url" || return $?
@@ -369,21 +370,21 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         () { builtin setopt localoptions noautopushd; builtin cd -q "$local_path"; } || return 1
         integer count
 
-        for REPLY ( $reply ) {
+        for REPLY ( $reply ); do
           count+=1
           url="https://github.com${REPLY}"
-          if [[ -d $local_path/._zi ]] {
+          if [[ -d $local_path/._zi ]]; then
             { local old_version="$(<$local_path/._zi/is_release${count:#1})"; } 2>/dev/null
             old_version=${old_version/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}
-          }
+          fi
           +zi-message "(Requesting \`${REPLY:t}'${version:+, version $version}{…}${old_version:+ Current version: $old_version.})"
-          if { ! .zi-download-file-stdout "$url" 0 1 >! "${REPLY:t}" } {
-            if { ! .zi-download-file-stdout "$url" 1 1 >! "${REPLY:t}" } {
+          if { ! .zi-download-file-stdout "$url" 0 1 >! "${REPLY:t}" }; then
+            if { ! .zi-download-file-stdout "$url" 1 1 >! "${REPLY:t}" }; then
               command rm -f "${REPLY:t}"
               +zi-message "{auto}Download of release for \`$remote_url_path' failed{nl}{mmdsh} Tried url{ehi}:{rst} {auto}"
               return 1
-            }
-          }
+            fi
+          fi
           if .zi-download-file-stdout "$url.sig" 2>/dev/null >! "${REPLY:t}.sig"; then
             :
           else
@@ -395,12 +396,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           builtin print -r -- $url >! ._zi/url || return 3
           builtin print -r -- ${REPLY} >! ._zi/is_release${count:#1} || return 4
           ziextract ${REPLY:t} ${${${#reply}:#1}:+--nobkp} ${${(M)ICE[extract]:#!([^!]|(#e))*}:+--move} ${${(M)ICE[extract]:#!!*}:+--move2}
-        }
+        done
         return $?
       ) || {
         return 1
       }
-    } elif [[ $site = cygwin ]] {
+    elif [[ $site = cygwin ]]; then
       command mkdir -p "$local_path/._zi"
       [[ -d "$local_path" ]] || return 1
       (
@@ -409,7 +410,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         builtin print -r -- $REPLY >! ._zi/is_release
         ziextract "$REPLY"
       ) || return $?
-    } elif [[ $tpe = github ]] {
+    elif [[ $tpe = github ]]; then
       case ${ICE[proto]} in
         (|https|git|http|ftp|ftps|rsync|ssh)
           :zi-git-clone() {
@@ -423,17 +424,17 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             return $retval
           }
           :zi-git-clone |& { command ${ZI[BIN_DIR]}/lib/zsh/git-process-output.zsh || cat; }
-          if (( pipestatus[1] == 141 )) {
+          if (( pipestatus[1] == 141 )); then
             :zi-git-clone
             integer retval=$?
-            if (( retval )) {
+            if (( retval )); then
               builtin print -Pr -- "$ZI[col-error]Clone failed (code: $ZI[col-obj]$retval$ZI[col-error]).%f%b"
               return 1
-            }
-          } elif (( pipestatus[1] )) {
+            fi
+          elif (( pipestatus[1] )); then
             builtin print -Pr -- "$ZI[col-error]Clone failed (code: $ZI[col-obj]$pipestatus[1]$ZI[col-error]).%f%b"
             return 1
-          }
+          fi
           ;;
         (*)
           builtin print -Pr "${ZI[col-error]}Unknown protocol:%f%b ${ICE[proto]}."
@@ -443,7 +444,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       if [[ -n ${ICE[ver]} ]]; then
         command git -C "$local_path" checkout "${ICE[ver]}"
       fi
-    }
+    fi
 
     if [[ $update != -u ]]; then
       hook_rc=0
@@ -481,7 +482,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       done
     fi
     return "$retval"
-  ) || return $?
+  ) || {return $?}
 
   typeset -ga INSTALLED_EXECS
   { INSTALLED_EXECS=( "${(@f)$(<${TMPDIR:-/tmp}/zi-execs.$$.lst)}" ) } 2>/dev/null
@@ -576,19 +577,19 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     fi
   done
 
-  if (( quiet == 1 && (${#INSTALLED_COMPS} || ${#SKIPPED_COMPS}) )) {
+  if (( quiet == 1 && (${#INSTALLED_COMPS} || ${#SKIPPED_COMPS}) )); then
     +zi-message "{msg}Installed {num}${#INSTALLED_COMPS} {msg}completions" \
       "{nl}{mmdsh} They are stored in{var} \$INSTALLED_COMPS{msg} array"
-    if (( ${#SKIPPED_COMPS} )) {
+    if (( ${#SKIPPED_COMPS} )); then
       +zi-message "{msg}Skipped installing {num}${#SKIPPED_COMPS}{msg} completions" \
         "{nl}{mmdsh} They are stored in{var} \$SKIPPED_COMPS{msg} array"
-    }
-  }
+    fi
+  fi
 
-  if (( ZSH_SUBSHELL )) {
+  if (( ZSH_SUBSHELL )); then
     builtin print -rl -- $INSTALLED_COMPS >! ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst
     builtin print -rl -- $SKIPPED_COMPS >! ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst
-  }
+  fi
 
   .zi-compinit 1 1 &>/dev/null
 } # ]]]
@@ -642,7 +643,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt localtraps extendedglob
 
-  if (( restart )) {
+  if (( restart )); then
     (( ${path[(I)/usr/local/bin]} )) || {
         path+=( "/usr/local/bin" );
         trap "path[-1]=()" EXIT
@@ -665,7 +666,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       "{nl}{mmdsh} Expected{ehi}:{rst} {cmd}curl{rst}, {cmd}wget{rst}, {cmd}lftp{rst}," "{cmd}lynx{rst}"
       return 2
     fi
-  } else {
+  else
     if type curl 2>/dev/null 1>&2; then
       if [[ -n $progress ]]; then
         command curl --progress-bar -fSL "$url" 2> >(${ZI[BIN_DIR]}/lib/zsh/single-line.zsh >&2) || return 1
@@ -680,7 +681,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       .zi-download-file-stdout "$url" "1" "$progress"
       return $?
     fi
-  }
+  fi
 
   return 0
 
@@ -784,11 +785,11 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   local k
   integer first=1
-  for k ( $commands ) {
+  for k ( $commands ); do
     unset "_comps[$k]"
     (( quiet )) || builtin print -Prn "${${first:#1}:+, }${ZI[col-info]}$k%f%b"
     first=0
-  }
+  done
   (( quiet || first )) || builtin print
 
   unfunction -- 2>/dev/null "$f"
@@ -817,19 +818,19 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       fi
       reply=( "${list[1]:h}" "${list[1]}" )
     else
-      if (( is_snippet )) {
-        if [[ -f $plugin_dir/$filename ]] {
+      if (( is_snippet )); then
+        if [[ -f $plugin_dir/$filename ]]; then
           reply=( "$plugin_dir" $plugin_dir/$filename )
-        } elif { ! .zi-first % "$plugin_dir" } {
+        elif { ! .zi-first % "$plugin_dir" }; then
           +zi-message "No files for compilation found{rst}{…}"
           return 1
-        }
-      } else {
+        fi
+      else
         .zi-first "$1" "$2" || {
           +zi-message "No files for compilation found{rst}{…}"
           return 1
         }
-      }
+      fi
     fi
     local pdir_path=${reply[-2]}
     first=${reply[-1]}
@@ -839,12 +840,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]]; then
       () {
         builtin emulate -LR zsh -o extendedglob
-        if { ! zcompile -U "$first" } {
+        if { ! zcompile -U "$first" }; then
           +zi-message "{error}Warning{ehi}:{rst} Compilation failed. Don't worry, the plugin will work also without compilation"
           +zi-message "{error}Warning{ehi}:{rst} Consider submitting an error report to ❮ ZI ❯ or to the plugin's author"
-        } else {
+        else
           +zi-message " {version}✔{rst}"
-        }
+        fi
         # Try to catch possible additional file
         zcompile -U "${${first%.plugin.zsh}%.zsh-theme}.zsh" 2>/dev/null
       }
@@ -856,12 +857,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     pats=( ${(s.;.)ICE[compile]} )
     local pat
     list=()
-    for pat ( $pats ) {
+    for pat ( $pats ); do
       eval "list+=( \$plugin_dir/$~pat(N) )"
-    }
-    if [[ ${#list} -eq 0 ]] {
+    done
+    if [[ ${#list} -eq 0 ]]; then
       +zi-message "{error}Warning{ehi}:{rst} ice {ice}compile{apo}''{rst} didn't match any files."
-    } else {
+    else
       integer retval
       for first in $list; do
         () {
@@ -870,14 +871,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         }
       done
       builtin print -rl -- ${list[@]#$plugin_dir/} >! ${TMPDIR:-/tmp}/zi.compiled.$$.lst
-      if (( retval )) {
+      if (( retval )); then
         +zi-message "{mmdsh}{rst} The additional {num}${#list}{rst} compiled files" \
           "are listed in the {var}\$ADD_COMPILED{rst} array ({p}exit code{ehi}:{rst} {data2}$retval{rst})"
-      } else {
+      else
         +zi-message "{mmdsh}{rst} The additional {num}${#list}{rst} compiled files" \
           "are listed in the {var}\$ADD_COMPILED{rst} array"
-      }
-    }
+      fi
+    fi
   fi
 
   return 0
@@ -906,27 +907,27 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   fi
   sname=${sname#./}
 
-  if (( ${+ICE[svn]} )) {
+  if (( ${+ICE[svn]} )); then
     if [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]]; then
       local ZSH=${ZI[SNIPPETS_DIR]}
     fi
     url=${url/(#s)(#m)(${(~kj.|.)ZI_1MAP})/$ZI_1MAP[$MATCH]}
-  } else {
+  else
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
-    if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]] {
+    if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]]; then
       if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]]; then
-        if [[ $save_url == OMZT::* ]] {
+        if [[ $save_url == OMZT::* ]]; then
           url+=.zsh-theme
-        } else {
+        else
           url+=/${${url#*::}:t}.plugin.zsh
-        }
+        fi
       fi
-    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
+    elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
       if [[ $url != *.zsh && $url != */_[^/]## ]]; then
         url+=/init.zsh
       fi
     fi
-  }
+  fi
 
   # Change the url to point to raw github content if it isn't like that
   if [[ "$url" = *github.com* && ! "$url" = */raw/* && "${+ICE[svn]}" = "0" ]]; then
@@ -956,20 +957,22 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   # otherwise it sets it to 2 – a new download is treated like a full update.
   ZI[annex-multi-flag:pull-active]=${${${(M)update:#-u}:+${ZI[annex-multi-flag:pull-active]}}:-2}
   (
-    if [[ $url = (http|https|ftp|ftps|scp)://* ]] {
+    if [[ $url = (http|https|ftp|ftps|scp)://* ]]; then
       # URL
       (
         () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
         (( !OPTS[opt_-q,--quiet] )) && \
         +zi-message "Downloading{ehi}:{rst} {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" ({p}with Subversion{rst})"}:-" ({p}with curl, wget, lftp{rst})"}{…}"
 
-        if (( ${+ICE[svn]} )) {
-          if [[ $update = -u ]] {
+        if (( ${+ICE[svn]} )); then
+          if [[ $update = -u ]]; then
             # Test if update available
             if ! .zi-mirror-using-svn "$url" "-t" "$dirname"; then
-              if (( ${+ICE[run-atpull]} || OPTS[opt_-u,--urge] )) {
+              if (( ${+ICE[run-atpull]} || OPTS[opt_-u,--urge] )); then
                 ZI[annex-multi-flag:pull-active]=1
-              } else { return 0; }
+              else
+                return 0
+              fi
               # Will return when no updates so atpull'' code below doesn't need any checks.
               # This return 0 statement also sets the pull-active flag outside this subshell.
             else
@@ -991,7 +994,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
               fi
             done
 
-            if (( ZI[annex-multi-flag:pull-active] == 2 )) {
+            if (( ZI[annex-multi-flag:pull-active] == 2 )); then
               # Do the update
               # The condition is reversed on purpose – to show only the messages on an actual update
               if (( OPTS[opt_-q,--quiet] )); then
@@ -1000,10 +1003,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
                 +zi-message "Downloading{ehi}:{rst} {apo}\`{rst}$sname{apo}\`{rst} ({p}with Subversion{rst}){…}"
               fi
               .zi-mirror-using-svn "$url" "-u" "$dirname" || return 4
-            }
-          } else {
+            fi
+          else
             .zi-mirror-using-svn "$url" "" "$dirname" || return 4
-          }
+          fi
 
           # Redundant code, just to compile SVN snippet
           if [[ ${ICE[as]} != command ]]; then
@@ -1015,24 +1018,24 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
                 $local_dir/$dirname/*.zsh(DN) $local_dir/$dirname/*.sh(DN) $local_dir/$dirname/.zshrc(DN)
               )
             fi
-            if [[ -e ${list[1]} && ${list[1]} != */dev/null && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && ${+ICE[nocompile]} -eq 0 ]] {
+            if [[ -e ${list[1]} && ${list[1]} != */dev/null && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && ${+ICE[nocompile]} -eq 0 ]]; then
               () {
                 builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                 zcompile -U "${list[1]}" &>/dev/null || \
                   +zi-message "{error}Warning{ehi}:{rst} Couldn't compile {apo}\`{file}${list[1]}{rst}'"
               }
-            }
+            fi
           fi
 
           return $ZI[annex-multi-flag:pull-active]
-        } else {
+        else
           command mkdir -p "$local_dir/$dirname"
 
-          if (( !OPTS[opt_-f,--force] )) {
+          if (( !OPTS[opt_-f,--force] )); then
             .zi-get-url-mtime "$url"
-          } else {
+          else
             REPLY=$EPOCHSECONDS
-          }
+          fi
 
           # Returned is: modification time of the remote file.
           # Thus, EPOCHSECONDS - REPLY is: allowed window for the
@@ -1046,24 +1049,24 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           integer skip_dl
           local -a matched
           matched=( $local_dir/$dirname/$filename(DNms-$secs) )
-          if (( ${#matched} )) {
+          if (( ${#matched} )); then
             +zi-message "{info}Already up to date.{rst}"
             # Empty-update return-short path – it also decides the
             # pull-active flag after the return from this sub-shell
             (( ${+ICE[run-atpull]} || OPTS[opt_-u,--urge] )) && skip_dl=1 || return 0
-          }
-          if [[ ! -f $local_dir/$dirname/$filename ]] {
+          fi
+          if [[ ! -f $local_dir/$dirname/$filename ]]; then
             ZI[annex-multi-flag:pull-active]=2
-          } else {
+          else
             # secs > 1 → the file is outdated, then:
             #   - if true, then the mode is 2 minus run-atpull-activation,
             #   - if false, then mode is 3 → a forced download (no remote mtime found).
             ZI[annex-multi-flag:pull-active]=$(( secs > 1 ? (2 - skip_dl) : 3 ))
-          }
+          fi
 
           # Run annexes' atpull hooks (the before atpull-ice ones).
           # The URL-snippet block.
-          if [[ $update = -u && $ZI[annex-multi-flag:pull-active] -ge 1 ]] {
+          if [[ $update = -u && $ZI[annex-multi-flag:pull-active] -ge 1 ]]; then
             reply=(
               ${(on)ZI_EXTS2[(I)zi hook:e-\\\!atpull-pre <->]}
               ${${ICE[atpull]#\!}:+${(on)ZI_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
@@ -1078,19 +1081,19 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
                 builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
               fi
             done
-          }
+          fi
 
-          if (( !skip_dl )) {
-            if { ! .zi-download-file-stdout "$url" 0 1 >! "$dirname/$filename" } {
-              if { ! .zi-download-file-stdout "$url" 1 1 >! "$dirname/$filename" } {
+          if (( !skip_dl )); then
+            if { ! .zi-download-file-stdout "$url" 0 1 >! "$dirname/$filename" }; then
+              if { ! .zi-download-file-stdout "$url" 1 1 >! "$dirname/$filename" }; then
                 command rm -f "$dirname/$filename"
                 +zi-message "{error}Error{ehi}:{rst} Download failed{…}"
                 return 4
-              }
-            }
-          }
+              fi
+            fi
+          fi
           return $ZI[annex-multi-flag:pull-active]
-        }
+        fi
       )
       retval=$?
 
@@ -1098,13 +1101,13 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       # – no hooks will be run anyway because of the error
       ZI[annex-multi-flag:pull-active]=$retval
 
-      if [[ $ICE[as] != command && ${+ICE[svn]} -eq 0 ]] {
+      if [[ $ICE[as] != command && ${+ICE[svn]} -eq 0 ]]; then
         local file_path=$local_dir/$dirname/$filename
         if [[ -n ${ICE[pick]} ]]; then
           list=( ${(M)~ICE[pick]##/*}(DN) $local_dir/$dirname/${~ICE[pick]}(DN) )
           file_path=${list[1]}
         fi
-        if [[ -e $file_path && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && $file_path != */dev/null && ${+ICE[nocompile]} -eq 0 ]] {
+        if [[ -e $file_path && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && $file_path != */dev/null && ${+ICE[nocompile]} -eq 0 ]]; then
           () {
             builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
             if ! zcompile -U "$file_path" 2>/dev/null; then
@@ -1114,9 +1117,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
               retval=4
             fi
           }
-        }
-      }
-    } else { # Local-file snippet branch
+        fi
+      fi
+    else # Local-file snippet branch
       # Local files are (yet…) forcefully copied.
       ZI[annex-multi-flag:pull-active]=3 retval=3
       # Run annexes' atpull hooks (the before atpull-ice ones).
@@ -1152,29 +1155,29 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           "accessible{nl}{mmdsh}{error} wrong permissions{rst}"
         retval=4
       fi
-      if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
+      if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]]; then
         +zi-message "{msg}Copying {file}$filename{msg}{…}{rst}"
         command cp -vf "$url" "$local_dir/$dirname/$filename" || \
           { +zi-message "{error}Error{ehi}:{rst} {auto}The file copying has been unsuccessful"; retval=4; }
-      } else {
+      else
         command cp -f "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
           { +zi-message "{error}Error{ehi}:{rst} {msg}The copying of {file}$filename{msg} has been unsuccessful"\
             "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}{rst}"; retval=4; }
-      }
-    }
+      fi
+    fi
 
     (( retval == 4 )) && { command rmdir "$local_dir/$dirname" 2>/dev/null; return $retval; }
 
-    if [[ ${${:-$local_dir/$dirname}%%/##} != ${ZI[SNIPPETS_DIR]} ]] {
+    if [[ ${${:-$local_dir/$dirname}%%/##} != ${ZI[SNIPPETS_DIR]} ]]; then
       # Store ices at "clone" and update of snippet, SVN and single-file
       local pfx=$local_dir/$dirname/._zi
       .zi-store-ices "$pfx" ICE url_rsvd "" "$save_url" "${+ICE[svn]}"
-    } elif [[ -n $id_as ]] {
+    elif [[ -n $id_as ]]; then
       +zi-message "{u-warn}Warning{b-warn}:{rst} the snippet {url}$id_as{rst} isn't" \
         "fully downloaded – you should remove it with {apo}\`{cmd}zi delete $id_as{apo}\`{rst}."
-    }
+    fi
     # Empty update short-path
-    if (( ZI[annex-multi-flag:pull-active] == 0 )) {
+    if (( ZI[annex-multi-flag:pull-active] == 0 )); then
       # Run annexes' atpull hooks (the `always' after atpull-ice ones)
       reply=(
         ${(on)ZI_EXTS2[(I)zi hook:%atpull-pre <->]}
@@ -1191,9 +1194,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         fi
       done
       return $retval;
-    }
+    fi
 
-    if [[ $update = -u ]] {
+    if [[ $update = -u ]]; then
       # Run annexes' atpull hooks (the before atpull-ice ones).
       # The block is common to all 3 snippet types.
       reply=(
@@ -1210,7 +1213,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
         fi
       done
-    } else {
+    else
       # Run annexes' atclone hooks (the before atclone-ice ones)
       # The block is common to all 3 snippet types.
       reply=(
@@ -1232,12 +1235,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
         "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" load
       done
-    }
+    fi
 
     # Run annexes' atpull hooks (the after atpull-ice ones)
     # The block is common to all 3 snippet types.
     if [[ $update = -u ]]; then
-      if (( ZI[annex-multi-flag:pull-active] > 0 )) {
+      if (( ZI[annex-multi-flag:pull-active] > 0 )); then
         reply=(
           ${(on)ZI_EXTS2[(I)zi hook:atpull-pre <->]}
           ${(on)ZI_EXTS[(I)z-annex hook:atpull-<-> <->]}
@@ -1252,7 +1255,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
           fi
         done
-      }
+      fi
       # Run annexes' atpull hooks (the `always' after atpull-ice ones)
       # The block is common to all 3 snippet types.
       reply=(
@@ -1336,41 +1339,41 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   # - case A: called from `update --all', ICE empty, static ice will win
   # - case B: called from `update', ICE packed, so it will win
   tmp=( "${(Q@)${(z@)ZI_SICE[$id_as]}}" )
-  if (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )) {
+  if (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )); then
     ICE=( "${(kv)ICE[@]}" "${tmp[@]}" )
-  } elif [[ -n ${ZI_SICE[$id_as]} ]] {
+  elif [[ -n ${ZI_SICE[$id_as]} ]]; then
     +zi-message "{error}Warning{ehi}:{rst} {msg2}Inconsistency #3 occurred, please report the string: \`{obj}${ZI_SICE[$id_as]}{msg2}' to the" \
     "GitHub issues page: {obj}https://github.com/z-shell/zi/issues/{msg2}.{rst}"
-  }
+  fi
   id_as=${ICE[id-as]:-$id_as}
 
   # Oh-My-Zsh, Prezto and manual shorthands
-  if (( ${+ICE[svn]} )) {
+  if (( ${+ICE[svn]} )); then
     if [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]]; then
       local ZSH=${ZI[SNIPPETS_DIR]}
     fi
     url=${url/(#s)(#m)(${(~kj.|.)ZI_1MAP})/$ZI_1MAP[$MATCH]}
-  } else {
+  else
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
-    if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]] {
+    if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]]; then
       if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]]; then
-        if [[ $save_url == OMZT::* ]] {
+        if [[ $save_url == OMZT::* ]]; then
           url+=.zsh-theme
-        } else {
+        else
           url+=/${${url#*::}:t}.plugin.zsh
-        }
+        fi
       fi
-    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
+    elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
       if [[ $url != *.zsh ]]; then
         url+=/init.zsh
       fi
     fi
-  }
+  fi
 
-  if { ! .zi-get-object-path snippet "$id_as" } {
+  if { ! .zi-get-object-path snippet "$id_as" }; then
     +zi-message "{msg2}Error{ehi}:{rst} the snippet \`{obj}$id_as{msg2}'" "doesn't exist, aborting the update.{rst}"
       return 1
-  }
+  fi
   filename=$reply[-2] dirname=$reply[-2] local_dir=$reply[-3]
 
   local -a arr
@@ -1404,11 +1407,11 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   REPLY=
   local user=$1 plugin=$2 urlpart=$3
 
-  if [[ -z $urlpart ]] {
+  if [[ -z $urlpart ]]; then
     local url=https://github.com/$user/$plugin/releases/$ICE[ver]
-  } else {
+  else
     local url=https://$urlpart
-  }
+  fi
 
   local -A matchstr
   matchstr=(
@@ -1450,7 +1453,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local bpick
 
   reply=()
-  for bpick ( "${bpicks[@]}" ) {
+  for bpick ( "${bpicks[@]}" ); do
     list=( $init_list )
 
     if [[ -n $bpick ]]; then
@@ -1492,19 +1495,19 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       (( $#list2 > 0 )) && list=( ${list2[@]} )
     fi
 
-    if (( !$#list )) {
+    if (( !$#list )); then
       +zi-message -n "{error}Didn't find correct Github" "release-file to download"
-      if [[ -n $bpick ]] {
+      if [[ -n $bpick ]]; then
         +zi-message -n ", try adapting {obj}bpick{error}-ICE" "({auto}current bpick{ehi}:{rst} {file}${bpick}{error})"
-      } else {
+      else
         +zi-message -n .
-      }
+      fi
       +zi-message '{rst}'
       return 1
-    }
+    fi
 
     reply+=( $list[1] )
-  }
+  done
   [[ -n $reply ]] # testable
 }
 # ]]]
@@ -1520,9 +1523,10 @@ ziextract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob typesetsilent noshortloops # warncreateglobal
 
-  if (( $+commands[file] != 1 )) { +zi-message "{annex}ziextract{ehi}:{rst} {error}The {cmd}file{error} command is required for recognizing the type of data to be processed{rst}"
+  if (( $+commands[file] != 1 )); then
+   +zi-message "{annex}ziextract{ehi}:{rst} {error}The {cmd}file{error} command is required for recognizing the type of data to be processed{rst}"
     return 1
-  }
+  fi
   local -a opt_move opt_move2 opt_norm opt_auto opt_nobkp
   zparseopts -D -E -move=opt_move -move2=opt_move2 -norm=opt_norm -auto=opt_auto -nobkp=opt_nobkp || \
   { +zi-message "{annex}ziextract{ehi}:{rst} {error}Incorrect options given to" "\`{annex}ziextract{error}' {rst}({p}available are{ehi}:{rst} {opt}--auto{msg2}," \
@@ -1535,22 +1539,22 @@ ziextract() {
   auto=${${${(M)${#opt_auto}:#0}:+0}:-1} \
   nobkp=${${${(M)${#opt_nobkp}:#0}:+0}:-1}
 
-  if (( auto )) {
+  if (( auto )); then
     # First try known file extensions
     local -a files
     integer ret_val
     files=( (#i)**/*.(zip|rar|7z|tgz|tbz|tbz2|tar.gz|tar.bz2|tar.7z|txz|tar.xz|gz|xz|tar|dmg|exe)~(*/*|.(_backup|git))/*(-.DN) )
-    for file ( $files ) {
+    for file ( $files ); do
       ziextract "$file" $opt_move $opt_move2 $opt_norm $opt_nobkp ${${${#files}:#1}:+--nobkp}
       ret_val+=$?
-    }
+    done
     # Second, try to find the archive via `file' tool
-    if (( !${#files} )) {
+    if (( !${#files} )); then
       local -aU output infiles stage2_processed archives
       infiles=( **/*~(._zi*|._backup|.git)(|/*)~*/*/*(-.DN) )
       output=( ${(@f)"$(command file -- $infiles 2>&1)"} )
       archives=( ${(M)output[@]:#(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) *} )
-      for file ( $archives ) {
+      for file ( $archives ); do
         local fname=${(M)file#(${(~j:|:)infiles}): } desc=${file#(${(~j:|:)infiles}): } type
         fname=${fname%%??}
         if [[ -z $fname || -n ${stage2_processed[(r)$fname]} ]]; then
@@ -1577,7 +1581,7 @@ ziextract() {
             output2=( ${(@f)"$(command file -- "$fname"(N) "${fname:r}"(N) $files[1](N) 2>&1)"} )
             archives2=( ${(M)output2[@]:#(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) *} )
             local file2
-            for file2 ( $archives2 ) {
+            for file2 ( $archives2 ); do
               fname=${file2%:*} desc=${file2##*:}
               local type2=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
               if [[ $type != $type2 && $type2 = (zip|rar|xz|7-zip|gzip|bzip2|tar) ]]; then
@@ -1597,13 +1601,13 @@ ziextract() {
                   stage2_processed+=( ${fname%.out} )
                 fi
               fi
-            }
+            done
           fi
         fi
-      }
-    }
+      done
+    fi
     return $ret_val
-  }
+  fi
 
   if [[ -z $file ]]; then
     +zi-message "{annex}ziextract{ehi}:{rst} {error}Argument required for {file}file{error} to extract or the {opt}--auto{error} option{rst}"
@@ -1613,21 +1617,21 @@ ziextract() {
     +zi-message "{annex}ziextract{ehi}:{rst} {error}The {file}file{error} \`{pname}${file}{error}' does not exist{rst}"
     return 1
   fi
-  if (( !nobkp )) {
+  if (( !nobkp )); then
     command mkdir -p ._backup
     command rm -rf ._backup/*(DN)
     command mv -f *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) ._backup 2>/dev/null
-  }
+  fi
 
   .zi-extract-wrapper() {
     local file="$1" fun="$2" retval
     (( !OPTS[opt_-q,--quiet] )) && +zi-message "{annex}ziextract{ehi}:{rst} Unpacking the files from{ehi}:{rst} \`{file}$file{rst}'{…}{rst}"
     $fun; retval=$?
-    if (( retval == 0 )) {
+    if (( retval == 0 )); then
       local -a files
       files=( *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) )
       (( ${#files} && !norm )) && command rm -f "$file"
-    }
+    fi
     return $retval
   }
 
@@ -1710,9 +1714,9 @@ ziextract() {
         command cp -Rf ${attached_vol:-${TMPDIR:-/tmp}/acb321GEF}/*(D) .
         retval=$?
         command hdiutil detach $attached_vol
-        if (( retval )) {
+        if (( retval )); then
           +zi-message "{annex}ziextract{ehi}:{rst} {warn}Problem occurred when attempted to copy the files from the mounted image{ehi}:{rst} \`{file}${file}{rst}'"
-        }
+        fi
         return $retval
       }
       ;;
@@ -1730,23 +1734,23 @@ ziextract() {
       ;;
   esac
 
-  if [[ $(typeset -f + →zi-extract) == "→zi-extract" ]] {
+  if [[ $(typeset -f + →zi-extract) == "→zi-extract" ]]; then
     .zi-extract-wrapper "$file" →zi-extract || {
       +zi-message -n "{annex}ziextract{ehi}:{rst} {warn}Problem occurred while extracting \`{file}$file{warn}'{rst}"
       local -a bfiles
       bfiles=( ._backup/*(DN) )
-      if (( ${#bfiles} && !nobkp )) {
+      if (( ${#bfiles} && !nobkp )); then
         +zi-message -n ", restoring the previous version of the {pname}plugin{ehi}/{apo}snippet{rst}"
         command mv ._backup/*(DN) . 2>/dev/null
-      }
+      fi
       +zi-message ".{rst}"
       unfunction -- →zi-extract →zi-check 2>/dev/null
       return 1
     }
     unfunction -- →zi-extract →zi-check
-  } else {
+  else
     integer warning=1
-  }
+  fi
   unfunction -- .zi-extract-wrapper
 
   local -a execs
@@ -1758,43 +1762,43 @@ ziextract() {
   fi
 
   builtin print -rl -- ${execs[@]} >! ${TMPDIR:-/tmp}/zi-execs.$$.lst
-  if [[ ${#execs} -gt 0 ]] {
+  if [[ ${#execs} -gt 0 ]]; then
     command chmod a+x "${execs[@]}"
-    if (( !OPTS[opt_-q,--quiet] )) {
+    if (( !OPTS[opt_-q,--quiet] )); then
       if (( ${#execs} == 1 )); then
         +zi-message "{annex}ziextract{ehi}:{rst} {auto}Successfully extracted and assigned \`+x\` chmod to the file{ehi}:{rst} \`{file}${execs[1]}{rst}'"
       else
         local sep="$ZI[col-rst],$ZI[col-obj] "
-        if (( ${#execs} > 7 )) {
+        if (( ${#execs} > 7 )); then
           +zi-message "{annex}ziextract{ehi}:{rst} {auto}Successfully extracted and assigned \`+x\` chmod to the files{ehi}:{rst} ({obj2}${(pj:$sep:)${(@)execs[1,5]:t}},…{rst}) contained" \
             "in \`{file}$file{rst}' {nl}{mmdsh}{msg} All the extracted {obj2}${#execs}{rst} executables are available in the {var}INSTALLED_EXECS{rst} array"
-        } else {
+        else
           +zi-message "{annex}ziextract{ehi}:{rst} {auto}Successfully extracted and assigned \`+x\` chmod to the files{ehi}:{rst} ({obj2}${(pj:$sep:)${execs[@]:t}}{rst}) contained in \`{file}$file{rst}'"
-        }
+        fi
       fi
-    }
-  } elif (( warning )) {
+    fi
+  elif (( warning )); then
     +zi-message "{annex}ziextract{ehi}:{rst} {auto}Did not recognize the archive type of \`{file}${file}{rst}'" \
       "${ext:+/ {obj2}${ext}{rst} } {nl}{mmdsh}{rst}{error} No extraction has been done{rst}"
-  }
-  if (( move | move2 )) {
+  fi
+  if (( move | move2 )); then
     local -a files
     files=( *~(._zi|.git|._backup|.tmp231ABC)(DN/) )
-    if (( ${#files} )) {
+    if (( ${#files} )); then
       command mkdir -p .tmp231ABC
       command mv -f *~(._zi|.git|._backup|.tmp231ABC)(D) .tmp231ABC
-      if (( !move2 )) {
+      if (( !move2 )); then
         command mv -f **/*~(*/*~*/*/*|*/*/*/*|^*/*|._zi(|/*)|.git(|/*)|._backup(|/*))(DN) .
-      } else {
+      else
         command mv -f **/*~(*/*~*/*/*/*|*/*/*/*/*|^*/*|._zi(|/*)|.git(|/*)|._backup(|/*))(DN) .
-      }
+      fi
       command mv .tmp231ABC/$file . &>/dev/null
       command rm -rf .tmp231ABC
-    }
+    fi
     REPLY="${${execs[1]:h}:h}/${execs[1]:t}"
-  } else {
+  else
     REPLY="${execs[1]}"
-  }
+  fi
   return 0
 } # ]]]
 # FUNCTION: .zi-extract() [[[
@@ -1809,19 +1813,19 @@ ziextract() {
     }
     local -a files
     files=( ${(@)${(@s: :)${extract##(\!-|-\!|\!|-)}}//(#b)(((#s)|([^\\])[\\]([\\][\\])#)|((#s)|([^\\])([\\][\\])#)) /${match[2]:+$match[3]$match[4] }${match[5]:+$match[6]${(l:${#match[7]}/2::\\:):-} }} )
-    if [[ ${#files} -eq 0 && -n ${extract##(\!-|-\!|\!|-)} ]] {
+    if [[ ${#files} -eq 0 && -n ${extract##(\!-|-\!|\!|-)} ]]; then
         +zi-message "{auto}The files ${extract##(\!-|-\!|\!|-)} not found{rst}{nl}{mmdsh}{error} Failed to extract{rst}"
         return 1
-    } else {
+    else
       (( !${#files} )) && files=( "" )
-    }
+    fi
     local file
-    for file ( "${files[@]}" ) {
+    for file ( "${files[@]}" ); do
       if [[ -z $extract ]]; then
         local auto2=--auto
       fi
       ziextract ${${(M)extract:#(\!|-)##}:+--auto} $auto2 $file ${${(MS)extract[1,2]##-}:+--norm} ${${(MS)extract[1,2]##\!}:+--move} ${${(MS)extract[1,2]##\!\!}:+--move2} ${${${#files}:#1}:+--nobkp}
-    }
+    done
   )
 }
 # ]]]
@@ -1856,7 +1860,7 @@ zpextract() { ziextract "$@"; }
 
   +zi-message "{info}Downloading{ehi}:{rst} {obj}mirrors.lst{info}{…}{rst}"
   local mlst="$(mktemp)"
-  while (( retry -- )) {
+  while (( retry -- )); do
     if ! .zi-download-file-stdout https://cygwin.com/mirrors.lst 0 > $mlst; then
       .zi-download-file-stdout https://cygwin.com/mirrors.lst 1 > $mlst
     fi
@@ -1868,7 +1872,7 @@ zpextract() { ziextract "$@"; }
     if [[ -n $mirror ]]; then
       break
     fi
-  }
+  done
 
   if [[ -z $mirror ]]; then
     +zi-message "{error}Couldn't download{ehi}:{rst} {obj}mirrors.lst {error}."
@@ -1885,7 +1889,7 @@ zpextract() { ziextract "$@"; }
   +zi-message "{info}Downloading{ehi}:{rst} {file}setup.ini.bz2{info}{…}{rst}"
   local setup="$(mktemp -u)"
   retry=3
-  while (( retry -- )) {
+  while (( retry -- )); do
     if ! .zi-download-file-stdout ${mirror}x86_64/setup.bz2 0 1 > $setup.bz2; then
       .zi-download-file-stdout ${mirror}x86_64/setup.bz2 1 1 > $setup.bz2
     fi
@@ -1896,7 +1900,7 @@ zpextract() { ziextract "$@"; }
     fi
     mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
     +zi-message "{pre}Retrying{ehi}:{rst} {meta}#{obj}$(( 3 - $retry ))/3, {pre}with mirror{error}: {url}$mirror{rst}"
-  }
+  done
   local setup_contents="$(command grep -A 26 "@ $pkg\$" "$setup")"
   local urlpart=${${(S)setup_contents/(#b)*@ $pkg${nl}*install: (*)$nl*/$match[1]}%% *}
   if [[ -z $urlpart ]]; then
@@ -1911,7 +1915,7 @@ zpextract() { ziextract "$@"; }
 
   +zi-message "{info}Downloading{ehi}:{rst} {file}${url:t}{info}{…}{rst}"
   retry=2
-  while (( retry -- )) {
+  while (( retry -- )); do
     integer retval=0
     if ! .zi-download-file-stdout $url 0 1 > $outfile; then
       if ! .zi-download-file-stdout $url 1 1 > $outfile; then
@@ -1919,14 +1923,14 @@ zpextract() { ziextract "$@"; }
         retval=1
         mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
         url=$mirror/$urlpart outfile=${TMPDIR:-${TMPDIR:-/tmp}}/${urlpart:t}
-        if (( retry )) {
+        if (( retry )); then
           +zi-message "{info2}Retrying, with mirror{ehi}:{rst} {url}$mirror{info2}{…}{rst}"
           continue
-        }
+        fi
       fi
     fi
     break
-  }
+  done
   REPLY=$outfile
 }
 # ]]]
@@ -1954,17 +1958,17 @@ zicp() {
     fi
     local a b var
     integer retval
-    for a b ( "${(s: :)${${(@s.;.)${arg%\;}}:-* .}}" ) {
-      for var ( a b ) {
+    for a b ( "${(s: :)${${(@s.;.)${arg%\;}}:-* .}}" ); do
+      for var ( a b ); do
         : ${(P)var::=${(P)var//(#b)(((#s)|([^\\])[\\]([\\][\\])#)|((#s)|([^\\])([\\][\\])#)) /${match[2]:+$match[3]$match[4] }${match[5]:+$match[6]${(l:${#match[7]}/2::\\:):-} }}}
-      }
+      done
       if [[ $a != *\** ]]; then
         a=${a%%/##}"/*"
       fi
       command mkdir -p ${~${(M)b:#/*}:-$ZPFX/$b}
       command $cmd -f ${${(M)cmd:#cp}:+-R} $~a ${~${(M)b:#/*}:-$ZPFX/$b}
       retval+=$?
-    }
+    done
     return $retval
   )
   return
@@ -1982,82 +1986,82 @@ zimv() {
 # FUNCTION: ∞zi-reset-opt-hook [[[
 ∞zi-reset-hook() {
   # File
-  if [[ "$1" = plugin ]] {
+  if [[ "$1" = plugin ]]; then
     local type="$1" user="$2" plugin="$3" id_as="$4" dir="${5#%}" hook="$6"
-  } else {
+  else
     local type="$1" url="$2" id_as="$3" dir="${4#%}" hook="$5"
-  }
-  if (( ( OPTS[opt_-r,--reset] && ZI[-r/--reset-opt-hook-has-been-run] == 0 ) || ( ${+ICE[reset]} && ZI[-r/--reset-opt-hook-has-been-run] == 1 ) )) {
-    if (( ZI[-r/--reset-opt-hook-has-been-run] )) {
+  fi
+  if (( ( OPTS[opt_-r,--reset] && ZI[-r/--reset-opt-hook-has-been-run] == 0 ) || ( ${+ICE[reset]} && ZI[-r/--reset-opt-hook-has-been-run] == 1 ) )); then
+    if (( ZI[-r/--reset-opt-hook-has-been-run] )); then
       local msg_bit="{ice}reset{msg} ice given{pre}" option=
-    } else {
+    else
       local msg_bit="{opt}-r/--reset{msg} given to \`{cmd}update{rst}'{pre}" option=1
-    }
-    if [[ $type == snippet ]] {
-      if (( $+ICE[svn] )) {
+    fi
+    if [[ $type == snippet ]]; then
+      if (( $+ICE[svn] )); then
         if [[ $skip_pull -eq 0 && -d $filename/.svn ]]; then
           (( !OPTS[opt_-q,--quiet] )) && +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Resetting the repository ($msg_bit) with command{ehi}:{rst} {rst}svn revert --recursive {…}/{file}$filename/.{rst} {…}"
           command svn revert --recursive $filename/.
         fi
-      } else {
-        if (( ZI[annex-multi-flag:pull-active] >= 2 )) {
-          if (( !OPTS[opt_-q,--quiet] )) {
-            if [[ -f $local_dir/$dirname/$filename ]] {
-              if [[ -n $option || -z $ICE[reset] ]] {
+      else
+        if (( ZI[annex-multi-flag:pull-active] >= 2 )); then
+          if (( !OPTS[opt_-q,--quiet] )); then
+            if [[ -f $local_dir/$dirname/$filename ]]; then
+              if [[ -n $option || -z $ICE[reset] ]]; then
                 +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Removing the snippet-file{ehi}:{rst} {file}$filename{msg} {…}{rst}"
-              } else {
+              else
                 +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Removing the snippet-file{ehi}:{rst} {file}$filename{msg}, with the supplied code{ehi}:{rst} {data2}$ICE[reset]{msg} {…}{rst}"
-              }
-              if (( option )) {
+              fi
+              if (( option )); then
                 command rm -f "$local_dir/$dirname/$filename"
-              } else {
+              else
                 eval "${ICE[reset]:-rm -f \"$local_dir/$dirname/$filename\"}"
-              }
-            } else {
+              fi
+            else
               +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}The file {file}$filename{msg} is already deleted {…}{rst}"
               if [[ -n $ICE[reset] && ! -n $option ]]; then
                 +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}(skipped running the provided reset-code{ehi}:{rst} {data2}$ICE[reset]{msg}){rst}"
               fi
-            }
-          }
-        } else {
+            fi
+          fi
+        else
           if [[ -f $local_dir/$dirname/$filename ]]; then
             +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Skipping the removal of {file}$filename{msg} as there is no new copy scheduled for download{rst}" || \
             +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}The file {file}$filename{msg} is already deleted and no new download is being scheduled{rst}"
           fi
-        }
-      }
-    } elif [[ $type == plugin ]] {
-      if (( is_release && !skip_pull )) {
-        if (( option )) {
+        fi
+      fi
+    elif [[ $type == plugin ]]; then
+      if (( is_release && !skip_pull )); then
+        if (( option )); then
           (( !OPTS[opt_-q,--quiet] )) && +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Running{ehi}:{rst} rm -rf ${${ZI[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZI[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zi-protection-triggered}/*"
           builtin eval command rm -rf ${${ZI[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/"${${(M)${local_dir##${ZI[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zi-protection-triggered}"/*(ND)
-        } else {
+        else
           (( !OPTS[opt_-q,--quiet] )) && +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Running{ehi}:{rst} ${ICE[reset]:-rm -rf ${${ZI[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZI[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zi-protection-triggered}/*}"
           builtin eval ${ICE[reset]:-command rm -rf ${${ZI[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/"${${(M)${local_dir##${ZI[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zi-protection-triggered}"/*(ND)}
-        }
-      } elif (( !skip_pull )) {
-        if (( option )) {
+        fi
+      elif (( !skip_pull )); then
+        if (( option )); then
           +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Resetting the repository with command{ehi}:{rst} {auto}git reset --hard HEAD {…}"
           command git reset --hard HEAD
-        } else {
+        else
           +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Resetting the repository with command{ehi}:{rst} {auto}${ICE[reset]:-git reset --hard HEAD} {…}"
           builtin eval "${ICE[reset]:-git reset --hard HEAD}"
-        }
-      }
-    }
-  }
+        fi
+      fi
+    fi
+  fi
 
-  if (( OPTS[opt_-r,--reset] )) {
-    if (( ZI[-r/--reset-opt-hook-has-been-run] == 1 )) {
+  if (( OPTS[opt_-r,--reset] )); then
+    if (( ZI[-r/--reset-opt-hook-has-been-run] == 1 )); then
       ZI[-r/--reset-opt-hook-has-been-run]=0
-    } else {
+    else
       ZI[-r/--reset-opt-hook-has-been-run]=1
-    }
-  } else {
+    fi
+  else
     # If there's no -r/--reset, pretend that it already has been served.
     ZI[-r/--reset-opt-hook-has-been-run]=1
-  }
+  fi
 } # ]]]
 # FUNCTION: ∞zi-make-ee-hook [[[
 ∞zi-make-ee-hook() {
@@ -2140,24 +2144,24 @@ zimv() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
-  if [[ $ICE[mv] == *("->"|"→")* ]] {
+  if [[ $ICE[mv] == *("->"|"→")* ]]; then
     local from=${ICE[mv]%%[[:space:]]#(->|→)*} to=${ICE[mv]##*(->|→)[[:space:]]#} || \
-  } else {
+  else
     local from=${ICE[mv]%%[[:space:]]##*} to=${ICE[mv]##*[[:space:]]##}
-  }
+  fi
   @zi-substitute from to
   local -a mv_args=("-f")
   local -a afr
     ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
       afr=( ${~from}(DN) )
-      if (( ! ${#afr} )) {
+      if (( ! ${#afr} )); then
         +zi-message "{warn}Warning{ehi}:{rst} {auto}mv ice didn't match any file{rst} [{error}$ICE[mv]{rst}]" \
         "{nl}{mmdsh} Available files{ehi}:{rst}{nl}{obj}$(ls -1)"
         return 1
-      }
-      if (( !OPTS[opt_-q,--quiet] )) {
+      fi
+      if (( !OPTS[opt_-q,--quiet] )); then
         mv_args+=("-v")
-      }
+      fi
 
       command mv "${mv_args[@]}" "${afr[1]}" "$to"
       local retval=$?
@@ -2174,26 +2178,26 @@ zimv() {
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
 
-  if [[ $ICE[cp] == *("->"|"→")* ]] {
+  if [[ $ICE[cp] == *("->"|"→")* ]]; then
     local from=${ICE[cp]%%[[:space:]]#(->|→)*} to=${ICE[cp]##*(->|→)[[:space:]]#} || \
-  } else {
+  else
     local from=${ICE[cp]%%[[:space:]]##*} to=${ICE[cp]##*[[:space:]]##}
-  }
+  fi
 
   @zi-substitute from to
 
   local -a afr
   ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
     afr=( ${~from}(DN) )
-    if (( ${#afr} )) {
-      if (( !OPTS[opt_-q,--quiet] )) {
+    if (( ${#afr} )); then
+      if (( !OPTS[opt_-q,--quiet] )); then
         command cp -vf "${afr[1]}" "$to"
         command cp -vf "${afr[1]}".zwc "$to".zwc 2>/dev/null
-      } else {
+      else
         command cp -f "${afr[1]}" "$to"
         command cp -f "${afr[1]}".zwc "$to".zwc 2>/dev/null
-      }
-    }
+      fi
+    fi
   )
 } # ]]]
 # FUNCTION: ∞zi-compile-plugin-hook [[[
@@ -2209,11 +2213,11 @@ zimv() {
       () {
         builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
         builtin setopt extendedglob warncreateglobal
-        if [[ $tpe == snippet ]] {
+        if [[ $tpe == snippet ]]; then
           .zi-compile-plugin "%$dir" ""
-        } else {
+        else
           .zi-compile-plugin "$id_as" ""
-        }
+        fi
       }
     fi
 } # ]]]
@@ -2231,9 +2235,9 @@ zimv() {
 
   .zi-countdown atpull && {
     local ___oldcd=$PWD
-    (( ${+ICE[nocd]} == 0 )) && {
+    if (( ${+ICE[nocd]} == 0 )); then
       () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; }
-    }
+    fi
     .zi-at-eval "$atpull" "$ICE[atclone]"
     rc="$?"
     () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
@@ -2272,16 +2276,16 @@ zimv() {
   if [[ "$1" = plugin ]]; then
     local tpe="$1" dir="${5#%}" hook="$6" subtype="$7" || local tpe="$1" dir="${4#%}" hook="$5" subtype="$6"
   fi
-  if (( !OPTS[opt_-q,--quiet] )) {
+  if (( !OPTS[opt_-q,--quiet] )); then
     +zi-message "Running $tpe's provided update code{ehi}:{rst} {info}${ICE[ps-on-update][1,50]}${ICE[ps-on-update][51]:+…}{rst}"
     (
       builtin cd -q "$dir" || return 1
       eval "$ICE[ps-on-update]"
     )
-  } else {
+  else
     (
       builtin cd -q "$dir" || return 1
       eval "$ICE[ps-on-update]" &> /dev/null
     )
-  }
+  fi
 } # ]]]

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -54,7 +54,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         fi
       }
 
-      [[ ${match[1]} = \" && $___quoting != \' ]] && \
+      if [[ ${match[1]} = \" && $___quoting != \' ]]; then
         if [[ $___quoting = '"' ]]; then
           ___Strings[$___level/${___Counts[$___level]}]+=" ${(q)___input[___sidx,___idx-1]}"
           ___quoting=""
@@ -63,22 +63,22 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           ___sidx=___idx+1
           ___quoting='"'
         fi
-
-      [[ ${match[1]} = , && -z $___quoting ]] && \
+      fi
+      if [[ ${match[1]} = , && -z $___quoting ]]; then
         {
           (( !___had_quoted_value )) && \
             ___Strings[$___level/${___Counts[$___level]}]+=" ${(q)___input[___sidx,___idx-1]//((#s)[[:blank:]]##|([[:blank:]]##(#e)))}"
           ___sidx=___idx+1
           ___had_quoted_value=0
         }
-
-      [[ ${match[1]} = : && -z $___quoting ]] && \
+      fi
+      if [[ ${match[1]} = : && -z $___quoting ]]; then
         {
           ___had_quoted_value=0
           ___sidx=___idx+1
         }
-
-      [[ ${match[1]} = \' && $___quoting != \" ]] && \
+      fi
+      if [[ ${match[1]} = \' && $___quoting != \" ]]; then
         if [[ $___quoting = "'" ]]; then
           ___Strings[$___level/${___Counts[$___level]}]+=" ${(q)___input[___sidx,___idx-1]}"
           ___quoting=""
@@ -87,7 +87,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           ___sidx=___idx+1
           ___quoting="'"
         fi
-
+      fi
       ___workbuf=${match[4]}
     }
   done
@@ -136,7 +136,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   }
 
   # load json from file
-  [[ -e $tmpfile ]] && pkgjson="$(<$tmpfile)"
+  if [[ -e $tmpfile ]]; then
+    pkgjson="$(<$tmpfile)"
+  fi
 
   if [[ -z $pkgjson ]] {
     +zi-message "{u-warn}Error{b-warn}{ehi}:{rst} the package {apo}\`{pid}$id_as{apo}\` {rst}couldn't be found"
@@ -156,13 +158,22 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   pos=${${(@Q)${(@z)Strings[2/2]}}[(I)$profile]}
   if (( pos )) {
     for key value ( "${(@Q)${(@z)Strings[3/$(( (pos + 1) / 2 ))]}}" ) {
-      (( ${+ICE[$key]} )) && [[ ${ICE[$key]} != +* ]] && continue
+      (( ${+ICE[$key]} )) && \
+      if [[ ${ICE[$key]} != +* ]]; then
+        continue
+      fi
       ICE[$key]=$value${ICE[$key]#+}
     }
     ICE=( "${(kv)ICE[@]//\\\"/\"}" )
-    [[ ${ICE[as]} = program ]] && ICE[as]="command"
-    [[ -n ${ICE[on-update-of]} ]] && ICE[subscribe]="${ICE[subscribe]:-${ICE[on-update-of]}}"
-    [[ -n ${ICE[pick]} ]] && ICE[pick]="${ICE[pick]//\$ZPFX/${ZPFX%/}}"
+    if [[ ${ICE[as]} = program ]]; then
+      ICE[as]="command"
+    fi
+    if [[ -n ${ICE[on-update-of]} ]]; then
+      ICE[subscribe]="${ICE[subscribe]:-${ICE[on-update-of]}}"
+    fi
+    if [[ -n ${ICE[pick]} ]]; then
+      ICE[pick]="${ICE[pick]//\$ZPFX/${ZPFX%/}}"
+    fi
     if [[ -n ${ICE[id-as]} ]] {
       @zi-substitute 'ICE[id-as]'
       local -A map
@@ -226,7 +237,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message "{nl}You can download the" "annex from its homepage at {url}https://github.com/z-shell/z-a-patch-dl{rst}."
   }
 
-  [[ -n ${jsondata1[message]} ]] && +zi-message "{info}${jsondata1[message]}{rst}"
+  if [[ -n ${jsondata1[message]} ]]; then
+    +zi-message "{info}${jsondata1[message]}{rst}"
+  fi
 
   if (( ${+ICE[is-snippet]} )) {
     reply=( "" "$url" )
@@ -336,7 +349,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     }
 
     local site
-    [[ -n ${ICE[from]} ]] && site=${sites[${ICE[from]}]}
+    if [[ -n ${ICE[from]} ]]; then
+      site=${sites[${ICE[from]}]}
+    fi
     if [[ -z $site && ${ICE[from]} = *(gh-r|github-rel)* ]] {
       site=${ICE[from]/(gh-r|github-re)/${sites[gh-r]}}
     }
@@ -444,10 +459,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_path" "${${key##(zi|z-annex) hook:}%% <->}" load
         hook_rc=$?
         # Effectively return the last != 0 rc
-        [[ "$hook_rc" -ne 0 ]] && {
+        if [[ "$hook_rc" -ne 0 ]]; then
           retval="$hook_rc"
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-        }
+        fi
       done
       # Run annexes' atclone hooks (the after atclone-ice ones)
       reply=(
@@ -459,10 +474,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
         "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_path" "${${key##(zi|z-annex) hook:}%% <->}"
         hook_rc=$?
-        [[ "$hook_rc" -ne 0 ]] && {
+        if [[ "$hook_rc" -ne 0 ]]; then
           retval="$hook_rc"
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-        }
+        fi
       done
     }
     return "$retval"
@@ -474,8 +489,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   # After additional executions like atclone'' - install completions (1 - plugins)
   local -A OPTS
   OPTS[opt_-q,--quiet]=1
-  [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]] && \
+  if [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]]; then
     .zi-install-completions "$id_as" "" "0"
+  fi
 
   if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]] {
     typeset -ga INSTALLED_COMPS SKIPPED_COMPS
@@ -510,7 +526,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}}
   local reinstall=${3:-0} quiet=${${4:+1}:-0}
   (( OPTS[opt_-q,--quiet] )) && quiet=1
-  [[ $4 = -Q ]] && quiet=2
+  if [[ $4 = -Q ]]; then
+    quiet=2
+  fi
   typeset -ga INSTALLED_COMPS SKIPPED_COMPS
   INSTALLED_COMPS=() SKIPPED_COMPS=()
 
@@ -526,7 +544,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   typeset -a completions already_symlinked backup_comps
   local c cfile bkpfile
   # The plugin == . is a semi-hack/trick to handle `creinstall .' properly
-  [[ $user == % || ( -z $user && $plugin == . ) ]] && \
+  [[ $user == % || ( -z $user && $plugin == . ) &]] & \
   completions=( "${plugin}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) ) || \
   completions=( "${ZI[PLUGINS_DIR]}/${id_as//\//---}"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) )
   already_symlinked=( "${ZI[COMPLETIONS_DIR]}"/_[^_.]*~*.zwc(DN) )
@@ -579,7 +597,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 #
 # No arguments.
 .zi-compinit() {
-  [[ -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]] && return
+  if [[ -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]]; then
+    return
+  fi
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt nullglob extendedglob warncreateglobal typesetsilent
 
@@ -726,7 +746,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
       out1=( "${(M)out1[@]:#Revision:*}" )
       out2=( "${(M)out2[@]:#Revision:*}" )
-      [[ "${out1[1]##[^0-9]##}" != "${out2[1]##[^0-9]##}" ]] && return 0
+      if [[ "${out1[1]##[^0-9]##}" != "${out2[1]##[^0-9]##}" ]]; then
+        return 0
+      fi
       return 1
     )
     return $?
@@ -755,7 +777,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   typeset -a commands
   commands=( ${(k)_comps[(Re)$f]} )
 
-  [[ "${#commands}" -gt 0 ]] && (( quiet == 0 )) && builtin print -Prn "Forgetting commands completed by \`${ZI[col-obj]}$f%f%b': "
+  if [[ "${#commands}" -gt 0 ]]; then
+    (( quiet == 0 )) && builtin print -Prn "Forgetting commands completed by \`${ZI[col-obj]}$f%f%b': "
+  fi
 
   local k
   integer first=1
@@ -872,14 +896,19 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local -a list arr
   integer retval=0 hook_rc=0
   local teleid_clean=${ICE[teleid]%%\?*}
-  [[ $teleid_clean == *://* ]] && \
+  if [[ $teleid_clean == *://* ]]; then
     local sname=${(M)teleid_clean##*://[^/]##(/[^/]##)(#c0,4)} || \
     local sname=${${teleid_clean:h}:t}/${teleid_clean:t}
-  [[ $sname = */trunk* ]] && sname=${${ICE[teleid]%%/trunk*}:t}/${ICE[teleid]:t}
+  fi
+  if [[ $sname = */trunk* ]]; then
+    sname=${${ICE[teleid]%%/trunk*}:t}/${ICE[teleid]:t}
+  fi
   sname=${sname#./}
 
   if (( ${+ICE[svn]} )) {
-    [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]] && local ZSH=${ZI[SNIPPETS_DIR]}
+    if [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]]; then
+      local ZSH=${ZI[SNIPPETS_DIR]}
+    fi
     url=${url/(#s)(#m)(${(~kj.|.)ZI_1MAP})/$ZI_1MAP[$MATCH]}
   } else {
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
@@ -907,7 +936,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   if [[ ! -d $local_dir/$dirname ]]; then
     local id_msg_part="{…} ({p}at label{ehi}:{rst} {id-as}$id_as{rst})"
-    [[ $update != -u ]] && +zi-message "{nl}{apo}Snippet{ehi}:{rst} {url}$sname{rst}${ICE[id-as]:+$id_msg_part}"
+    if [[ $update != -u ]]; then
+      +zi-message "{nl}{apo}Snippet{ehi}:{rst} {url}$sname{rst}${ICE[id-as]:+$id_msg_part}"
+    fi
     command mkdir -p "$local_dir"
   fi
 
@@ -953,10 +984,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
               arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
               "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update:svn
               hook_rc=$?
-              [[ "$hook_rc" -ne 0 ]] && {
+              if [[ "$hook_rc" -ne 0 ]]; then
                 retval="$hook_rc"
                 builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-              }
+              fi
             done
 
             if (( ZI[annex-multi-flag:pull-active] == 2 )) {
@@ -1041,10 +1072,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
               arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
               "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update:url
               hook_rc="$?"
-              [[ "$hook_rc" -ne 0 ]] && {
+              if [[ "$hook_rc" -ne 0 ]]; then
                 retval="$hook_rc"
                 builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-              }
+              fi
             done
           }
 
@@ -1099,10 +1130,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
           "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update:file
           hook_rc="$?"
-          [[ "$hook_rc" -ne 0 ]] && {
+          if [[ "$hook_rc" -ne 0 ]]; then
             retval="$hook_rc"
             builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-          }
+          fi
         done
       }
 
@@ -1153,10 +1184,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
         "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update:0
         hook_rc="$?"
-        [[ "$hook_rc" -ne 0 ]] && {
+        if [[ "$hook_rc" -ne 0 ]]; then
           retval="$hook_rc"
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-        }
+        fi
       done
       return $retval;
     }
@@ -1173,10 +1204,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
         "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update
         hook_rc=$?
-        [[ "$hook_rc" -ne 0 ]] && {
+        if [[ "$hook_rc" -ne 0 ]]; then
           retval="$hook_rc"
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-        }
+        fi
       done
     } else {
       # Run annexes' atclone hooks (the before atclone-ice ones)
@@ -1215,10 +1246,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
           "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update
           hook_rc=$?
-          [[ "$hook_rc" -ne 0 ]] && {
+          if [[ "$hook_rc" -ne 0 ]]; then
             retval="$hook_rc"
             builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-          }
+          fi
         done
       }
       # Run annexes' atpull hooks (the `always' after atpull-ice ones)
@@ -1232,10 +1263,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         arr=( "${(Q)${(z@)ZI_EXTS[$key]:-$ZI_EXTS2[$key]}[@]}" )
         "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" "${${key##(zi|z-annex) hook:}%% <->}" update:$ZI[annex-multi-flag:pull-active]
         hook_rc=$?
-        [[ "$hook_rc" -ne 0 ]] && {
+        if [[ "$hook_rc" -ne 0 ]]; then
           retval="$hook_rc"
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
-        }
+        fi
       done
     }
   ) || return $?
@@ -1244,8 +1275,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   # After additional executions like atclone'' - install completions (2 - snippets)
   local -A OPTS
   OPTS[opt_-q,--quiet]=1
-  [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]] && \
+  if [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]]; then
     .zi-install-completions "%" "$local_dir/$dirname" 0
+  fi
   if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]] {
     typeset -ga INSTALLED_COMPS SKIPPED_COMPS
     { INSTALLED_COMPS=( "${(@f)$(<${TMPDIR:-/tmp}/zi.installed_comps.$$.lst)}" ) } 2>/dev/null
@@ -1272,7 +1304,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local -a tmp opts
   local url=$1
   integer correct=0
-  [[ -o ksharrays ]] && correct=1
+  if [[ -o ksharrays ]]; then
+    correct=1
+  fi
   opts=( -u ) # for z-a-readurl
 
   # Create a local copy of OPTS,
@@ -1287,7 +1321,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   # Remove leading whitespace and trailing /
   url=${${url#${url%%[! $'\t']*}}%/}
   ICE[teleid]=${ICE[teleid]:-$url}
-  [[ ${ICE[as]} = null || ${+ICE[null]} -eq 1 || ${+ICE[binary]} -eq 1 ]] && ICE[pick]=${ICE[pick]:-/dev/null}
+  if [[ ${ICE[as]} = null || ${+ICE[null]} -eq 1 || ${+ICE[binary]} -eq 1 ]]; then
+    ICE[pick]=${ICE[pick]:-/dev/null}
+  fi
 
   local local_dir dirname filename save_url=$url id_as=${ICE[id-as]:-$url}
 
@@ -1309,7 +1345,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   # Oh-My-Zsh, Prezto and manual shorthands
   if (( ${+ICE[svn]} )) {
-    [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]] && local ZSH=${ZI[SNIPPETS_DIR]}
+    if [[ $url = *(${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}}|robbyrussell*oh-my-zsh|ohmyzsh/ohmyzsh)* ]]; then
+      local ZSH=${ZI[SNIPPETS_DIR]}
+    fi
     url=${url/(#s)(#m)(${(~kj.|.)ZI_1MAP})/$ZI_1MAP[$MATCH]}
   } else {
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
@@ -1347,7 +1385,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   done
 
   # Download or copy the file
-  [[ $url = *github.com* && $url != */raw/* ]] && url=${url/\/(blob|tree)\///raw/}
+  if [[ $url = *github.com* && $url != */raw/* ]]; then
+    url=${url/\/(blob|tree)\///raw/}
+  fi
   .zi-download-snippet "$save_url" "$url" "$id_as" "$local_dir" "$dirname" "$filename" "-u"
 
   return $?
@@ -1403,7 +1443,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   local -a list2 bpicks
   bpicks=( ${(s.;.)ICE[bpick]} )
-  [[ -z $bpicks ]] && bpicks=( "" )
+  if [[ -z $bpicks ]]; then
+    bpicks=( "" )
+  fi
   local bpick
 
   reply=()
@@ -1510,7 +1552,9 @@ ziextract() {
       for file ( $archives ) {
         local fname=${(M)file#(${(~j:|:)infiles}): } desc=${file#(${(~j:|:)infiles}): } type
         fname=${fname%%??}
-        [[ -z $fname || -n ${stage2_processed[(r)$fname]} ]] && continue
+        if [[ -z $fname || -n ${stage2_processed[(r)$fname]} ]]; then
+          continue
+        fi
         type=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
         if [[ $type = (zip|rar|xz|7-zip|gzip|bzip2|tar|exe|pe32) ]] {
           (( !OPTS[opt_-q,--quiet] )) && \
@@ -1523,7 +1567,9 @@ ziextract() {
 
           # Support nested tar.(bz2|gz|…) archives
           local infname=$fname
-          [[ -f $fname.out ]] && fname=$fname.out
+          if [[ -f $fname.out ]]; then
+            fname=$fname.out
+          fi
           files=( *.tar(ND) )
           if [[ -f $fname || -f ${fname:r} ]] {
             local -aU output2 archives2
@@ -1535,14 +1581,18 @@ ziextract() {
               local type2=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
               if [[ $type != $type2 && $type2 = (zip|rar|xz|7-zip|gzip|bzip2|tar) ]] {
                 # TODO: #115 If multiple archives are really in the archive, this might delete too soon… However, it's unusual case.
-                [[ $fname != $infname && $norm -eq 0 ]] && command rm -f "$infname"
+                if [[ $fname != $infname && $norm -eq 0 ]]; then
+                  command rm -f "$infname"
+                fi
                 (( !OPTS[opt_-q,--quiet] )) && \
                 +zi-message "{annex}ziextract{ehi}:{rst} {note}Detected a {obj2}${type2}{note} archive in the file{ehi}:{rst} {file}${fname}{rst}"
                 ziextract "$fname" "$type2" $opt_move $opt_move2 $opt_norm ${${${#archives}:#1}:+--nobkp}
                 ret_val+=$?
                 stage2_processed+=( $fname )
                 if [[ $fname == *.out ]] {
-                  [[ -f $fname ]] && command mv -f "$fname" "${fname%.out}"
+                  if [[ -f $fname ]]; then
+                    command mv -f "$fname" "${fname%.out}"
+                  fi
                   stage2_processed+=( ${fname%.out} )
                 }
               }
@@ -1766,7 +1816,9 @@ ziextract() {
     }
     local file
     for file ( "${files[@]}" ) {
-      [[ -z $extract ]] && local auto2=--auto
+      if [[ -z $extract ]]; then
+        local auto2=--auto
+      fi
       ziextract ${${(M)extract:#(\!|-)##}:+--auto} $auto2 $file ${${(MS)extract[1,2]##-}:+--norm} ${${(MS)extract[1,2]##\!}:+--move} ${${(MS)extract[1,2]##\!\!}:+--move2} ${${${#files}:#1}:+--nobkp}
     }
   )
@@ -1781,9 +1833,11 @@ zpextract() { ziextract "$@"; }
   integer retval
   @zi-substitute atclone atpull
   local cmd="$atpull"
-  [[ $atpull == "%atclone" ]] && cmd="$atclone"
+  if [[ $atpull == "%atclone" ]]; then
+    cmd="$atclone"
+  fi
   eval "$cmd"
-  return "$?"
+  return "$?"f
 } # ]]]
 # FUNCTION: .zi-get-cygwin-package [[[
 .zi-get-cygwin-package() {
@@ -1810,7 +1864,9 @@ zpextract() { ziextract "$@"; }
     mlist=( "${(@f)$(<$mlst)}" )
 
     local mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
-    [[ -n $mirror ]] && break
+    if [[ -n $mirror ]]; then
+      break
+    fi
   }
 
   if [[ -z $mirror ]] {
@@ -1834,7 +1890,9 @@ zpextract() { ziextract "$@"; }
     fi
 
     command bunzip2 "$setup.bz2" 2>/dev/null
-    [[ -s $setup ]] && break
+    if [[ -s $setup ]]; then
+      break
+    fi
     mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
     +zi-message "{pre}Retrying{ehi}:{rst} {meta}#{obj}$(( 3 - $retry ))/3, {pre}with mirror{error}: {url}$mirror{rst}"
   }
@@ -1952,9 +2010,10 @@ zimv() {
             }
           }
         } else {
-          [[ -f $local_dir/$dirname/$filename ]] && \
+          if [[ -f $local_dir/$dirname/$filename ]]; then
             +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Skipping the removal of {file}$filename{msg} as there is no new copy scheduled for download{rst}" || \
             +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}The file {file}$filename{msg} is already deleted and no new download is being scheduled{rst}"
+          fi
         }
       }
     } elif [[ $type == plugin ]] {
@@ -1991,7 +2050,9 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-make-ee-hook [[[
 ∞zi-make-ee-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
 
   local make=${ICE[make]}
   @zi-substitute make
@@ -2002,7 +2063,9 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-make-e-hook [[[
 ∞zi-make-e-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
 
   local make=${ICE[make]}
   @zi-substitute make
@@ -2013,7 +2076,9 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-make-hook [[[
 ∞zi-make-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   local make=${ICE[make]}
   @zi-substitute make
   (( ${+ICE[make]} )) || return 0
@@ -2023,28 +2088,34 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-atclone-hook [[[
 ∞zi-atclone-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   local atclone=${ICE[atclone]}
   @zi-substitute atclone
   (( ${+ICE[atclone]} )) || return 0
   local rc=0
-  [[ -n $atclone ]] && .zi-countdown atclone && {
-    local ___oldcd=$PWD
-    (( ${+ICE[nocd]} == 0 )) && {
-      () {
-        builtin setopt localoptions noautopushd
-        builtin cd -q "$dir"
+  if [[ -n $atclone ]]; then
+    .zi-countdown atclone && {
+      local ___oldcd=$PWD
+      (( ${+ICE[nocd]} == 0 )) && {
+        () {
+          builtin setopt localoptions noautopushd
+          builtin cd -q "$dir"
+        }
       }
+      eval "$atclone"
+      rc="$?"
+      () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
     }
-    eval "$atclone"
-    rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
-  }
+  fi
   return "$rc"
 } # ]]]
 # FUNCTION: ∞zi-extract-hook [[[
 ∞zi-extract-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   local extract=${ICE[extract]}
   @zi-substitute extract
   (( ${+ICE[extract]} )) || return 0
@@ -2052,8 +2123,12 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-mv-hook [[[
 ∞zi-mv-hook() {
-  [[ -z $ICE[mv] ]] && return 0
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ -z $ICE[mv] ]]; then
+    return 0
+  fi
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   if [[ $ICE[mv] == *("->"|"→")* ]] {
     local from=${ICE[mv]%%[[:space:]]#(->|→)*} to=${ICE[mv]##*(->|→)[[:space:]]#} || \
   } else {
@@ -2081,8 +2156,12 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-cp-hook [[[
 ∞zi-cp-hook() {
-  [[ -z $ICE[cp] ]] && return
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ -z $ICE[cp] ]]; then
+    return
+  fi
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
 
   if [[ $ICE[cp] == *("->"|"→")* ]] {
     local from=${ICE[cp]%%[[:space:]]#(->|→)*} to=${ICE[cp]##*(->|→)[[:space:]]#} || \
@@ -2108,7 +2187,9 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-compile-plugin-hook [[[
 ∞zi-compile-plugin-hook() {
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
     if ! [[ ( $hook = *\!at(clone|pull)* && ${+ICE[nocompile]} -eq 0 ) || ( $hook = at(clone|pull)* && $ICE[nocompile] = '!' ) ]] {
       return 0
     }
@@ -2131,7 +2212,9 @@ zimv() {
   [[ -n ${ICE[atpull]} ]] || return 0
   # Only process atpull"!cmd"
   [[ $ICE[atpull] == "!"* ]] || return 0
-  [[ "$1" = plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ "$1" = plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   local atpull=${ICE[atpull]#\!}
   local rc=0
 
@@ -2151,8 +2234,12 @@ zimv() {
   (( ${+ICE[atpull]} )) || return 0
   [[ -n ${ICE[atpull]} ]] || return 0
   # Exit early if atpull"!cmd" -> this is done by zi-atpull-e-hook
-  [[ $ICE[atpull] == "!"* ]] && return 0
-  [[ "$1" == plugin ]] && local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  if [[ $ICE[atpull] == "!"* ]]; then
+    return 0
+  fi
+  if [[ "$1" == plugin ]]; then
+    local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
+  fi
   local atpull=${ICE[atpull]}
   local rc=0
   .zi-countdown atpull && {
@@ -2168,8 +2255,12 @@ zimv() {
 } # ]]]
 # FUNCTION: ∞zi-ps-on-update-hook [[[
 ∞zi-ps-on-update-hook() {
-  [[ -z $ICE[ps-on-update] ]] && return 0
-  [[ "$1" = plugin ]] && local tpe="$1" dir="${5#%}" hook="$6" subtype="$7" || local tpe="$1" dir="${4#%}" hook="$5" subtype="$6"
+  if [[ -z $ICE[ps-on-update] ]]; then
+    return 0
+  fi
+  if [[ "$1" = plugin ]]; then
+    local tpe="$1" dir="${5#%}" hook="$6" subtype="$7" || local tpe="$1" dir="${4#%}" hook="$5" subtype="$6"
+  fi
   if (( !OPTS[opt_-q,--quiet] )) {
     +zi-message "Running $tpe's provided update code{ehi}:{rst} {info}${ICE[ps-on-update][1,50]}${ICE[ps-on-update][51]:+…}{rst}"
     (

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -28,7 +28,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         { ___workbuf=${match[3]:1}; (( ++ ___idx )); }
     } else {
       ___idx+=${mbegin[1]}
-      if [[ -z $___quoting ]] {
+      if [[ -z $___quoting ]]; then
         if [[ ${match[1]} = ["({["] ]]; then
           ___Strings[$___level/${___Counts[$___level]}]+=" $'\0'--object--$'\0'"
           ___pos_to_level[$___idx]=$(( ++ ___level ))
@@ -43,16 +43,16 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           if (( ___level > 0 )); then
             ___pair_idx=${___level_to_pos[$___level]}
             ___pos_to_level[$___idx]=$(( ___level -- ))
-            if [[ ${___pair_map[${___input[___pair_idx]}]} = ${___input[___idx]} ]] {
+            if [[ ${___pair_map[${___input[___pair_idx]}]} = ${___input[___idx]} ]]; then
               ___final_pairs[$___idx]=$___pair_idx
               ___final_pairs[$___pair_idx]=$___idx
               ___pair_order+=( $___idx )
-            }
+            fi
           else
             ___pos_to_level[$___idx]=-1
           fi
         fi
-      }
+      fi
 
       if [[ ${match[1]} = \" && $___quoting != \' ]]; then
         if [[ $___quoting = '"' ]]; then
@@ -104,9 +104,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     }
   }
 
-  if [[ -n $___found && $___nest -lt 2 ]] {
+  if [[ -n $___found && $___nest -lt 2 ]]; then
     .zi-parse-json "$___found" "$___key" "$___varname" 2
-  }
+  fi
 
   if (( ___nest == 2 )) {
     : ${(PAA)___varname::="${(kv)___Strings[@]}"}
@@ -140,10 +140,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     pkgjson="$(<$tmpfile)"
   fi
 
-  if [[ -z $pkgjson ]] {
+  if [[ -z $pkgjson ]]; then
     +zi-message "{u-warn}Error{b-warn}{ehi}:{rst} the package {apo}\`{pid}$id_as{apo}\` {rst}couldn't be found"
     return 1
-  }
+  fi
 
   local -A Strings
   .zi-parse-json "$pkgjson" "plugin-info" Strings
@@ -188,10 +188,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   +zi-message "{info3}Package{ehi}:{rst} {pid}$pkg{rst}. Selected" "profile{ehi}:{rst} {hi}$profile{rst}. \
   Available profiles:${${${(M)profile:#default}:+$lhi_hl}:-$profile_hl}" "${(pj:$pro_sep:)profiles[@]}{rst}."
-  if [[ $profile != *bgn* && -n ${(M)profiles[@]:#*bgn*} ]] {
+  if [[ $profile != *bgn* && -n ${(M)profiles[@]:#*bgn*} ]]; then
     +zi-message "{note}Note:{rst} The {apo}\`{profile}bgn{glob}*{apo}\`{rst}" "profiles are recommended (if available)." \
     "They provide binaries without {slight}altering/cluttering{rst} the  {var}\$PATH{rst} environment variable."
-  }
+  fi
 
   ICE[required]=${ICE[required]:-$ICE[requires]}
   local -a req
@@ -229,13 +229,13 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     fi
   }
 
-  if [[ -n ${ICE[dl]} && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-patch-dl *]} ]] {
+  if [[ -n ${ICE[dl]} && -z ${(k)ZI_EXTS[(r)<-> z-annex-data: z-a-patch-dl *]} ]]; then
     +zi-message "{nl}{u-warn}WARNING{b-warn}:{rst} the profile uses" \
       "{ice}dl''{rst} ice however there's currently no {annex}z-a-patch-dl{rst}" "annex loaded, which provides it."
     +zi-message "The ice will be inactive, i.e.: no additional" "files will become downloaded (the ice downloads the given URLs)." \
       "The package should still work, as it doesn't indicate to" "{u}{slight}require{rst} the annex."
     +zi-message "{nl}You can download the" "annex from its homepage at {url}https://github.com/z-shell/z-a-patch-dl{rst}."
-  }
+  fi
 
   if [[ -n ${jsondata1[message]} ]]; then
     +zi-message "{info}${jsondata1[message]}{rst}"
@@ -301,10 +301,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   local user=$1 plugin=$2 id_as=$3 remote_url_path=${1:+$1/}$2 local_path tpe=$4 update=$5 version=$6
 
-  if .zi-get-object-path plugin "$id_as" && [[ -z $update ]] {
+  if .zi-get-object-path plugin "$id_as" && [[ -z $update ]]; then
     +zi-message "{error}Error{ehi}:{rst} A plugin named {pid}$id_as{rst} already exists, aborting."
     return 1
-  }
+  fi
   local_path=$REPLY
 
   trap "rmdir ${(qqq)local_path}/._zi ${(qqq)local_path} 2>/dev/null" EXIT
@@ -340,22 +340,22 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   command rm -f ${TMPDIR:-/tmp}/zi-execs.$$.lst ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst \
         ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst ${TMPDIR:-/tmp}/zi.compiled.$$.lst
 
-  if [[ $tpe != tarball ]] {
-    if [[ -z $update ]] {
+  if [[ $tpe != tarball ]]; then
+    if [[ -z $update ]]; then
       .zi-any-colorify-as-uspl2 "$user" "$plugin"
       local pid_hl='{pid}' id_msg_part=" (at label{ehi}:{rst} {id-as}$id_as{rst}{…})"
       (( $+ICE[pack] )) && local infix_m="({b}{ice}pack{apo}''{rst}) "
       +zi-message "{nl}Downloading{ehi}:{rst} $infix_m{pid}$user${user:+/}$plugin{…}${${${id_as:#$user/$plugin}}:+$id_msg_part}"
-    }
+    fi
 
     local site
     if [[ -n ${ICE[from]} ]]; then
       site=${sites[${ICE[from]}]}
     fi
-    if [[ -z $site && ${ICE[from]} = *(gh-r|github-rel)* ]] {
+    if [[ -z $site && ${ICE[from]} = *(gh-r|github-rel)* ]]; then
       site=${ICE[from]/(gh-r|github-re)/${sites[gh-r]}}
-    }
-  }
+    fi
+  fi
 
   (
     if [[ $site = */releases ]] {
@@ -440,12 +440,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           return 1
       esac
 
-      if [[ -n ${ICE[ver]} ]] {
+      if [[ -n ${ICE[ver]} ]]; then
         command git -C "$local_path" checkout "${ICE[ver]}"
-      }
+      fi
     }
 
-    if [[ $update != -u ]] {
+    if [[ $update != -u ]]; then
       hook_rc=0
       # Store ices at clone of a plugin
       .zi-store-ices "$local_path/._zi" ICE "" "" "" ""
@@ -479,7 +479,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
         fi
       done
-    }
+    fi
     return "$retval"
   ) || return $?
 
@@ -493,16 +493,16 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     .zi-install-completions "$id_as" "" "0"
   fi
 
-  if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]] {
+  if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]]; then
     typeset -ga INSTALLED_COMPS SKIPPED_COMPS
     { INSTALLED_COMPS=( "${(@f)$(<${TMPDIR:-/tmp}/zi.installed_comps.$$.lst)}" ) } 2>/dev/null
     { SKIPPED_COMPS=( "${(@f)$(<${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst)}" ) } 2>/dev/null
-  }
+  fi
 
-  if [[ -e ${TMPDIR:-/tmp}/zi.compiled.$$.lst ]] {
+  if [[ -e ${TMPDIR:-/tmp}/zi.compiled.$$.lst ]]; then
     typeset -ga ADD_COMPILED
     { ADD_COMPILED=( "${(@f)$(<${TMPDIR:-/tmp}/zi.compiled.$$.lst)}" ) } 2>/dev/null
-  }
+  fi
 
   # After any download – rehash the command table this will miss the as"program" binaries
   # as their PATH gets extended - and it is done later. It will however work for sbin'' ice.
@@ -711,10 +711,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     header="${${line#*, }//$'\r'}"
   done
 
-  if [[ -z $header ]] {
+  if [[ -z $header ]]; then
     REPLY=$(( $(date +"%s") ))
     return 3
-  }
+  fi
 
   LANG=C TZ=UTC strftime -r -s REPLY "%d %b %Y %H:%M:%S GMT" "$header" &>/dev/null || {
     REPLY=$(( $(date +"%s") ))
@@ -807,14 +807,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local -A ICE
   .zi-compute-ice "$id_as" "pack" ICE plugin_dir filename is_snippet || return 1
 
-  if [[ ${ICE[pick]} != /dev/null && ${ICE[as]} != null && ${+ICE[null]} -eq 0 && ${ICE[as]} != command && ${+ICE[binary]} -eq 0 && ( ${+ICE[nocompile]} = 0 || ${ICE[nocompile]} = \! ) ]] {
+  if [[ ${ICE[pick]} != /dev/null && ${ICE[as]} != null && ${+ICE[null]} -eq 0 && ${ICE[as]} != command && ${+ICE[binary]} -eq 0 && ( ${+ICE[nocompile]} = 0 || ${ICE[nocompile]} = \! ) ]]; then
     reply=()
     if [[ -n ${ICE[pick]} ]]; then
       list=( ${~${(M)ICE[pick]:#/*}:-$plugin_dir/$ICE[pick]}(DN) )
-      if [[ ${#list} -eq 0 ]] {
+      if [[ ${#list} -eq 0 ]]; then
         +zi-message "No files for compilation found (pick-ice didn't match){rst}{…}"
         return 1
-      }
+      fi
       reply=( "${list[1]:h}" "${list[1]}" )
     else
       if (( is_snippet )) {
@@ -836,7 +836,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     local fname=${first#$pdir_path/}
 
     +zi-message -n "Compiling{ehi}:{rst} {b}{file}$fname{rst}{…}"
-    if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
+    if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]]; then
       () {
         builtin emulate -LR zsh -o extendedglob
         if { ! zcompile -U "$first" } {
@@ -848,8 +848,8 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         # Try to catch possible additional file
         zcompile -U "${${first%.plugin.zsh}%.zsh-theme}.zsh" 2>/dev/null
       }
-    }
-  }
+    fi
+  fi
 
   if [[ -n "${ICE[compile]}" ]]; then
     local -a pats
@@ -914,24 +914,24 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   } else {
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
     if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]] {
-      if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]] {
+      if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]]; then
         if [[ $save_url == OMZT::* ]] {
           url+=.zsh-theme
         } else {
           url+=/${${url#*::}:t}.plugin.zsh
         }
-      }
-    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]] {
-      if [[ $url != *.zsh && $url != */_[^/]## ]] {
+      fi
+    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
+      if [[ $url != *.zsh && $url != */_[^/]## ]]; then
         url+=/init.zsh
-      }
-    }
+      fi
+    fi
   }
 
   # Change the url to point to raw github content if it isn't like that
-  if [[ "$url" = *github.com* && ! "$url" = */raw/* && "${+ICE[svn]}" = "0" ]] {
+  if [[ "$url" = *github.com* && ! "$url" = */raw/* && "${+ICE[svn]}" = "0" ]]; then
     url="${${url/\/blob\///raw/}/\/tree\///raw/}"
-  }
+  fi
 
   command rm -f ${TMPDIR:-/tmp}/zi-execs.$$.lst ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst ${TMPDIR:-/tmp}/zi.compiled.$$.lst
 
@@ -1121,7 +1121,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       ZI[annex-multi-flag:pull-active]=3 retval=3
       # Run annexes' atpull hooks (the before atpull-ice ones).
       # The local-file snippets block.
-      if [[ $update = -u ]] {
+      if [[ $update = -u ]]; then
         reply=(
           ${(on)ZI_EXTS2[(I)zi hook:e-\\\!atpull-pre <->]}
           ${${(M)ICE[atpull]#\!}:+${(on)ZI_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
@@ -1136,22 +1136,22 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
           fi
         done
-      }
+      fi
 
       command mkdir -p "$local_dir/$dirname"
-      if [[ ! -e $url ]] {
+      if [[ ! -e $url ]]; then
         (( !OPTS[opt_-q,--quiet] )) && +zi-message "{error}Error{ehi}:{rst} {msg}The source file {file}$url{msg} doesn't exist.{rst}"
         retval=4
-      }
-      if [[ -e $url && ! -f $url && $url != /dev/null ]] {
+      fi
+      if [[ -e $url && ! -f $url && $url != /dev/null ]]; then
         (( !OPTS[opt_-q,--quiet] )) && +zi-message "{error}Error{ehi}:{rst} {msg}The source {file}$url{msg} isn't a regular file.{rst}"
         retval=4
-      }
-      if [[ -e $url && ! -r $url && $url != /dev/null ]] {
+      fi
+      if [[ -e $url && ! -r $url && $url != /dev/null ]]; then
         (( !OPTS[opt_-q,--quiet] )) && +zi-message "{error}Error{ehi}:{rst} {msg}The source {file}$url{msg} isn't" \
           "accessible{nl}{mmdsh}{error} wrong permissions{rst}"
         retval=4
-      }
+      fi
       if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
         +zi-message "{msg}Copying {file}$filename{msg}{…}{rst}"
         command cp -vf "$url" "$local_dir/$dirname/$filename" || \
@@ -1236,7 +1236,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
     # Run annexes' atpull hooks (the after atpull-ice ones)
     # The block is common to all 3 snippet types.
-    if [[ $update = -u ]] {
+    if [[ $update = -u ]]; then
       if (( ZI[annex-multi-flag:pull-active] > 0 )) {
         reply=(
           ${(on)ZI_EXTS2[(I)zi hook:atpull-pre <->]}
@@ -1269,7 +1269,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
           builtin print -Pr -- "${ZI[col-warn]}Warning:%f%b ${ZI[col-obj]}${arr[5]}${ZI[col-warn]} hook returned with ${ZI[col-obj]}${hook_rc}${ZI[col-rst]}"
         fi
       done
-    }
+    fi
   ) || return $?
   typeset -ga INSTALLED_EXECS
   { INSTALLED_EXECS=( "${(@f)$(<${TMPDIR:-/tmp}/zi-execs.$$.lst)}" ) } 2>/dev/null
@@ -1279,15 +1279,15 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   if [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]]; then
     .zi-install-completions "%" "$local_dir/$dirname" 0
   fi
-  if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]] {
+  if [[ -e ${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zi.installed_comps.$$.lst ]]; then
     typeset -ga INSTALLED_COMPS SKIPPED_COMPS
     { INSTALLED_COMPS=( "${(@f)$(<${TMPDIR:-/tmp}/zi.installed_comps.$$.lst)}" ) } 2>/dev/null
     { SKIPPED_COMPS=( "${(@f)$(<${TMPDIR:-/tmp}/zi.skipped_comps.$$.lst)}" ) } 2>/dev/null
-  }
-  if [[ -e ${TMPDIR:-/tmp}/zi.compiled.$$.lst ]] {
+  fi
+  if [[ -e ${TMPDIR:-/tmp}/zi.compiled.$$.lst ]]; then
     typeset -ga ADD_COMPILED
     { ADD_COMPILED=( "${(@f)$(<${TMPDIR:-/tmp}/zi.compiled.$$.lst)}" ) } 2>/dev/null
-  }
+  fi
 
   # After any download – rehash the command table
   # This will however miss the as"program" binaries as their PATH gets extended - and it is done later.
@@ -1353,18 +1353,18 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   } else {
     url=${url/(#s)(#m)(${(~kj.|.)ZI_2MAP})/$ZI_2MAP[$MATCH]}
     if [[ $save_url == (${(~kj.|.)${(Mk)ZI_1MAP:#OMZ*}})* ]] {
-      if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]] {
+      if [[ $url != *.zsh(|-theme) && $url != */_[^/]## ]]; then
         if [[ $save_url == OMZT::* ]] {
           url+=.zsh-theme
         } else {
           url+=/${${url#*::}:t}.plugin.zsh
         }
-      }
-    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]] {
-      if [[ $url != *.zsh ]] {
+      fi
+    } elif [[ $save_url = (${(~kj.|.)${(kM)ZI_1MAP:#PZT*}})* ]]; then
+      if [[ $url != *.zsh ]]; then
         url+=/init.zsh
-      }
-    }
+      fi
+    fi
   }
 
   if { ! .zi-get-object-path snippet "$id_as" } {
@@ -1453,44 +1453,44 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   for bpick ( "${bpicks[@]}" ) {
     list=( $init_list )
 
-    if [[ -n $bpick ]] {
+    if [[ -n $bpick ]]; then
       list=( ${(M)list[@]:#(#i)*/$~bpick} )
-    }
+    fi
 
-    if (( $#list > 1 )) {
+    if (( $#list > 1 )); then
       list2=( ${(M)list[@]:#(#i)*${~matchstr[$MACHTYPE]:-${MACHTYPE#(#i)(i|amd)}}*} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( ${#list} > 1 && ${#matchstr[${MACHTYPE}-2]} )) {
+    if (( ${#list} > 1 && ${#matchstr[${MACHTYPE}-2]} )); then
       list2=( ${(M)list[@]:#(#i)*${~matchstr[${MACHTYPE}-2]:-${MACHTYPE#(#i)(i|amd)}}*} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( $#list > 1 )) {
+    if (( $#list > 1 )); then
       list2=( ${(M)list[@]:#(#i)*${~matchstr[$CPUTYPE]:-${CPUTYPE#(#i)(i|amd)}}*} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( $#list > 1 )) {
+    if (( $#list > 1 )); then
       list2=( ${(M)list[@]:#(#i)*${~matchstr[${${OSTYPE%(#i)-(gnu|musl)}%%(-|)[0-9.]##}]:-${${OSTYPE%(#i)-(gnu|musl)}%%(-|)[0-9.]##}}*} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( $#list > 1 )) {
+    if (( $#list > 1 )); then
       list2=( ${list[@]:#(#i)*.(sha[[:digit:]]#|asc)} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( $#list > 1 && $+commands[dpkg-deb] )) {
+    if (( $#list > 1 && $+commands[dpkg-deb] )); then
       list2=( ${list[@]:#*.deb} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
-    if (( $#list > 1 && $+commands[rpm] )) {
+    if (( $#list > 1 && $+commands[rpm] )); then
       list2=( ${list[@]:#*.rpm} )
       (( $#list2 > 0 )) && list=( ${list2[@]} )
-    }
+    fi
 
     if (( !$#list )) {
       +zi-message -n "{error}Didn't find correct Github" "release-file to download"
@@ -1557,7 +1557,7 @@ ziextract() {
           continue
         fi
         type=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
-        if [[ $type = (zip|rar|xz|7-zip|gzip|bzip2|tar|exe|pe32) ]] {
+        if [[ $type = (zip|rar|xz|7-zip|gzip|bzip2|tar|exe|pe32) ]]; then
           (( !OPTS[opt_-q,--quiet] )) && \
           +zi-message "{annex}ziextract{ehi}:{rst} {note}Detected a {obj2}$type{note} archive in the file{ehi}:{rst} {file}$fname{rst}"
           ziextract "$fname" "$type" $opt_move $opt_move2 $opt_norm --norm ${${${#archives}:#1}:+--nobkp}
@@ -1572,7 +1572,7 @@ ziextract() {
             fname=$fname.out
           fi
           files=( *.tar(ND) )
-          if [[ -f $fname || -f ${fname:r} ]] {
+          if [[ -f $fname || -f ${fname:r} ]]; then
             local -aU output2 archives2
             output2=( ${(@f)"$(command file -- "$fname"(N) "${fname:r}"(N) $files[1](N) 2>&1)"} )
             archives2=( ${(M)output2[@]:#(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) *} )
@@ -1580,7 +1580,7 @@ ziextract() {
             for file2 ( $archives2 ) {
               fname=${file2%:*} desc=${file2##*:}
               local type2=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
-              if [[ $type != $type2 && $type2 = (zip|rar|xz|7-zip|gzip|bzip2|tar) ]] {
+              if [[ $type != $type2 && $type2 = (zip|rar|xz|7-zip|gzip|bzip2|tar) ]]; then
                 # TODO: #115 If multiple archives are really in the archive, this might delete too soon… However, it's unusual case.
                 if [[ $fname != $infname && $norm -eq 0 ]]; then
                   command rm -f "$infname"
@@ -1590,29 +1590,29 @@ ziextract() {
                 ziextract "$fname" "$type2" $opt_move $opt_move2 $opt_norm ${${${#archives}:#1}:+--nobkp}
                 ret_val+=$?
                 stage2_processed+=( $fname )
-                if [[ $fname == *.out ]] {
+                if [[ $fname == *.out ]]; then
                   if [[ -f $fname ]]; then
                     command mv -f "$fname" "${fname%.out}"
                   fi
                   stage2_processed+=( ${fname%.out} )
-                }
-              }
+                fi
+              fi
             }
-          }
-        }
+          fi
+        fi
       }
     }
     return $ret_val
   }
 
-  if [[ -z $file ]] {
+  if [[ -z $file ]]; then
     +zi-message "{annex}ziextract{ehi}:{rst} {error}Argument required for {file}file{error} to extract or the {opt}--auto{error} option{rst}"
     return 1
-  }
-  if [[ ! -e $file ]] {
+  fi
+  if [[ ! -e $file ]]; then
     +zi-message "{annex}ziextract{ehi}:{rst} {error}The {file}file{error} \`{pname}${file}{error}' does not exist{rst}"
     return 1
-  }
+  fi
   if (( !nobkp )) {
     command mkdir -p ._backup
     command rm -rf ._backup/*(DN)
@@ -1656,11 +1656,11 @@ ziextract() {
       →zi-extract() { →zi-check tar "$file" || return 1; command tar -xf "$file"; }
       ;;
     ((#i)*.gz|(#i)*.gzip)
-      if [[ $file != (#i)*.gz ]] {
+      if [[ $file != (#i)*.gz ]]; then
         command mv $file $file.gz
         file=$file.gz
         integer zi_was_renamed=1
-      }
+      fi
       →zi-extract() {
         →zi-check gunzip "$file" || return 1
         .zi-get-mtime-into "$file" 'ZI[tmp]'
@@ -1672,10 +1672,10 @@ ziextract() {
       ;;
     ((#i)*.bz2|(#i)*.bzip2)
       # Rename file if its extension does not match "bz2". bunzip2 refuses to operate on files that are not named correctly.
-      if [[ $file != (#i)*.bz2 ]] {
+      if [[ $file != (#i)*.bz2 ]]; then
         command mv $file $file.bz2
         file=$file.bz2
-      }
+      fi
       →zi-extract() { →zi-check bunzip2 "$file" || return 1
         .zi-get-mtime-into "$file" 'ZI[tmp]'
         command bunzip2 "$file" |& command egrep -v '.out$'
@@ -1685,10 +1685,10 @@ ziextract() {
       }
       ;;
     ((#i)*.xz)
-      if [[ $file != (#i)*.xz ]] {
+      if [[ $file != (#i)*.xz ]]; then
         command mv $file $file.xz
         file=$file.xz
-      }
+      fi
       →zi-extract() { →zi-check xz "$file" || return 1
         .zi-get-mtime-into "$file" 'ZI[tmp]'
         command xz -d "$file"
@@ -1751,11 +1751,11 @@ ziextract() {
 
   local -a execs
   execs=( **/*~(._zi(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )
-  if [[ ${#execs} -gt 0 && -n $execs ]] {
+  if [[ ${#execs} -gt 0 && -n $execs ]]; then
     execs=( ${(@f)"$( file ${execs[@]} )"} )
     execs=( "${(M)execs[@]:#[^:]##:*executable*}" )
     execs=( "${execs[@]/(#b)([^:]##):*/${match[1]}}" )
-  }
+  fi
 
   builtin print -rl -- ${execs[@]} >! ${TMPDIR:-/tmp}/zi-execs.$$.lst
   if [[ ${#execs} -gt 0 ]] {
@@ -1870,10 +1870,10 @@ zpextract() { ziextract "$@"; }
     fi
   }
 
-  if [[ -z $mirror ]] {
+  if [[ -z $mirror ]]; then
     +zi-message "{error}Couldn't download{ehi}:{rst} {obj}mirrors.lst {error}."
     return 1
-  }
+  fi
 
   mirror=http://ftp.eq.uc.pt/software/pc/prog/cygwin/
 
@@ -1899,10 +1899,10 @@ zpextract() { ziextract "$@"; }
   }
   local setup_contents="$(command grep -A 26 "@ $pkg\$" "$setup")"
   local urlpart=${${(S)setup_contents/(#b)*@ $pkg${nl}*install: (*)$nl*/$match[1]}%% *}
-  if [[ -z $urlpart ]] {
+  if [[ -z $urlpart ]]; then
     +zi-message "{error}Couldn't find package{ehi}:{rst} {data2}\`{data}$pkg{data2}'{error}.{rst}"
     return 2
-  }
+  fi
   local url=$mirror/$urlpart outfile=${TMPDIR:-${TMPDIR:-/tmp}}/${urlpart:t}
 
   #
@@ -1937,22 +1937,30 @@ zicp() {
 
   local -a mbegin mend match
   local cmd=cp
-  if [[ $1 = (-m|--mv) ]] { cmd=mv; shift; }
+  if [[ $1 = (-m|--mv) ]]; then
+    cmd=mv; shift;
+  fi
 
   local dir
-  if [[ $1 = (-d|--dir)  ]] { dir=$2; shift 2; }
+  if [[ $1 = (-d|--dir)  ]]; then
+    dir=$2; shift 2;
+  fi
 
   local arg
   arg=${${(j: :)@}//(#b)(([[:space:]]~ )#(([^[:space:]]| )##)([[:space:]]~ )#(#B)(->|=>|→)(#B)([[:space:]]~ )#(#b)(([^[:space:]]| )##)|(#B)([[:space:]]~ )#(#b)(([^[:space:]]| )##))/${match[3]:+$match[3] $match[6]\;}${match[8]:+$match[8] $match[8]\;}}
   (
-    if [[ -n $dir ]] { cd $dir || return 1; }
+    if [[ -n $dir ]]; then
+      cd $dir || return 1;
+    fi
     local a b var
     integer retval
     for a b ( "${(s: :)${${(@s.;.)${arg%\;}}:-* .}}" ) {
       for var ( a b ) {
         : ${(P)var::=${(P)var//(#b)(((#s)|([^\\])[\\]([\\][\\])#)|((#s)|([^\\])([\\][\\])#)) /${match[2]:+$match[3]$match[4] }${match[5]:+$match[6]${(l:${#match[7]}/2::\\:):-} }}}
       }
-      if [[ $a != *\** ]] { a=${a%%/##}"/*" }
+      if [[ $a != *\** ]]; then
+        a=${a%%/##}"/*"
+      fi
       command mkdir -p ${~${(M)b:#/*}:-$ZPFX/$b}
       command $cmd -f ${${(M)cmd:#cp}:+-R} $~a ${~${(M)b:#/*}:-$ZPFX/$b}
       retval+=$?
@@ -1965,7 +1973,9 @@ zicp() {
 # FUNCTION zimv [[[
 zimv() {
   local dir
-  if [[ $1 = (-d|--dir) ]] { dir=$2; shift 2; }
+  if [[ $1 = (-d|--dir) ]]; then
+    dir=$2; shift 2;
+  fi
   zicp --mv ${dir:+--dir} $dir "$@"
 }
 # ]]]
@@ -1985,10 +1995,10 @@ zimv() {
     }
     if [[ $type == snippet ]] {
       if (( $+ICE[svn] )) {
-        if [[ $skip_pull -eq 0 && -d $filename/.svn ]] {
+        if [[ $skip_pull -eq 0 && -d $filename/.svn ]]; then
           (( !OPTS[opt_-q,--quiet] )) && +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}Resetting the repository ($msg_bit) with command{ehi}:{rst} {rst}svn revert --recursive {…}/{file}$filename/.{rst} {…}"
           command svn revert --recursive $filename/.
-        }
+        fi
       } else {
         if (( ZI[annex-multi-flag:pull-active] >= 2 )) {
           if (( !OPTS[opt_-q,--quiet] )) {
@@ -2005,9 +2015,9 @@ zimv() {
               }
             } else {
               +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}The file {file}$filename{msg} is already deleted {…}{rst}"
-              if [[ -n $ICE[reset] && ! -n $option ]] {
+              if [[ -n $ICE[reset] && ! -n $option ]]; then
                 +zi-message "{pre}reset ($msg_bit){ehi}:{rst} {msg}(skipped running the provided reset-code{ehi}:{rst} {data2}$ICE[reset]{msg}){rst}"
-              }
+              fi
             }
           }
         } else {
@@ -2191,11 +2201,11 @@ zimv() {
   if [[ "$1" = plugin ]]; then
     local dir="${5#%}" hook="$6" subtype="$7" || local dir="${4#%}" hook="$5" subtype="$6"
   fi
-    if ! [[ ( $hook = *\!at(clone|pull)* && ${+ICE[nocompile]} -eq 0 ) || ( $hook = at(clone|pull)* && $ICE[nocompile] = '!' ) ]] {
+    if ! [[ ( $hook = *\!at(clone|pull)* && ${+ICE[nocompile]} -eq 0 ) || ( $hook = at(clone|pull)* && $ICE[nocompile] = '!' ) ]]; then
       return 0
-    }
+    fi
     # Compile plugin
-    if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
+    if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]]; then
       () {
         builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
         builtin setopt extendedglob warncreateglobal
@@ -2205,7 +2215,7 @@ zimv() {
           .zi-compile-plugin "$id_as" ""
         }
       }
-    }
+    fi
 } # ]]]
 # FUNCTION: ∞zi-atpull-e-hook [[[
 ∞zi-atpull-e-hook() {

--- a/zi.zsh
+++ b/zi.zsh
@@ -1363,7 +1363,9 @@ function .zi-load-snippet() {
         else
           ((1))
           builtin source "$ZERO"
+        fi
         (( retval += $? ))
+      fi
     fi
     if [[ -n ${ICE[multisrc]} ]]; then
       local ___oldcd="$PWD"
@@ -1442,7 +1444,6 @@ function .zi-load-snippet() {
         fi
       fi
     fi
-  fi
   elif [[ -n ${opts[(r)--command]} || ${ICE[as]} = command ]]; then
     if [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]]; then
       ICE[pick]="${id_as:t}"
@@ -1543,10 +1544,11 @@ function .zi-load-snippet() {
           else
             ((1))
             builtin source "$ZERO"
-          (( retval += $? ))
           fi
+          (( retval += $? ))
         fi
       done
+    fi
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\\\!atload-<-> <->]} )
     for key in "${reply[@]}"; do
@@ -1577,7 +1579,7 @@ function .zi-load-snippet() {
       fi
     fi
     if [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]]; then
-      (( -- ZI[TMP_SUBST] == 0 )) && {
+      if (( -- ZI[TMP_SUBST] == 0 )); then
         ZI[TMP_SUBST]=inactive
         builtin setopt noaliases
         if (( ${+ZI[bkp-compdef]} )); then
@@ -1588,7 +1590,7 @@ function .zi-load-snippet() {
         if (( ZI[ALIASES_OPT] )); then
           builtin setopt aliases
         fi
-      }
+      fi
     fi
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
@@ -1625,6 +1627,7 @@ function .zi-load-snippet() {
     else
      +zi-deploy-message @msg "notify: Plugin not loaded / loaded with problem, the return code: $retval"
     fi
+  fi
   if (( ${+ICE[reset-prompt]} == 1 )); then
     +zi-deploy-message @rst
   fi
@@ -1633,7 +1636,8 @@ function .zi-load-snippet() {
   ZI[TIME_${ZI[TIME_INDEX]}_${id_as}]=$SECONDS
   ZI[AT_TIME_${ZI[TIME_INDEX]}_${id_as}]=$EPOCHREALTIME
   .zi-set-m-func unset
-  return retval
+  return retval;
+
 } # ]]]
 # FUNCTION: .zi-load. [[[
 # Implements the exposed-to-user action of loading a plugin.

--- a/zi.zsh
+++ b/zi.zsh
@@ -901,7 +901,7 @@ builtin setopt noaliases
 # FUNCTION: .zi-register-plugin. [[[
 # Adds the plugin to ZI_REGISTERED_PLUGINS array and to the
 # zsh_loaded_plugins array (managed according to the plugin standard:
-# https://z.digitalclouds.dev/community/zsh_plugin_standard).
+# https://wiki.zshell.dev/community/zsh_plugin_standard).
 .zi-register-plugin() {
   local uspl2="$1" mode="$2" teleid="$3"
   integer ret=0
@@ -1019,7 +1019,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: @zsh-plugin-run-on-update. [[[
 # The Plugin Standard required mechanism, see:
-# https://z.digitalclouds.dev/community/zsh_plugin_standard
+# https://wiki.zshell.dev/community/zsh_plugin_standard
 @zsh-plugin-run-on-unload() {
   ICE[ps-on-unload]="${(j.; .)@}"
   .zi-pack-ice "$id_as" ""

--- a/zi.zsh
+++ b/zi.zsh
@@ -5,7 +5,9 @@
 
 typeset -gaH ZI_REGISTERED_PLUGINS ZI_TASKS ZI_RUN
 typeset -ga zsh_loaded_plugins
-if (( !${#ZI_TASKS} )) { ZI_TASKS=( "<no-data>" ); }
+if (( !${#ZI_TASKS} )); then
+  ZI_TASKS=( "<no-data>" )
+fi
 # Rename snippets URL -> NAME.
 typeset -gAH ZI ZI_SNIPPETS ZI_REPORTS ZI_ICES ZI_SICE ZI_CUR_BIND_MAP ZI_EXTS ZI_EXTS2
 typeset -gaH ZI_COMPDEF_REPLAY
@@ -34,13 +36,19 @@ cclear|cdisable|cenable|creinstall|cuninstall|csearch|compinit|dtrace|dstart|dst
 uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|module|add-fpath|run"
 
 # BIN_DIR setup.
-[[ ! -e ${ZI[BIN_DIR]}/zi.zsh ]] && ZI[BIN_DIR]=
+if [[ ! -e ${ZI[BIN_DIR]}/zi.zsh ]]; then
+  ZI[BIN_DIR]=
+fi
 ZI[ZERO]="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 
-[[ ! -o functionargzero || ${options[posixargzero]} = on || ${ZI[ZERO]} != */* ]] && ZI[ZERO]="${(%):-%N}"
+if [[ ! -o functionargzero || ${options[posixargzero]} = on || ${ZI[ZERO]} != */* ]]; then
+  ZI[ZERO]="${(%):-%N}"
+fi
 : ${ZI[BIN_DIR]:="${ZI[ZERO]:h}"}
 
-[[ ${ZI[BIN_DIR]} = \~* ]] && ZI[BIN_DIR]=${~ZI[BIN_DIR]}
+if [[ ${ZI[BIN_DIR]} = \~* ]]; then
+  ZI[BIN_DIR]=${~ZI[BIN_DIR]}
+fi
 ZI[BIN_DIR]="${${(M)ZI[BIN_DIR]:#/*}:-$PWD/${ZI[BIN_DIR]}}"
 
 # Check if ZI[BIN_DIR] is established correctly.
@@ -87,13 +95,31 @@ export ZPFX=${~ZPFX} PMSPEC=0fuUpiPsX \
 ZCDR="${ZCDR:-${XDG_CONFIG_HOME:-$HOME/.config}/zi}" \
 ZSH_CACHE_DIR="${ZSH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/zi}"
 
-[[ -z ${path[(re)${ZPFX}/bin]} ]] && [[ -d "${ZPFX}/bin" ]] && path=( "${ZPFX}/bin" "${path[@]}" )
-[[ -z ${path[(re)${ZPFX}/sbin]} ]] && [[ -d "${ZPFX}/sbin" ]] && path=( "${ZPFX}/sbin" "${path[@]}" )
-[[ -z ${fpath[(re)${ZI[COMPLETIONS_DIR]}]} ]] && fpath=( "${ZI[COMPLETIONS_DIR]}" "${fpath[@]}" )
-[[ -n ${ZI[ZCOMPDUMP_PATH]} ]] && ZI[ZCOMPDUMP_PATH]=${~ZI[ZCOMPDUMP_PATH]}
-[[ ! -d ${~ZI[MAN_DIR]} ]] && command mkdir -p ${~ZI[MAN_DIR]}/man{1..9}
-[[ ! -d $ZSH_CACHE_DIR ]] && command mkdir -p "$ZSH_CACHE_DIR"
-[[ ! -d $ZCDR ]] && command mkdir -p "$ZCDR"
+if [[ -z ${path[(re)${ZPFX}/bin]} ]]; then
+  if [[ -d "${ZPFX}/bin" ]]; then
+    path=( "${ZPFX}/bin" "${path[@]}" )
+  fi
+fi
+if [[ -z ${path[(re)${ZPFX}/sbin]} ]]; then
+  if [[ -d "${ZPFX}/sbin" ]]; then
+    path=( "${ZPFX}/sbin" "${path[@]}" )
+  fi
+fi
+if [[ -z ${fpath[(re)${ZI[COMPLETIONS_DIR]}]} ]]; then
+  fpath=( "${ZI[COMPLETIONS_DIR]}" "${fpath[@]}" )
+fi
+if [[ -n ${ZI[ZCOMPDUMP_PATH]} ]]; then
+  ZI[ZCOMPDUMP_PATH]=${~ZI[ZCOMPDUMP_PATH]}
+fi
+if [[ ! -d ${~ZI[MAN_DIR]} ]]; then
+  command mkdir -p ${~ZI[MAN_DIR]}/man{1..9}
+fi
+if [[ ! -d $ZSH_CACHE_DIR ]]; then
+  command mkdir -p "$ZSH_CACHE_DIR"
+fi
+if [[ ! -d $ZCDR ]]; then
+  command mkdir -p "$ZCDR"
+fi
 
 ZI[UPAR]=";:^[[A;:^[OA;:\\e[A;:\\eOA;:${termcap[ku]/$'\e'/^\[};:${terminfo[kcuu1]/$'\e'/^\[};:"
 ZI[DOWNAR]=";:^[[B;:^[OB;:\\e[B;:\\eOB;:${termcap[kd]/$'\e'/^\[};:${terminfo[kcud1]/$'\e'/^\[};:"
@@ -211,7 +237,9 @@ function :zi-reload-and-run () {
   local -a ___fpath
   ___fpath=( ${fpath[@]} )
   local -a +h fpath
-  [[ $FPATH != *${${(@0)fpath_prefix}[1]}* ]] && fpath=( ${(@0)fpath_prefix} ${___fpath[@]} )
+  if [[ $FPATH != *${${(@0)fpath_prefix}[1]}* ]]; then
+    fpath=( ${(@0)fpath_prefix} ${___fpath[@]} )
+  fi
   # After this the function exists again.
   builtin autoload ${(s: :)autoload_opts} -- "$func"
   # User wanted to call the function, not only load it.
@@ -235,14 +263,19 @@ function :zi-tmp-subst-autoload () {
 
   # Process the id-as''/teleid'' to get the plugin dir.
   .zi-any-to-user-plugin $ZI[CUR_USPL2]
-  [[ $reply[1] = % ]] && local PLUGIN_DIR="$reply[2]" || \
-  local PLUGIN_DIR="$ZI[PLUGINS_DIR]/${reply[1]:+$reply[1]---}${reply[2]//\//---}"
+  if [[ $reply[1] = % ]]; then
+    local PLUGIN_DIR="$reply[2]"
+  else
+    local PLUGIN_DIR="$ZI[PLUGINS_DIR]/${reply[1]:+$reply[1]---}${reply[2]//\//---}"
+  fi
   # "Fpath elements" - ie those elements that are inside the plug-in directory.
   # The name comes from the fact that they are the selected fpath elements → so just "items".
   local -a fpath_elements
   fpath_elements=( ${fpath[(r)$PLUGIN_DIR/*]} )
   # Add a function subdirectory to items, if any (this action is according to the Plug Standard version 1.07 and later).
-  [[ -d $PLUGIN_DIR/functions ]] && fpath_elements+=( "$PLUGIN_DIR"/functions )
+  if [[ -d $PLUGIN_DIR/functions ]]; then
+    fpath_elements+=( "$PLUGIN_DIR"/functions )
+  fi
   if (( ${+opts[(r)-X]} )); then
     .zi-add-report "${ZI[CUR_USPL2]}" "Warning: Failed autoload ${(j: :)opts[@]} $*"
     +zi-message -u2 "{error}builtin autoload required for {obj}${(j: :)opts[@]}{error} option(s)"
@@ -272,9 +305,11 @@ function :zi-tmp-subst-autoload () {
     # Author of the idea of FPATH-clean autoloading: Bart Schaefer.
     if (( ${+functions[$func]} != 1 )) {
       builtin setopt noaliases
-      if [[ $func == /* ]] && is-at-least 5.4; then
-        builtin autoload ${opts[@]} $func
-        return $?
+      if [[ $func == /* ]]; then
+        if is-at-least 5.4; then
+          builtin autoload ${opts[@]} $func
+          return $?
+        fi
       elif [[ $func == /* ]]; then
         if [[ $ZI[MUTE_WARNINGS] != (1|true|on|yes) && -z $ZI[WARN_SHOWN_FOR_$ZI[CUR_USPL2]] ]]; then
           +zi-message "{u-warn}Warning{b-warn}: {rst}the plugin {pid}$ZI[CUR_USPL2]" \
@@ -295,7 +330,10 @@ function :zi-tmp-subst-autoload () {
         if (( ${+opts[(r)-C]} )); then
           local pth nl=$'\n' sel=""
           for pth ( $PLUGIN_DIR $fpath_elements $fpath ); do
-            [[ -f $pth/$func ]] && { sel=$pth; break; }
+            if [[ -f $pth/$func ]]; then
+              sel=$pth
+              break
+            fi
           done
           if [[ -z $sel ]]; then
             +zi-message '{u-warn}zi{b-warn}:{error} Couldn''t find autoload function{ehi}:' \
@@ -306,7 +344,9 @@ function :zi-tmp-subst-autoload () {
               local body=\"\$(<${(qqq)sel}/${(qqq)func})\" body2
               () { builtin setopt localoptions extendedglob
                 body2=\"\${body##[[:space:]]#${func}[[:blank:]]#\(\)[[:space:]]#\{}\"
-                [[ \$body2 != \$body ]] && body2=\"\${body2%\}[[:space:]]#([$nl]#([[:blank:]]#\#[^$nl]#((#e)|[$nl]))#)#}\"
+                if [[ \$body2 != \$body ]]; then
+                  body2=\"\${body2%\}[[:space:]]#([$nl]#([[:blank:]]#\#[^$nl]#((#e)|[$nl]))#)#}\"
+                fi
               }
               functions[${${(q)custom[count*2]}:-$func}]=\"\$body2\"
               ${(q)${custom[count*2]}:-$func} \"\$@\"
@@ -377,17 +417,34 @@ function :zi-tmp-subst-bindkey() {
 
     local bmap_val="${ZI_CUR_BIND_MAP[${1}]}"
     if (( !ZI_CUR_BIND_MAP[empty] )); then
-      [[ -z $bmap_val ]] && bmap_val="${ZI_CUR_BIND_MAP[${(qqq)1}]}"
-      [[ -z $bmap_val ]] && bmap_val="${ZI_CUR_BIND_MAP[${(qqq)${(Q)1}}]}"
-      [[ -z $bmap_val ]] && { bmap_val="${ZI_CUR_BIND_MAP[!${(qqq)1}]}"; integer val=1; }
-      [[ -z $bmap_val ]] && bmap_val="${ZI_CUR_BIND_MAP[!${(qqq)${(Q)1}}]}"
+      if [[ -z $bmap_val ]]; then
+        bmap_val="${ZI_CUR_BIND_MAP[${(qqq)1}]}"
+      fi
+      if [[ -z $bmap_val ]]; then
+        bmap_val="${ZI_CUR_BIND_MAP[${(qqq)${(Q)1}}]}"
+      fi
+      if [[ -z $bmap_val ]]; then
+        bmap_val="${ZI_CUR_BIND_MAP[!${(qqq)1}]}"
+        integer val=1
+      fi
+      if [[ -z $bmap_val ]]; then
+        bmap_val="${ZI_CUR_BIND_MAP[!${(qqq)${(Q)1}}]}"
+      fi
     fi
     if [[ -n $bmap_val ]]; then
       string="${(q)bmap_val}"
       if (( val )); then
-        [[ ${pos[1]} = "-M" ]] && pos[4]="$bmap_val" || pos[2]="$bmap_val"
+        if [[ ${pos[1]} = "-M" ]]; then
+          pos[4]="$bmap_val"
+        else
+          pos[2]="$bmap_val"
+        fi
       else
-        [[ ${pos[1]} = "-M" ]] && pos[3]="${(Q)bmap_val}" || pos[1]="${(Q)bmap_val}"
+        if [[ ${pos[1]} = "-M" ]]; then
+          pos[3]="${(Q)bmap_val}"
+        else
+          pos[1]="${(Q)bmap_val}"
+        fi
       fi
       .zi-add-report "${ZI[CUR_USPL2]}" ":::Bindkey: combination <$1> changed to <$bmap_val>${${(M)bmap_val:#hold}:+, i.e. ${ZI[col-error]}unmapped${ZI[col-rst]}}"
       ((1))
@@ -398,9 +455,17 @@ function :zi-tmp-subst-bindkey() {
     ]]; then
       string="${(q)bmap_val}"
       if (( val )); then
-        [[ ${pos[1]} = "-M" ]] && pos[4]="$bmap_val" || pos[2]="$bmap_val"
+        if [[ ${pos[1]} = "-M" ]]; then
+          pos[4]="$bmap_val"
+        else
+          pos[2]="$bmap_val"
+        fi
       else
-        [[ ${pos[1]} = "-M" ]] && pos[3]="${(Q)bmap_val}" || pos[1]="${(Q)bmap_val}"
+        if [[ ${pos[1]} = "-M" ]]; then
+          pos[3]="${(Q)bmap_val}"
+        else
+          pos[1]="${(Q)bmap_val}"
+        fi
       fi
       .zi-add-report "${ZI[CUR_USPL2]}" ":::Bindkey: combination <$1> recognized as cursor-key and changed to <${bmap_val}>${${(M)bmap_val:#hold}:+, i.e. ${ZI[col-error]}unmapped${ZI[col-rst]}}"
     fi
@@ -435,9 +500,13 @@ function :zi-tmp-subst-bindkey() {
     fi
     quoted="${(q)quoted}"
     # Remember the bindkey, only when load is in progress (it can be dstart that leads execution here).
-    [[ -n ${ZI[CUR_USPL2]} ]] && ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
+    if [[ -n ${ZI[CUR_USPL2]} ]]; then
+      ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
+    fi
     # Remember for dtrace.
-    [[ ${ZI[DTRACE]} = 1 ]] && ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+    if [[ ${ZI[DTRACE]} = 1 ]]; then
+      ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+    fi
   else
     # bindkey -A newkeymap main?
     # Negative indices for KSH_ARRAYS immunity.
@@ -452,8 +521,12 @@ function :zi-tmp-subst-bindkey() {
       local quoted="${(q)keys} ${(q)widget} ${(q)prev} ${(q)optA} ${(q)mapname} ${(q)optR}"
       quoted="${(q)quoted}"
       # Remember the bindkey, only when load is in progress (it can be dstart that leads execution here).
-      [[ -n ${ZI[CUR_USPL2]} ]] && ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
-      [[ ${ZI[DTRACE]} = 1 ]] && ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+      if [[ -n ${ZI[CUR_USPL2]} ]]; then
+        ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
+      fi
+      if [[ ${ZI[DTRACE]} = 1 ]]; then
+        ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+      fi
       .zi-add-report "${ZI[CUR_USPL2]}" "Warning: keymap \`main' copied to \`${name}' because of \`${pos[-2]}' substitution"
     # bindkey -N newkeymap [other].
     elif [[ ${#opts} -eq 1 && ${+opts[-N]} = 1 ]]; then
@@ -463,8 +536,12 @@ function :zi-tmp-subst-bindkey() {
       local quoted="${(q)keys} ${(q)widget} ${(q)prev} ${(q)optN} ${(q)mapname} ${(q)optR}"
       quoted="${(q)quoted}"
       # Remember the bindkey, only when load is in progress (it can be dstart that leads execution here).
-      [[ -n ${ZI[CUR_USPL2]} ]] && ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
-      [[ ${ZI[DTRACE]} = 1 ]] && ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+      if [[ -n ${ZI[CUR_USPL2]} ]]; then
+        ZI[BINDKEYS__${ZI[CUR_USPL2]}]+="$quoted "
+      fi
+      if [[ ${ZI[DTRACE]} = 1 ]]; then
+        ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
+      fi
     else
       .zi-add-report "${ZI[CUR_USPL2]}" "Warning: last bindkey used non-typical options: ${(kv)opts[*]}"
     fi
@@ -492,9 +569,13 @@ function :zi-tmp-subst-zstyle() {
     local ps="$pattern $style"
     ps="${(q)ps}"
     # Remember the zstyle, only when load is in progress (it can be dstart that leads execution here).
-    [[ -n ${ZI[CUR_USPL2]} ]] && ZI[ZSTYLES__${ZI[CUR_USPL2]}]+="$ps "
+    if [[ -n ${ZI[CUR_USPL2]} ]]; then
+      ZI[ZSTYLES__${ZI[CUR_USPL2]}]+="$ps "
+    fi
     # Remember for dtrace.
-    [[ ${ZI[DTRACE]} = 1 ]] && ZI[ZSTYLES___dtrace/_dtrace]+=$ps
+    if [[ ${ZI[DTRACE]} = 1 ]]; then
+      ZI[ZSTYLES___dtrace/_dtrace]+=$ps
+    fi
   else
     if [[ ! ${#opts[@]} = 1 && ( ${+opts[(r)-s]} = 1 || ${+opts[(r)-b]} = 1 || ${+opts[(r)-a]} = 1 || ${+opts[(r)-t]} = 1 || ${+opts[(r)-T]} = 1 || ${+opts[(r)-m]} = 1 ) ]]; then
       .zi-add-report "${ZI[CUR_USPL2]}" "Warning: last zstyle used non-typical options: ${opts[*]}"
@@ -521,7 +602,9 @@ function :zi-tmp-subst-alias() {
     local aname="${a%%[=]*}"
     local avalue="${a#*=}"
     # Check if alias is to be redefined.
-    (( ${+aliases[$aname]} )) && .zi-add-report "${ZI[CUR_USPL2]}" "Warning: redefining alias \`${aname}', previous value: ${aliases[$aname]}"
+    if (( ${+aliases[$aname]} )); then
+      .zi-add-report "${ZI[CUR_USPL2]}" "Warning: redefining alias \`${aname}', previous value: ${aliases[$aname]}"
+    fi
     local bname=${(q)aliases[$aname]}
     aname="${(q)aname}"
     if (( ${+opts[(r)-s]} )); then
@@ -537,9 +620,13 @@ function :zi-tmp-subst-alias() {
     fi
     quoted="${(q)quoted}"
     # Remember the alias, only when load is in progress (it can be dstart that leads execution here).
-    [[ -n ${ZI[CUR_USPL2]} ]] && ZI[ALIASES__${ZI[CUR_USPL2]}]+="$quoted "
+    if [[ -n ${ZI[CUR_USPL2]} ]]; then
+      ZI[ALIASES__${ZI[CUR_USPL2]}]+="$quoted "
+    fi
     # Remember for dtrace.
-    [[ ${ZI[DTRACE]} = 1 ]] && ZI[ALIASES___dtrace/_dtrace]+="$quoted "
+    if [[ ${ZI[DTRACE]} = 1 ]]; then
+      ZI[ALIASES___dtrace/_dtrace]+="$quoted "
+    fi
   done
   # Actual alias.
   builtin alias "${pos[@]}"
@@ -563,9 +650,13 @@ function :zi-tmp-subst-zle() {
       local quoted="$2"
       quoted="${(q)quoted}"
       # Remember only when load is in progress (it can be dstart that leads execution here).
-      [[ -n ${ZI[CUR_USPL2]} ]] && ZI[WIDGETS_DELETE__${ZI[CUR_USPL2]}]+="$quoted "
+      if [[ -n ${ZI[CUR_USPL2]} ]]; then
+        ZI[WIDGETS_DELETE__${ZI[CUR_USPL2]}]+="$quoted "
+      fi
       # Remember for dtrace.
-      [[ ${ZI[DTRACE]} = 1 ]] && ZI[WIDGETS_DELETE___dtrace/_dtrace]+="$quoted "
+      if [[ ${ZI[DTRACE]} = 1 ]]; then
+        ZI[WIDGETS_DELETE___dtrace/_dtrace]+="$quoted "
+      fi
     # These will be saved and restored.
     elif (( ${+widgets[$2]} )); then
       # Have to remember original widget "$2" and the copy that it's going to be done.
@@ -579,18 +670,26 @@ function :zi-tmp-subst-zle() {
       local quoted="$1 $widname $completion_widget $targetfun $saved_widcontents"
       quoted="${(q)quoted}"
       # Remember only when load is in progress (it can be dstart that leads execution here).
-      [[ -n ${ZI[CUR_USPL2]} ]] && ZI[WIDGETS_SAVED__${ZI[CUR_USPL2]}]+="$quoted "
+      if [[ -n ${ZI[CUR_USPL2]} ]]; then
+        ZI[WIDGETS_SAVED__${ZI[CUR_USPL2]}]+="$quoted "
+      fi
       # Remember for dtrace.
-      [[ ${ZI[DTRACE]} = 1 ]] && ZI[WIDGETS_SAVED___dtrace/_dtrace]+="$quoted "
+      if [[ ${ZI[DTRACE]} = 1 ]]; then
+        ZI[WIDGETS_SAVED___dtrace/_dtrace]+="$quoted "
+      fi
     # These will be deleted.
     else
       .zi-add-report "${ZI[CUR_USPL2]}" "Note: a new widget created via zle -N: \`$2'"
       local quoted="$2"
       quoted="${(q)quoted}"
       # Remember only when load is in progress (it can be dstart that leads execution here).
-      [[ -n ${ZI[CUR_USPL2]} ]] && ZI[WIDGETS_DELETE__${ZI[CUR_USPL2]}]+="$quoted "
+      if [[ -n ${ZI[CUR_USPL2]} ]]; then
+        ZI[WIDGETS_DELETE__${ZI[CUR_USPL2]}]+="$quoted "
+      fi
       # Remember for dtrace.
-      [[ ${ZI[DTRACE]} = 1 ]] && ZI[WIDGETS_DELETE___dtrace/_dtrace]+="$quoted "
+      if [[ ${ZI[DTRACE]} = 1 ]]; then
+        ZI[WIDGETS_DELETE___dtrace/_dtrace]+="$quoted "
+      fi
     fi
   fi
 
@@ -694,37 +793,77 @@ function .zi-tmp-subst-off() {
   local mode="$1"
   # Disable temporary substituting of functions only once.
   # Disable temporary substituting of functions only the way it was enabled first.
-  [[ ${ZI[TMP_SUBST]} = inactive || ${ZI[TMP_SUBST]} != $mode ]] && return 0
+  if [[ ${ZI[TMP_SUBST]} = inactive || ${ZI[TMP_SUBST]} != $mode ]]; then
+    return 0
+  fi
   ZI[TMP_SUBST]=inactive
   if [[ $mode != compdef ]]; then
     # 0. Unfunction autoload.
-    (( ${+ZI[bkp-autoload]} )) && functions[autoload]="${ZI[bkp-autoload]}" || unfunction autoload
+    if (( ${+ZI[bkp-autoload]} )); then
+      functions[autoload]="${ZI[bkp-autoload]}"
+    else
+      unfunction autoload
+    fi
   fi
   # E. Restore original compdef if it existed.
-  (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef
+  if (( ${+ZI[bkp-compdef]} )); then
+    functions[compdef]="${ZI[bkp-compdef]}"
+  else
+    unfunction compdef
+  fi
   # Restore the possible source function.
-  (( ${+ZI[bkp-source]} )) && functions[source]="${ZI[bkp-source]}" || unfunction source 2>/dev/null
-  (( ${+ZI[bkp-.]} )) && functions[.]="${ZI[bkp-.]}" || unfunction . 2> /dev/null
+  if (( ${+ZI[bkp-source]} )); then
+    functions[source]="${ZI[bkp-source]}"
+  else
+    unfunction source 2>/dev/null
+  fi
+  if (( ${+ZI[bkp-.]} )); then
+    functions[.]="${ZI[bkp-.]}"
+  else
+    unfunction . 2> /dev/null
+  fi
   # Light and compdef temporary substituting of functions stops here.
-  [[ ( $mode = light && ${+ICE[trackbinds]} -eq 0 ) || $mode = compdef ]] && return 0
+  if [[ ( $mode = light && ${+ICE[trackbinds]} -eq 0 ) || $mode = compdef ]]; then
+    return 0
+  fi
   # Unfunction temporary substituting of functions functions.
   # A.
-  (( ${+ZI[bkp-bindkey]} )) && functions[bindkey]="${ZI[bkp-bindkey]}" || unfunction bindkey
+  if (( ${+ZI[bkp-bindkey]} )); then
+    functions[bindkey]="${ZI[bkp-bindkey]}"
+  else
+    unfunction bindkey
+  fi
   # When `zi light -b ...' or when `zi ice trackbinds ...; zi light ...'.
-  [[ $mode = light-b || ( $mode = light && ${+ICE[trackbinds]} -eq 1 ) ]] && return 0
+  if [[ $mode = light-b || ( $mode = light && ${+ICE[trackbinds]} -eq 1 ) ]]; then
+    return 0
+  fi
   # B.
-  (( ${+ZI[bkp-zstyle]} )) && functions[zstyle]="${ZI[bkp-zstyle]}" || unfunction zstyle
+  if (( ${+ZI[bkp-zstyle]} )); then
+    functions[zstyle]="${ZI[bkp-zstyle]}"
+  else
+    unfunction zstyle
+  fi
   # C.
-  (( ${+ZI[bkp-alias]} )) && functions[alias]="${ZI[bkp-alias]}" || unfunction alias
+  if (( ${+ZI[bkp-alias]} )); then
+    functions[alias]="${ZI[bkp-alias]}"
+  else
+    unfunction alias
+  fi
   # D.
-  (( ${+ZI[bkp-zle]} )) && functions[zle]="${ZI[bkp-zle]}" || unfunction zle
+  if (( ${+ZI[bkp-zle]} )); then
+    functions[zle]="${ZI[bkp-zle]}"
+  else
+    unfunction zle
+  fi
   return 0
 } # ]]]
 # FUNCTION: pmodload. [[[
 # {function:pmodload} Compatibility with Prezto. Calls can be recursive.
 (( ${+functions[pmodload]} )) || pmodload() {
   local -A ices
-  (( ${+ICE} )) && ices=( "${(kv)ICE[@]}" teleid '' )
+  if (( ${+ICE} )); then
+    ices=( "${(kv)ICE[@]}" teleid '' )
+  fi
   local -A ICE ZI_ICE
   ICE=( "${(kv)ices[@]}" ) ZI_ICE=( "${(kv)ices[@]}" )
   while (( $# )); do
@@ -734,7 +873,9 @@ function .zi-tmp-subst-off() {
       shift
       continue
     else
-      [[ -z ${ZI_SNIPPETS[PZT::modules/$1${ICE[svn]-/init.zsh}]} && -z ${ZI_SNIPPETS[https://github.com/sorin-ionescu/prezto/trunk/modules/$1${ICE[svn]-/init.zsh}]} ]] && .zi-load-snippet PZT::modules/"$1${ICE[svn]-/init.zsh}"
+      if [[ -z ${ZI_SNIPPETS[PZT::modules/$1${ICE[svn]-/init.zsh}]} && -z ${ZI_SNIPPETS[https://github.com/sorin-ionescu/prezto/trunk/modules/$1${ICE[svn]-/init.zsh}]} ]]; then
+        .zi-load-snippet PZT::modules/"$1${ICE[svn]-/init.zsh}"
+      fi
       shift
     fi
   done
@@ -752,7 +893,13 @@ function .zi-tmp-subst-off() {
 function .zi-diff-functions() {
   local uspl2="$1"
   local cmd="$2"
-  [[ $cmd = begin ]] && { [[ -z ${ZI[FUNCTIONS_BEFORE__$uspl2]} ]] && ZI[FUNCTIONS_BEFORE__$uspl2]="${(j: :)${(qk)functions[@]}}" } || ZI[FUNCTIONS_AFTER__$uspl2]+=" ${(j: :)${(qk)functions[@]}}"
+  if [[ $cmd = begin ]]; then
+    if [[ -z ${ZI[FUNCTIONS_BEFORE__$uspl2]} ]]; then
+      ZI[FUNCTIONS_BEFORE__$uspl2]="${(j: :)${(qk)functions[@]}}"
+    else
+      ZI[FUNCTIONS_AFTER__$uspl2]+=" ${(j: :)${(qk)functions[@]}}"
+    fi
+  fi
 } # ]]]
 # FUNCTION: .zi-diff-options. [[[
 # Implements detection of change in option state. Performs data gathering, computation is done in *-compute().
@@ -761,7 +908,13 @@ function .zi-diff-functions() {
 # $2 - command, can be "begin" or "end"
 function .zi-diff-options() {
   local IFS=" "
-  [[ $2 = begin ]] && { [[ -z ${ZI[OPTIONS_BEFORE__$uspl2]} ]] && ZI[OPTIONS_BEFORE__$1]="${(kv)options[@]}" } || ZI[OPTIONS_AFTER__$1]+=" ${(kv)options[@]}"
+  if [[ $2 = begin ]]; then
+    if [[ -z ${ZI[OPTIONS_BEFORE__$uspl2]} ]]; then
+      ZI[OPTIONS_BEFORE__$1]="${(kv)options[@]}"
+    else
+      ZI[OPTIONS_AFTER__$1]+=" ${(kv)options[@]}"
+    fi
+  fi
 } # ]]]
 # FUNCTION: .zi-diff-env. [[[
 # Implements detection of change in PATH and FPATH.
@@ -771,19 +924,21 @@ function .zi-diff-options() {
 function .zi-diff-env() {
   typeset -a tmp
   local IFS=" "
-  [[ $2 = begin ]] && {
-    { [[ -z ${ZI[PATH_BEFORE__$uspl2]} ]] && tmp=( "${(q)path[@]}" )
+  if [[ $2 = begin ]]; then
+    if [[ -z ${ZI[PATH_BEFORE__$uspl2]} ]]; then
+      tmp=( "${(q)path[@]}" )
       ZI[PATH_BEFORE__$1]="${tmp[*]}"
-    }
-    { [[ -z ${ZI[FPATH_BEFORE__$uspl2]} ]] && tmp=( "${(q)fpath[@]}" )
+    fi
+    if [[ -z ${ZI[FPATH_BEFORE__$uspl2]} ]]; then
+      tmp=( "${(q)fpath[@]}" )
       ZI[FPATH_BEFORE__$1]="${tmp[*]}"
-    }
-  } || {
+    fi
+  else
     tmp=( "${(q)path[@]}" )
     ZI[PATH_AFTER__$1]+=" ${tmp[*]}"
     tmp=( "${(q)fpath[@]}" )
     ZI[FPATH_AFTER__$1]+=" ${tmp[*]}"
-  }
+  fi
 } # ]]]
 # FUNCTION: .zi-diff-parameter. [[[
 # Implements detection of change in any parameter's existence and type.
@@ -947,7 +1102,11 @@ function .zi-register-plugin() {
   # Support Zsh plugin standard.
   zsh_loaded_plugins+=( "$teleid" )
   # Full or light load?
-  [[ $mode == light ]] && ZI[STATES__$uspl2]=1 || ZI[STATES__$uspl2]=2
+  if [[ $mode == light ]]; then
+    ZI[STATES__$uspl2]=1
+  else
+    ZI[STATES__$uspl2]=2
+  fi
   ZI_REPORTS[$uspl2]=             ZI_CUR_BIND_MAP=( empty 1 )
   # Functions.
   ZI[FUNCTIONS_BEFORE__$uspl2]=  ZI[FUNCTIONS_AFTER__$uspl2]=
@@ -1080,21 +1239,23 @@ function @zsh-plugin-run-on-update() {
 # FUNCTION: .zi-prepare-home. [[[
 # Creates all directories needed by ZI, first checks if they already exist.
 function .zi-prepare-home() {
-  [[ -n ${ZI[HOME_READY]} ]] && return
+  if [[ -n ${ZI[HOME_READY]} ]]; then
+    return
+  fi
   ZI[HOME_READY]=1
-  [[ ! -d ${ZI[HOME_DIR]} ]] && {
+  if [[ ! -d ${ZI[HOME_DIR]} ]]; then
     command mkdir  -p "${ZI[HOME_DIR]}"
     # For compaudit.
     command chmod go-w "${ZI[HOME_DIR]}"
     # Also set up */bin and ZPFX in general.
     command mkdir 2>/dev/null -p $ZPFX/bin
-  }
-  [[ ! -d ${ZI[ZMODULES_DIR]} ]] && {
+  fi
+  if [[ ! -d ${ZI[ZMODULES_DIR]} ]]; then
     command mkdir -p "${ZI[ZMODULES_DIR]}"
     # For compaudit.
     command chmod go-w "${ZI[ZMODULES_DIR]}"
-  }
-  [[ ! -d ${ZI[PLUGINS_DIR]}/_local---zi ]] && {
+  fi
+  if [[ ! -d ${ZI[PLUGINS_DIR]}/_local---zi ]]; then
     command rm -rf "${ZI[PLUGINS_DIR]:-${TMPDIR:-/tmp}/132bcaCAB}/_local---zi"
     command mkdir -p "${ZI[PLUGINS_DIR]}/_local---zi"
     command chmod go-w "${ZI[PLUGINS_DIR]}"
@@ -1105,8 +1266,8 @@ function .zi-prepare-home() {
     (( ${+functions[.zi-confirm]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" || return 1
     .zi-clear-completions &>/dev/null
     .zi-compinit &>/dev/null
-  }
-  [[ ! -d ${ZI[COMPLETIONS_DIR]} ]] && {
+  fi
+  if [[ ! -d ${ZI[COMPLETIONS_DIR]} ]]; then
     command mkdir "${ZI[COMPLETIONS_DIR]}"
     # For compaudit.
     command chmod go-w "${ZI[COMPLETIONS_DIR]}"
@@ -1116,8 +1277,8 @@ function .zi-prepare-home() {
     command mkdir 2>/dev/null -p $ZPFX/bin
     (( ${+functions[.zi-setup-plugin-dir]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/install.zsh" || return 1
     .zi-compinit &>/dev/null
-  }
-  [[ ! -d ${ZI[SNIPPETS_DIR]} ]] && {
+  fi
+  if [[ ! -d ${ZI[SNIPPETS_DIR]} ]]; then
     command mkdir -p "${ZI[SNIPPETS_DIR]}/OMZ::plugins"
     command chmod go-w "${ZI[SNIPPETS_DIR]}"
     ( builtin cd ${ZI[SNIPPETS_DIR]}; command ln -s OMZ::plugins plugins; )
@@ -1126,7 +1287,7 @@ function .zi-prepare-home() {
     command chmod go-w "${ZI[SERVICES_DIR]}"
     # Also set up */bin and ZPFX in general.
     command mkdir 2>/dev/null -p $ZPFX/bin
-  }
+  fi
 } # ]]]
 # FUNCTION: .zi-load-object. [[[
 function .zi-load-object() {
@@ -1274,7 +1435,11 @@ function .zi-load-snippet() {
     # Source the file with compdef temporary substituting of functions.
     if [[ ${ZI[TMP_SUBST]} = inactive ]]; then
       # Temporary substituting of functions code is inlined from .zi-tmp-subst-on.
-      (( ${+functions[compdef]} )) && ZI[bkp-compdef]="${functions[compdef]}" || builtin unset "ZI[bkp-compdef]"
+      if (( ${+functions[compdef]} )); then
+        ZI[bkp-compdef]="${functions[compdef]}"
+      else
+        builtin unset "ZI[bkp-compdef]"
+      fi
       functions[compdef]=':zi-tmp-subst-compdef "$@";'
       ZI[TMP_SUBST]=1
     else
@@ -1833,7 +1998,11 @@ function .zi-load-plugin() {
     fi
     if [[ ${ICE[atinit]} = '!'* || -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]]; then
       if [[ ${ZI[TMP_SUBST]} = inactive ]]; then
-        (( ${+functions[compdef]} )) && ZI[bkp-compdef]="${functions[compdef]}" || builtin unset "ZI[bkp-compdef]"
+        if (( ${+functions[compdef]} )); then
+          ZI[bkp-compdef]="${functions[compdef]}"
+        else
+          builtin unset "ZI[bkp-compdef]"
+        fi
         functions[compdef]=':zi-tmp-subst-compdef "$@";'
         ZI[TMP_SUBST]=1
       else
@@ -2595,7 +2764,11 @@ function .zi-load-ices() {
 function .zi-setup-params() {
   builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
   reply=( ${(@)${(@s.;.)ICE[param]}/(#m)*/${${MATCH%%(-\>|→|=\>)*}//((#s)[[:space:]]##|[[:space:]]##(#e))}${${(M)MATCH#*(-\>|→|=\>)}:+\=${${MATCH#*(-\>|→|=\>)}//((#s)[[:space:]]##|[[:space:]]##(#e))}}} )
-  (( ${#reply} )) && return 0 || return 1
+  if (( ${#reply} )); then
+    return 0
+  else
+    return 1
+  fi
 } # ]]]
 
 #
@@ -2946,7 +3119,9 @@ function zi() {
       ZI_ICES=( "${(kv)ICE[@]}" )
       ICE=() ZI_ICE=()
       1="${1:+@}${1#@}${2:+/$2}"
-      (( $# > 1 )) && { shift -p $(( $# - 1 )); }
+      if (( $# > 1 )); then
+        shift -p $(( $# - 1 ))
+      fi
       if [[ -z $1 ]]; then
         +zi-message "Argument needed, try: {cmd}help."
         return 1
@@ -2983,12 +3158,16 @@ function zi() {
           ICE=( "${___ices[@]}" "${(kv)ZI_ICES[@]}" )
           ZI_ICE=( "${(kv)ICE[@]}" ) ZI_ICES=()
           integer ___msgs=${+ICE[debug]}
-          (( ___msgs )) && +zi-message "{profile}zi-main{ehi}:{faint} Processing {pname}$1{faint}{…}{rst}"
+          if (( ___msgs )); then
+            +zi-message "{profile}zi-main{ehi}:{faint} Processing {pname}$1{faint}{…}{rst}"
+          fi
           # Delete up to the final space to get the previously-processed ID.
           ZI[annex-exposed-processed-IDs]+="${___id:+ $___id}"
           # Strip the ID-qualifier (`@') and GitHub domain from the ID.
           ___id="${${1#@}%%(///|//|/)}"
-          (( ___is_snippet == -1 )) && ___id="${___id#https://github.com/}"
+          if (( ___is_snippet == -1 )); then
+            ___id="${___id#https://github.com/}"
+          fi
           # Effective handle-ID – the label under which the object will be identified / referred-to by ZI.
           ___ehid="${ICE[id-as]:-$___id}"
           # Effective remote-ID (i.e.: URL, GitHub username/repo, package name, etc.). teleid'' allows "overriding" of $1.
@@ -3027,7 +3206,9 @@ function zi() {
             if (( ___retval2 )); then
               # An error is actually only an odd return code.
               ___retval+=$(( ___retval2 & 1 ? ___retval2 : 0 ))
-              (( ___retval2 & 1 && $# )) && shift
+              if (( ___retval2 & 1 && $# )); then
+                shift
+              fi
               # Override $@?
               if (( ___retval2 & 2 )); then
                 local -a ___args
@@ -3062,8 +3243,10 @@ function zi() {
             else
               .zi-get-object-path plugin $___ehid
             fi
-            if (( $? )) && [[ ${zsh_eval_context[1]} = file ]]; then
-              ___action_load=1
+            if (( $? )); then
+              if [[ ${zsh_eval_context[1]} = file ]]; then
+                ___action_load=1
+              fi
             fi
             local ___object_path="$REPLY"
           elif (( ! ___turbo )); then
@@ -3528,7 +3711,9 @@ function zicompinit_fast() {
   local zcompf="${ZI[ZCOMPDUMP_PATH]:-${XDG_DATA_HOME:-$ZDOTDIR:-$HOME}/.zcompdump}"
   #local check_ub="$(awk -F= '/^NAME/{print $2}' /etc/os-release | grep 'Ubuntu')"
   local zcompf_a="${zcompf}.augur"
-  #[[ $check_ub ]] && export skip_global_compinit=1
+  #if [[ $check_ub ]]; then
+  #  export skip_global_compinit=1
+  #fi
 
   # Globbing (#qN.mh+24):
   # - '#q' is an explicit glob qualifier that makes globbing work within zsh's [[ ]] construct.
@@ -3593,8 +3778,12 @@ function zpcompdef() {
 # Source-executed code.
 #
 
-(( ZI[ALIASES_OPT] )) && builtin setopt aliases
-(( ZI[SOURCED] ++ )) && return
+if (( ZI[ALIASES_OPT] )); then
+  builtin setopt aliases
+fi
+if (( ZI[SOURCED] ++ )); then
+  return
+fi
 
 autoload add-zsh-hook
 if { zmodload zsh/datetime }; then


### PR DESCRIPTION
# Pull request template

Recently, the wiki moved from z.digitalclouds.dev to wiki.zshell.dev. Now, we need to update links

## Type of changes

- [ ] CI
- [ ] Bugfix
- [x] Feature
- [ ] Generic maintenance tasks
- [x] Documentation content changes
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: N/A

## What is the current behavior?

Link to z.digitalclouds.dev which redirect to wiki.zshell.dev

Use +zi-message for each user output even if it's an error

## What is the new behavior?

Link to wiki.zshell.dev

Use +zi-message for user output
And +zi-error for errors, (print to STDERR)

Follow Google's style guidelines: https://google.github.io/styleguide/shellguide.html

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

N/A
