### PR TITLE
codebase

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🚀 Run stale
-        uses: actions/stale@v6
+        uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -590,7 +590,7 @@ ZI[EXTENDED_GLOB]=""
 
 # FUNCTION: .zi-pager [[[
 .zi-pager() {
-  builtin setopt LOCAL_OPTIONS EQUALS
+  builtin setopt extended_glob no_short_loops local_options equals
   # Quiet mode ? → no pager.
   if (( OPTS[opt_-n,--no-pager] )) {
     cat
@@ -709,7 +709,7 @@ ZI[EXTENDED_GLOB]=""
 # 0. Call the Zsh Plugin's Standard *_plugin_unload function
 # 0. Call the code provided by the Zsh Plugin's Standard @zsh-plugin-run-at-update
 # 1. Delete bindkeys (...)
-# 2. Delete Zstyles
+# 2. Delete zstyles
 # 3. Restore options
 # 4. Remove aliases
 # 5. Restore Zle state
@@ -1680,8 +1680,7 @@ ZI[EXTENDED_GLOB]=""
     }
     return $retval
   }
-  local st=$1 id_as repo snip pd user plugin
-    integer PUPDATE=0
+  local st=$1 id_as repo snip pd user plugin; integer PUPDATE=0
   local -A ICE
   if (( OPTS[opt_-s,--snippets] || !OPTS[opt_-l,--plugins] )) {
     local -a snipps
@@ -1736,7 +1735,7 @@ ZI[EXTENDED_GLOB]=""
     else
       (( !OPTS[opt_-q,--quiet] )) && +zi-message "Updating{ehi}:{rst} $REPLY{rst}" || builtin print -n .
       .zi-update-or-status update "$user" "$plugin"
-      update_rc=$?
+      local update_rc=$?
       [[ $update_rc -ne 0 ]] && {
         +zi-message "{warn}Warning: {pid}${user}/${plugin} {warn}update returned{ehi}:{rst} {num}${update_rc}"
         retval=$?
@@ -1908,13 +1907,14 @@ ZI[EXTENDED_GLOB]=""
   [[ -z $sni ]] && builtin print -n " "
   builtin print '\b\b  '
 } # ]]]
-# FUNCTION: .zi-show-times [[[
+# FUNCTION: .zi-times [[[
 # Shows loading times of all loaded plugins.
 #
 # User-action entry point.
-.zi-show-times() {
-  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal noshortloops
+.zi-times() {
+builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+builtin setopt extended_glob warn_create_global typeset_silent \
+  no_short_loops rc_quotes no_auto_pushd no_bang_hist
 
   local opt="$1 $2 $3" entry entry2 entry3 user plugin
   float -F 3 sum=0.0
@@ -2603,7 +2603,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
     [[ $uspl1 = custom || $uspl1 = _local---zi ]] && continue
     pushd "$p" >/dev/null || continue
     if [[ -d .git ]]; then
-      gitout=`command git log --all --max-count=1 --since=$timespec 2>/dev/null`
+      gitout=$(command git log --all --max-count=1 --since=$timespec 2>/dev/null)
       if [[ -n $gitout ]]; then
         .zi-any-colorify-as-uspl2 "$uspl1"
         builtin print -r -- "$REPLY"

--- a/lib/zsh/git-process-output.zsh
+++ b/lib/zsh/git-process-output.zsh
@@ -3,6 +3,9 @@
 builtin emulate -LR zsh
 builtin setopt extended_glob warn_create_global typeset_silent
 
+typeset -Ag ZI_USR
+[[ -z $ZI_USR[GP_COL] ]] && ZI_USR[GP_COL]=46
+
 { typeset -g COLS="$(tput cols)" } 2>/dev/null
 if (( COLS < 10 )) {
   COLS=40
@@ -41,7 +44,7 @@ local first=1
 timeline() {
   local sp='▚▞'; sp="${sp:$2%2:1}"
   # Maximal width is 24 characters
-  local bar="$(builtin print -f "%.$2s█%0$(($3-$2-1))s" "░▒▓█████████████████████" "")"
+  local bar="$(builtin print -f "%.$2s█%0$(($3-$2-1))s" "░▒▓████████████████████" "")"
   local -a frames_splitted
   frames_splitted=( ${(@zQ)progress_frames[progress_style]} )
   if (( SECONDS - last_time >= frames_splitted[1] )) {
@@ -50,7 +53,7 @@ timeline() {
     last_time=$SECONDS
   }
   builtin print -nr -- ${frames_splitted[cur_frame+1]}" "
-  builtin print -nPr "%F{201}"
+  builtin print -nPr "%F{$ZI_USR[GP_COL]}"
   builtin print -f "%s %s" "${bar// /░}" ""
   builtin print -nPr "%f"
 }
@@ -98,10 +101,10 @@ IFS=''
 [[ $+ZI_CIVIS == 1 && -n $TERM ]] && eval $ZI_CIVIS
 
 if [[ -n $TERM ]] {
+[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || \
+  zmodload zsh/nearcolor &>/dev/null
 { command perl -pe 'BEGIN { $|++; $/ = \1 }; tr/\r/\n/' || \
-  gstdbuf -o0 gtr '\r' '\n' || \
-  cat } |& \
-while read -r line; do
+  gstdbuf -o0 gtr '\r' '\n' || cat; } |& while read -r line; do
   (( ++ loop_count ))
   if [[ "$line" = "Cloning into"* ]]; then
     builtin print $line


### PR DESCRIPTION
## Type of changes

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- [ ] CI
- [ ] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [x] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

Users may have to update `.zshrc.`:

- deprecated alias `zini`.
- deprecated function `zpcdreplay`, use: `zicdreplay`
- deprecated function `zpcdclear`, use: `zicdclear`
- deprecated function `zpcompinit`, use: `zicompinit`
- deprecated function `zpcompdef`, use: `zicompdef`

## Other information

- Improved source timestamp (function `.zi-set-mtime`)
- Added `zi -V|--version|version`
- Added hash `ZI_USR` to allow user additional customizations:
  - Change git process color (0-255), default: `typeset -Ag ZI_USR; ZI_USR[GP_COL]=46`
- Renamed function `.zi-show-times` to `.zi-times` for consistency
- Improved/fixed zi subcommands/options
- Codebase fixes/improvements:
  - fix `typeset -gxU` order to avoid `warn_create_global`
  - +minor improvements 