### PR TITLE
follow self-update -q

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -630,7 +630,7 @@ ZI[EXTENDED_GLOB]=""
 .zi-self-update() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob typesetsilent warncreateglobal
-  [[ $1 = -q ]] && +zi-message "{profile}Updating »»»»{rst} ❮ {happy}Zi{rst} ❯ {…}{rst}"
+  [[ $1 != -q ]] && +zi-message "{profile}Updating »»»»{rst} ❮ {happy}Zi{rst} ❯ {…}{rst}"
   local nl=$'\n' escape=$'\x1b[' current_branch=$(builtin cd -q "$ZI[BIN_DIR]" && command git rev-parse --abbrev-ref HEAD 2>/dev/null)
   local -a lines
   (   builtin cd -q "$ZI[BIN_DIR]" && command git checkout $current_branch &>/dev/null && command git fetch --quiet && \


### PR DESCRIPTION
# Pull request template


## Type of changes

emit outputs when quiet option passed to `.zi-self-update()`.


- [x] Bugfix

Issue Number: N/A

## What is the current behavior?

`zi update -p -q` shows `Updating »»»» ❮ Zi ❯ …` even there is `-q` option.

## What is the new behavior?

silent update

### Does this introduce a breaking change?

- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

N/A
