### PR TITLE
Prevent expansion in some lines in .zi-create func

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -2688,8 +2688,8 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # Copyright (c) $year $user_name
 # According to the Zsh Plugin Standard:
 # https://wiki.zshell.dev/community/zsh_plugin_standard
-0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
-0="${${(M)0:#/*}:-$PWD/$0}"
+0="\${ZERO:-\${\${0:#\$ZSH_ARGZERO}:-\${(%):-%N}}}"
+0="\${\${(M)0:#/*}:-\$PWD/\$0}"
 # Then \${0:h} to get plugin's directory
 if [[ \${zsh_loaded_plugins[-1]} != */${plugin:t} && -z \${fpath[(r)\${0:h}]} ]] {
   fpath+=( "\${0:h}" )


### PR DESCRIPTION
This makes sure that the lines output to the PLUGIN_NAME.plugin.zsh file are as intented in the documentation:
https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling

I just had the feeling that the variable expansion in these two particular lines wasn't intentional.

# Pull request template

<!--- Please provide a general summary of your changes in the title above -->

## Type of changes

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- [ ] CI
- [x] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: N/A

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
The following lines are created as a part of the file PLUGIN_NAME.plugin.zsh:
```
0=".zi-create"
0="MY_ZSH_HOME/.zi/plugins/_local---my-zsh-completions/.zi-create"
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
The following lines are created instead:
```
0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
0="${${(M)0:#/*}:-$PWD/$0}"
```

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

N/A
