### PR TITLE
chore(zsh): add standard modelines to remaining libraries

### DIFF
--- a/lib/zsh/git-process-output.zsh
+++ b/lib/zsh/git-process-output.zsh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
 builtin setopt extended_glob warn_create_global typeset_silent

--- a/lib/zsh/rpm2cpio.zsh
+++ b/lib/zsh/rpm2cpio.zsh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -R zsh ${=${options[xtrace]:#off}:+-o xtrace}
 builtin setopt extended_glob

--- a/lib/zsh/single-line.zsh
+++ b/lib/zsh/single-line.zsh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -R zsh ${=${options[xtrace]:#off}:+-o xtrace}
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes


### PR DESCRIPTION
## Summary

- add the canonical Emacs and Vim Zsh modelines immediately after the shebang in the three remaining library files
- keep the change comment-only with no runtime behavior changes
- preserve the reviewed signed commit discovered during archive-first workspace cleanup

## Verification

- `git diff --check` passes
- all eight tracked `.zsh` files pass `zsh -n`
- the existing `rpm2cpio.zsh` redirection diagnostic is identical on `next` and this branch

Closes #354