### PR TITLE
fix(autoload): correct bugs in auto-reload, zpmod build, and zi.zsh cleanup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,10 +37,10 @@
       <a href="https://translate.zshell.dev/" rel="noopener" target="_blank"><img align="center" src="https://badges.crowdin.net/e/f108c12713ee8526ac878d5671ad6e29/localized.svg" /></a>
       <a href="https://github.com/z-shell/zi/releases" rel="noopener" target="_blank"><img align="center" src="https://img.shields.io/github/tag/z-shell/zi.svg" alt="Version" /></a>
       <a href="https://github.com/z-shell/zi/blob/main/LICENSE" rel="noopener" target="_blank"><img align="center" src="https://img.shields.io/badge/License-MIT-blue.svg" alt="Project License" /></a>
-      <a thref="https://github.com/z-shell/zi-vim-syntax/" rel="noopener" target="_blank"><img align="center" src="https://img.shields.io/badge/--019733?logo=vim" alt="VIM" /></a>
+      <a href="https://github.com/z-shell/zi-vim-syntax/" rel="noopener" target="_blank"><img align="center" src="https://img.shields.io/badge/--019733?logo=vim" alt="VIM" /></a>
       <a href="https://open.vscode.dev/z-shell/zi/" rel="noopener" target="_blank">
-        <img align="center" src="https://img.shields.io/badge/--007ACC?logo=visual%20studio%20code&logoColor=ffffff"alt="Visual Studio Code" />
-      </p></a>
+        <img align="center" src="https://img.shields.io/badge/--007ACC?logo=visual%20studio%20code&logoColor=ffffff" alt="Visual Studio Code" />
+      </a></p>
       </div>
   </tr>
   </td>

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -651,7 +651,7 @@ ZI[EXTENDED_GLOB]=""
 
     # Remove all compiled files
     for rm_file ( ${ZI[BIN_DIR]}/**/*.zwc(DN) ) {
-      command rm -f -- ${rm_compiled} > /dev/null 2>&1
+      command rm -f -- "${rm_file}" > /dev/null 2>&1
     }
 
     # Recompile new ones
@@ -711,7 +711,7 @@ ZI[EXTENDED_GLOB]=""
 
       if (( ! dry_run )); then
         # Update the codebase
-        command git merge -n $opt --autostash --ff-only FETCH_HEAD || \
+        command git merge -n $opt --ff-only FETCH_HEAD || \
           { (( quiet )) || +zi-message "{mmdsh}{happy} Zi{rst} » {profile}update failed {quos}✘{rst}"; return 1 }
         .zi-auto-reload $opt
       fi
@@ -2962,7 +2962,8 @@ EOF
       local compiled_at_ts="$(<${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT)"
     [[ -e ${ZI[ZMODULES_DIR]}/zpmod/RECOMPILE_REQUEST ]] && \
       local recompile_request_ts="$(<${ZI[ZMODULES_DIR]}/zpmod/RECOMPILE_REQUEST)"
-    if [[ ${recompile_request_ts:-1} -gt ${compiled_at_ts:-0} ]]; then
+    if [[ -e ${ZI[ZMODULES_DIR]}/zpmod/RECOMPILE_REQUEST ]] && \
+       [[ ${recompile_request_ts:-1} -gt ${compiled_at_ts:-0} ]]; then
       +zi-message "{warn}Warning{warn}{ehi}:{rst} {lhi}recompilation{rst} of the {bcmd}zpmod{rst} module has been requested…"
       (( ${+functions[.zi-confirm]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" || return 1
       .zi-confirm "Do you want to proceed?" || return 1
@@ -3010,9 +3011,9 @@ EOF
         local cores=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || command getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
         local build_log="${ZI[LOG_DIR]}/zpmod/${EPOCHSECONDS}-build.log"
         command mkdir -p "${ZI[LOG_DIR]}/zpmod" 2>/dev/null
-        command make --jobs=$cores -C "${ZI[ZMODULES_DIR]}/zpmod" | command tee "$build_log" >/dev/null
-        if command make -C "${ZI[ZMODULES_DIR]}/zpmod" &>/dev/null; then
-          [[ -f Src/zi/zpmod.so ]] && command cp -vf Src/zi/zpmod.{so,bundle}
+        command make --jobs=$cores -C "${ZI[ZMODULES_DIR]}/zpmod" 2>&1 | command tee "$build_log" >/dev/null
+        if (( pipestatus[1] == 0 )); then
+          [[ -f Src/zi/zpmod.so ]] && command cp -vf Src/zi/zpmod.so Src/zi/zpmod.bundle
           builtin print "$EPOCHSECONDS" >! "${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT"
           +zi-message "{ok}-- Build successful! --{rst}"
           +zi-message "{faint}-- Build log{ehi}:{rst} {file}$build_log{faint} --{rst}"

--- a/zi.zsh
+++ b/zi.zsh
@@ -43,7 +43,7 @@ nocompile|reset"
 ZI[cmd-list]="-V|--version|version|-h|--help|help|subcmds|icemods|analytics|man|self-update|times|zstatus|load|light|unload|\
 snippet|ls|ice|update|status|report|delete|loaded|list|cd|create|edit|glance|stress|changes|recently|clist|completions|\
 cclear|cdisable|cenable|creinstall|cuninstall|csearch|compinit|dtrace|dstart|dstop|dunload|dreport|dclear|compile|\
-uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|module|add-fpath|run|version"
+uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|module|add-fpath|run"
 
 # Establish ZI[BIN_DIR]
 [[ ! -e ${ZI[BIN_DIR]}/zi.zsh ]] && ZI[BIN_DIR]=
@@ -2870,7 +2870,7 @@ zicdclear() { .zi-compdef-clear -q; }
 zicompinit() { builtin autoload -Uz compinit; compinit -d "${ZI[ZCOMPDUMP_PATH]}" "${(Q@)${(z@)ZI[COMPINIT_OPTS]}}"; }
 # ]]]
 # FUNCTION: zicompinit_fast. [[[
-# Checks the cached .zcompdump file to see if it must be regenerated adds a noticable delay to zsh startup.
+# Checks the cached .zcompdump file to see if it must be regenerated; adds a noticeable delay to zsh startup.
 # This restricts checking it once a day, determines when to regenerate, as compinit doesn't always need to
 # modify the compdump and compiles mapped to share (total mem reduction) run in background in multiple shells.
 # A function that can be invoked from within `atinit', `atload', e.g: zi ice atinit'zicompinit_fast'.


### PR DESCRIPTION
## Description

Fix several bugs in `lib/zsh/autoload.zsh` and clean up minor issues in
`zi.zsh`, identified during code review of #341.

## Changes

**`lib/zsh/autoload.zsh`:**
- `zi-auto-reload`: use loop variable `rm_file` (was incorrectly `rm_compiled`)
- `.zi-self-update`: drop `--autostash` from `git merge` (not a valid option for merge; only valid for rebase/pull)
- zpmod build: capture `pipestatus[1]` from `make | tee`; remove redundant second `make` invocation that ran the build twice
- zpmod build: make `cp` explicit — `zpmod.so → zpmod.bundle` (avoid brace expansion ambiguity)
- Fresh install: guard `--reset` recompile message with `[[ -e RECOMPILE_REQUEST ]]` check

**`zi.zsh`:**
- Remove duplicate `version` entry from `ZI[cmd-list]`
- Fix spelling `noticable` → `noticeable` and grammar in `zicompinit_fast` comment

**`docs/README.md`:**
- Fix `thref=` → `href=` on VIM badge link
- Fix `</p></a>` → `</a></p>` (mis-nested tags)

## Related issues

Extracted from #341.

## Type of change

- [x] `fix` — bug fix (non-breaking)

## Checklist

- [x] My branch was created from `next` (not `main`)
- [x] This PR targets the `next` branch
- [x] Commit messages follow Conventional Commits format
- [x] No AI co-author trailers in commit messages
- [x] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)