### PR TITLE
Replace egrep with grep -E

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1497,7 +1497,7 @@ ZI[EXTENDED_GLOB]=""
           }
         done
         ICE=()
-        (( ZI[annex-multi-flag:pull-active] >= 2 )) && command git pull --no-stat ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} |& command egrep -v '(FETCH_HEAD|up.to.date\.|From.*://)'
+        (( ZI[annex-multi-flag:pull-active] >= 2 )) && command git pull --no-stat ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} |& command grep -E -v '(FETCH_HEAD|up.to.date\.|From.*://)'
       }
         return ${ZI[annex-multi-flag:pull-active]}
       )
@@ -1509,7 +1509,7 @@ ZI[EXTENDED_GLOB]=""
         if (( OPTS[opt_-q,--quiet] )) {
           command git pull --recurse-submodules ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} &> /dev/null
         } else {
-          command git pull --recurse-submodules ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} |& command egrep -v '(FETCH_HEAD|up.to.date\.|From.*://)'
+          command git pull --recurse-submodules ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} |& command grep -E -v '(FETCH_HEAD|up.to.date\.|From.*://)'
         }
       )
     fi

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1613,7 +1613,7 @@ ziextract() {
       →zi-extract() {
         →zi-check gunzip "$file" || return 1
         .zi-get-mtime-into "$file" 'ZI[tmp]'
-        command gunzip "$file" |& command egrep -v '.out$'
+        command gunzip "$file" |& command grep -E -v '.out$'
         integer ret=$pipestatus[1]
         command touch -t "$(strftime %Y%m%d%H%M.%S $ZI[tmp])" "$file"
         return ret
@@ -1627,7 +1627,7 @@ ziextract() {
       }
       →zi-extract() { →zi-check bunzip2 "$file" || return 1
         .zi-get-mtime-into "$file" 'ZI[tmp]'
-        command bunzip2 "$file" |& command egrep -v '.out$'
+        command bunzip2 "$file" |& command grep -E -v '.out$'
         integer ret=$pipestatus[1]
         command touch -t "$(strftime %Y%m%d%H%M.%S $ZI[tmp])" "$file"
         return ret


### PR DESCRIPTION
# Pull request template

With the release of grep 3.8 the egrep is obsolete
https://git.savannah.gnu.org/cgit/grep.git/commit/src/egrep.sh?id=a9515624709865d480e3142fd959bccd1c9372d1

## Type of changes

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- [ ] CI
- [ ] Bugfix
- [ ] Feature
- [x] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: N/A

## What is the current behavior?

When using the newest version of `egrep` the deprecated warning jumps out

```
egrep: warning: egrep is obsolescent; using grep -E
```

## What is the new behavior?

No egrep warnings

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A
