### PR TITLE
Fix/replace svn with git sparse checkout

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1613,7 +1613,7 @@ ZI[EXTENDED_GLOB]=""
   if [[ "$st" = "status" ]]; then
     if (( ${+ICE2[svn]} )); then
       builtin print -r -- "${ZI[col-info]}Status for ${${${local_dir:h}:t}##*--}/${local_dir:t}${ZI[col-rst]}"
-      ( builtin cd -q "$local_dir"; command svn status -vu )
+      ( builtin cd -q "$local_dir"; if [[ -d .git ]]; then command git status; else command svn status -vu; fi )
       retval=$?
       builtin print
     else

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -767,8 +767,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         # Remove old files except .zi metadata
         command find "$directory" -maxdepth 1 -not -name '.zi' -not -name '.zi_rev' -not -path "$directory" -exec rm -rf {} + 2>/dev/null
       fi
-      command cp -Rf "$src_dir"/* "$directory"/ 2>/dev/null
-      command cp -Rf "$src_dir"/.[^.]* "$directory"/ 2>/dev/null
+      command cp -Rf "$src_dir"/(^.git)(DN) "$directory"/ 2>/dev/null
       # Store revision for update checks
       local rev
       rev=$(command git -C "$tmpdir/repo" rev-parse HEAD 2>/dev/null)

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -709,10 +709,10 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   return 0
 } # ]]]
 # FUNCTION: .zi-mirror-using-svn [[[
-# Used to clone subdirectories from Github.
-# If in update mode (see $2), then invokes `svn update',
-# in normal mode invokes `svn checkout --non-interactive -q <URL>'.
-# In test mode only compares remote and local revision and outputs true if update is needed.
+# Used to clone subdirectories from Github using git sparse-checkout.
+# If in update mode (see $2), then invokes `git pull',
+# in normal mode invokes `git clone' with sparse-checkout.
+# In test mode only compares remote and local HEAD and outputs true if update is needed.
 #
 # $1 - URL
 # $2 - mode, "" - normal, "-u" - update, "-t" - test
@@ -721,28 +721,45 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   builtin setopt localoptions extendedglob warncreateglobal
   local url="$1" update="$2" directory="$3"
 
-  (( ${+commands[svn]} )) || \
-    +zi-message "{error}Warning{ehi}:{rst} Subversion not found{nl}{mmdsh}{rst} {auto}Please install it to use \`svn' ice"
+  (( ${+commands[git]} )) || \
+    +zi-message "{error}Warning{ehi}:{rst} Git not found{nl}{mmdsh}{rst} {auto}Please install it to use \`svn' ice"
+
+  # Parse GitHub URL to extract repo URL and subpath
+  # e.g. https://github.com/ohmyzsh/ohmyzsh/plugins/git
+  #   -> repo_url=https://github.com/ohmyzsh/ohmyzsh subpath=plugins/git
+  local repo_url subpath
+  if [[ "$url" = *github.com* ]]; then
+    repo_url=${(M)url##https://github.com/[^/]##/[^/]##}
+    subpath=${url#$repo_url}
+    subpath=${subpath#/}
+    subpath=${subpath%/}
+  else
+    +zi-message "{error}Warning{ehi}:{rst} Non-GitHub URLs are not supported for \`svn' ice without Subversion"
+    return 1
+  fi
 
   if [[ "$update" = "-t" ]]; then
     ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
-      local -a out1 out2
-      out1=( "${(f@)"$(LANG=C svn info -r HEAD)"}" )
-      out2=( "${(f@)"$(LANG=C svn info)"}" )
-
-      out1=( "${(M)out1[@]:#Revision:*}" )
-      out2=( "${(M)out2[@]:#Revision:*}" )
-      [[ "${out1[1]##[^0-9]##}" != "${out2[1]##[^0-9]##}" ]] && return 0
+      local local_rev remote_rev
+      local_rev=$(command git rev-parse HEAD 2>/dev/null)
+      remote_rev=$(command git ls-remote --refs "$repo_url" HEAD 2>/dev/null | command awk '{print $1}')
+      [[ -n "$remote_rev" && "$local_rev" != "$remote_rev" ]] && return 0
       return 1
     )
     return $?
   fi
-  if [[ "$update" = "-u" && -d "$directory" && -d "$directory/.svn" ]]; then
+  if [[ "$update" = "-u" && -d "$directory" && -d "$directory/.git" ]]; then
     ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
-    command svn update
+    command git pull --depth=1 -q origin 2>/dev/null
     return $? )
   else
-    command svn checkout --non-interactive -q "$url" "$directory"
+    command git clone --no-checkout --depth=1 --filter=tree:0 -q "$repo_url" "$directory" || return 4
+    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; } || return 4
+    if [[ -n "$subpath" ]]; then
+      command git sparse-checkout set "$subpath" 2>/dev/null
+    fi
+    command git checkout -q 2>/dev/null
+    return $? )
   fi
   return $?
 }
@@ -935,7 +952,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       (
         () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
         (( !OPTS[opt_-q,--quiet] )) && \
-        +zi-message "Downloading{ehi}:{rst} {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" ({p}with Subversion{rst})"}:-" ({p}with curl, wget, lftp{rst})"}{…}"
+        +zi-message "Downloading{ehi}:{rst} {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" ({p}with git sparse-checkout{rst})"}:-" ({p}with curl, wget, lftp{rst})"}{…}"
 
         if (( ${+ICE[svn]} )) {
           if [[ $update = -u ]] {

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -739,29 +739,47 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   fi
 
   if [[ "$update" = "-t" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
-      local local_rev remote_rev
-      local_rev=$(command git rev-parse HEAD 2>/dev/null)
-      remote_rev=$(command git ls-remote --refs "$repo_url" HEAD 2>/dev/null | command awk '{print $1}')
-      [[ -n "$remote_rev" && "$local_rev" != "$remote_rev" ]] && return 0
-      return 1
-    )
-    return $?
+    local local_rev remote_rev
+    local_rev="$(<"$directory/.zi_rev" 2>/dev/null)"
+    remote_rev=$(command git ls-remote "$repo_url" HEAD 2>/dev/null | command awk '{print $1}')
+    [[ -n "$remote_rev" && "$local_rev" != "$remote_rev" ]] && return 0
+    return 1
   fi
-  if [[ "$update" = "-u" && -d "$directory" && -d "$directory/.git" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
-    command git pull --depth=1 -q origin 2>/dev/null
-    return $? )
-  else
-    command git clone --no-checkout --depth=1 --filter=tree:0 -q "$repo_url" "$directory" || return 4
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; } || return 4
-    if [[ -n "$subpath" ]]; then
-      command git sparse-checkout set "$subpath" 2>/dev/null
+
+  # Clone to temp dir, sparse-checkout subpath, copy contents to target
+  local tmpdir
+  tmpdir=$(command mktemp -d) || return 4
+  {
+    command git clone --no-checkout --depth=1 --filter=tree:0 -q "$repo_url" "$tmpdir/repo" || return 4
+    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$tmpdir/repo"; } || return 4
+      if [[ -n "$subpath" ]]; then
+        command git sparse-checkout set --no-cone "/$subpath" 2>/dev/null
+      fi
+      command git checkout -q 2>/dev/null
+    ) || return 4
+
+    local src_dir="$tmpdir/repo"
+    [[ -n "$subpath" ]] && src_dir="$tmpdir/repo/$subpath"
+
+    if [[ -d "$src_dir" ]]; then
+      command mkdir -p "$directory"
+      if [[ "$update" = "-u" ]]; then
+        # Remove old files except .zi metadata
+        command find "$directory" -maxdepth 1 -not -name '.zi' -not -name '.zi_rev' -not -path "$directory" -exec rm -rf {} + 2>/dev/null
+      fi
+      command cp -Rf "$src_dir"/* "$directory"/ 2>/dev/null
+      command cp -Rf "$src_dir"/.[^.]* "$directory"/ 2>/dev/null
+      # Store revision for update checks
+      local rev
+      rev=$(command git -C "$tmpdir/repo" rev-parse HEAD 2>/dev/null)
+      [[ -n "$rev" ]] && builtin print -r -- "$rev" > "$directory/.zi_rev"
+    else
+      return 4
     fi
-    command git checkout -q 2>/dev/null
-    return $? )
-  fi
-  return $?
+  } always {
+    command rm -rf "$tmpdir"
+  }
+  return 0
 }
 # ]]]
 # FUNCTION: .zi-forget-completion [[[

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -126,8 +126,8 @@
 
   .zi-get-object-path snippet "$url1"
   local_dirA=$reply[-3] dirnameA=$reply[-2]
-  [[ -d "$local_dirA/$dirnameA/.git" || -d "$local_dirA/$dirnameA/.svn" ]] && {
-    if [[ -d "$local_dirA/$dirnameA/.git" ]]; then svn_dirA=".git"; else svn_dirA=".svn"; fi
+  [[ -f "$local_dirA/$dirnameA/.zi_rev" || -d "$local_dirA/$dirnameA/.svn" ]] && {
+    if [[ -f "$local_dirA/$dirnameA/.zi_rev" ]]; then svn_dirA=".zi_rev"; else svn_dirA=".svn"; fi
     if { .zi-first % "$local_dirA/$dirnameA"; } {
       fileB_there=( ${reply[-1]} )
     }

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -126,8 +126,8 @@
 
   .zi-get-object-path snippet "$url1"
   local_dirA=$reply[-3] dirnameA=$reply[-2]
-  [[ -d "$local_dirA/$dirnameA/.svn" ]] && {
-    svn_dirA=".svn"
+  [[ -d "$local_dirA/$dirnameA/.git" || -d "$local_dirA/$dirnameA/.svn" ]] && {
+    if [[ -d "$local_dirA/$dirnameA/.git" ]]; then svn_dirA=".git"; else svn_dirA=".svn"; fi
     if { .zi-first % "$local_dirA/$dirnameA"; } {
       fileB_there=( ${reply[-1]} )
     }

--- a/zi.zsh
+++ b/zi.zsh
@@ -206,12 +206,12 @@ ZI[TMP_SUBST]=inactive   ZI[DTRACE]=0    ZI[CUR_PLUGIN]=
 # Parameters - ICE. [[[
 typeset -gA ZI_1MAP ZI_2MAP
 ZI_1MAP=(
-  OMZ:: https://github.com/ohmyzsh/ohmyzsh/trunk/
-  OMZP:: https://github.com/ohmyzsh/ohmyzsh/trunk/plugins/
-  OMZT:: https://github.com/ohmyzsh/ohmyzsh/trunk/themes/
-  OMZL:: https://github.com/ohmyzsh/ohmyzsh/trunk/lib/
-  PZT:: https://github.com/sorin-ionescu/prezto/trunk/
-  PZTM:: https://github.com/sorin-ionescu/prezto/trunk/modules/
+  OMZ:: https://github.com/ohmyzsh/ohmyzsh/
+  OMZP:: https://github.com/ohmyzsh/ohmyzsh/plugins/
+  OMZT:: https://github.com/ohmyzsh/ohmyzsh/themes/
+  OMZL:: https://github.com/ohmyzsh/ohmyzsh/lib/
+  PZT:: https://github.com/sorin-ionescu/prezto/
+  PZTM:: https://github.com/sorin-ionescu/prezto/modules/
 )
 ZI_2MAP=(
   OMZ:: https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/


### PR DESCRIPTION
GitHub sunset SVN support in January 2024, breaking the `svn` ice used to download subdirectories (e.g., OMZ plugins). This replaces the SVN implementation with git sparse-checkout which provides the same subdirectory cloning capability using native git.

Changes:
- ZI_1MAP: remove /trunk/ from URLs (no longer needed for git)
- .zi-mirror-using-svn(): rewrite to use git clone --no-checkout --depth=1 --filter=tree:0 + git sparse-checkout
- side.zsh: detect .git in addition to .svn for existing snippets
- autoload.zsh: use git status when .git dir is present

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Chore (general maintenance, refactoring, or code style update)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.

## Other information (if applicable)

<!--- Any other information that is important to this PR such as environment variables, special considerations, etc. -->
