### PR TITLE
fix(completions): rebuild compinit after managed changes

### DIFF
--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -587,11 +587,18 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   builtin setopt null_glob extended_glob warn_create_global typeset_silent
 
   integer use_C=$2
+  typeset -a compinit_opts
+  compinit_opts=( "${(Q@)${(z@)ZI[COMPINIT_OPTS]}}" )
+
+  if [[ $1 = 1 ]]; then
+    use_C=0
+    compinit_opts=( "${(@)compinit_opts:#-C}" )
+  fi
 
   +zi-message "{mmdsh}{happy} Zi{rst} » {faint}initializing {func}compinit{rst}{…}"
 
   builtin autoload -Uz compinit
-  compinit ${${(M)use_C:#1}:+-C} -d "${ZI[ZCOMPDUMP_PATH]}" "${(Q@)${(z@)ZI[COMPINIT_OPTS]}}"
+  compinit ${${(M)use_C:#1}:+-C} -d "${ZI[ZCOMPDUMP_PATH]}" "${compinit_opts[@]}"
 } # ]]]
 # FUNCTION: .zi-download-file-stdout [[[
 # Downloads file to stdout.


### PR DESCRIPTION
## Closed by maintainer direction

This PR is closed unmerged. Zi changes require major refactoring and should not be applied as a narrow code patch right now.

The completion-refresh observation should be kept only as future evaluation/tracker context under Linear `ZSH-4` / GitHub `zi#349`.

## Prior verification before closure

- `zsh -n lib/zsh/install.zsh`
- `zsh -n zi.zsh`
- Fake-`compinit` probe: `.zi-compinit 1` with `ZI[COMPINIT_OPTS]="-C -i"` passed `-d <dump> -i` and did not pass `-C`.
- Fake-`compinit` probe: `.zi-compinit` with `ZI[COMPINIT_OPTS]="-C -i"` still passed `-d <dump> -C -i`.

## Agent handoff

Status: Closed unmerged by maintainer direction.
Current state: Treat this as future design input only, not an implementation PR.
Blockers: Zi requires major refactoring before targeted completion-refresh changes should be applied.
Next steps: Keep the behavior and possible approach in Linear `ZSH-4` for future evaluation alongside `zi#349`.