### PR TITLE
Replace exa with eza

### DIFF
--- a/docs/man/zi.1
+++ b/docs/man/zi.1
@@ -408,7 +408,7 @@ zi creinstall %HOME/my_completions
 .RS 2
 .nf
 # For GNU ls (the binaries can be gls, gdircolors, e.g. on OS X when installing the
-# coreutils package from Homebrew; you can also use https://github.com/ogham/exa)
+# coreutils package from Homebrew; you can also use https://github.com/eza-community/eza)
 zi ice atclone"dircolors -b LS_COLORS > c.zsh" atpull'%atclone' pick"c.zsh" nocompile'!'
 zi light trapd00r/LS_COLORS
 .fi

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -2865,8 +2865,8 @@ EOF
 .zi-ls() {
   if (( ${+commands[tree]} )); then
     ZI[TREE]="${commands[tree]} -L 3 -C --charset utf-8"
-  elif (( ${+commands[exa]} )); then
-    ZI[TREE]="${commands[exa]} --color=always -T -l -L3"
+  elif (( ${+commands[eza]} )); then
+    ZI[TREE]="${commands[eza]} --color=always -T -l -L3"
   else
     builtin print "${ZI[col-error]}No \`tree' program, it is required by the subcommand \`ls\'${ZI[col-rst]}"
     builtin print "Download from: http://mama.indstate.edu/users/ice/tree/"


### PR DESCRIPTION
# Pull request template

Since exa is deprecated, this PR replaces all mentions to exa with eza (code, docs).

## Type of changes

- [ ] CI
- [ ] Bugfix
- [ ] Feature
- [x] Generic maintenance tasks
- [x] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: #284 

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

For any users of zi that are also using exa, this change would make the enhanced ls command to not work properly.
Such users should replace exa with eza in their setup.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

N/A
