### PR TITLE
fix(zpmod): only rebuild when a real, newer recompile request exists

### DIFF
--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -365,7 +365,8 @@
   local compiled_at_ts="$(<${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT)"
   [[ -e ${ZI[ZMODULES_DIR]}/zpmod/RECOMPILE_REQUEST ]] && \
   local recompile_request_ts="$(<${ZI[ZMODULES_DIR]}/zpmod/RECOMPILE_REQUEST)"
-  if [[ ${recompile_request_ts:-1} -gt ${compiled_at_ts:-0} ]]; then
+  if [[ -n ${recompile_request_ts} && -n ${compiled_at_ts} ]] && \
+  [[ ${recompile_request_ts} -gt ${compiled_at_ts} ]]; then
     +zi-message "{u-warn}WARNING{b-warn}:{rst}{msg} A {lhi}recompilation{rst}" \
     "of the zpmod module has been requested… {hi}Building{rst}…"
     (( ${+functions[.zi-confirm]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" || return 1


### PR DESCRIPTION
## Description

`.zi-check-module` (lib/zsh/side.zsh) decides that "a recompilation has been requested" with:

```zsh
if [[ ${recompile_request_ts:-1} -gt ${compiled_at_ts:-0} ]]; then
```

The defaults encode an inverted assumption: a *missing* `RECOMPILE_REQUEST` counts as `1`, i.e. as "a request exists". This PR instead requires both markers to exist and the request to be newer than the last recorded build:

```zsh
if [[ -n ${recompile_request_ts} && -n ${compiled_at_ts} ]] && \
[[ ${recompile_request_ts} -gt ${compiled_at_ts} ]]; then
```

(`recompile_request_ts` / `compiled_at_ts` are assigned just above only when the respective marker files exist, so the `-n` tests reuse those existence checks.)

## Motivation and Context

On installs where the module binary exists but `COMPILED_AT` is absent — module built manually, by older zi releases, or an interrupted `zi module build` — the comparison degenerates and the misleading "A recompilation of the zpmod module has been requested… Building…" warning plus a full rebuild fire at shell startup, although nothing was requested. Closes #342.

Two facts sharpen the scenario beyond the issue text:

- A truly fresh install (no `zpmod.so` yet) never reaches this code: the startup gate in `zi.zsh` only calls `.zi-check-module` when `zpmod.so` exists.
- In the affected state `RECOMPILE_REQUEST` is usually *present*: it is a tracked file of the zpmod repository (accidentally committed in z-shell/zpmod@58a0238a with a stale 2020 timestamp, `1580588806`) and nothing in zi or zpmod ever writes it. So the realistic broken comparison is `1580588806 > 0`, not only `1 > 0`.

The root-cause half is filed as z-shell/zpmod#69 (remove the fossil file, gitignore the marker). This guard makes zi behave correctly regardless of which marker files exist.

## How Has This Been Tested?

zsh 5.8.1, running the verbatim startup gate from `zi.zsh` plus the verbatim `.zi-check-module` (build steps stubbed), over the reachable disk states (`zpmod.so` present in all):

| state | before | after |
|---|---|---|
| `COMPILED_AT` + `RECOMPILE_REQUEST` (normal build) | silent | silent |
| `RECOMPILE_REQUEST` only (zpmod clone fossil), no `COMPILED_AT` | warning + rebuild | silent |
| neither marker | warning + rebuild | silent |
| genuine newer request (both markers) | warning + rebuild | warning + rebuild |
| stale request content with refreshed mtime (git pull) | silent | silent |

`zsh -n lib/zsh/side.zsh` passes. No automated tests were added: the ZUnit workflow only triggers for `lib/zsh/install.zsh` / `lib/zsh/autoload.zsh` path changes and the repo carries no `.zunit` suites for `lib/zsh/side.zsh`.

## Screenshots (if appropriate):

Not applicable — terminal-only behavior change; the before/after matrix above is the observable output.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (if none of the other choices apply)
- [ ] Chore (general maintenance, refactoring, or code style update)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document. (no CONTRIBUTING.md exists in the repository)
- [x] I have added tests to cover my changes. (no test infrastructure covers lib/zsh/side.zsh; verified manually as above)
- [x] All new and existing tests passed. (no tests are wired for this code path; see Testing)
- [x] I have updated the documentation accordingly. (no documentation describes this internal function)

## Other information (if applicable)

Alternatives considered:

- Guarding only on `[[ -e RECOMPILE_REQUEST ]]`: fixes the neither-marker state but not the fossil-marker state (`1580588806 > 0` still warns, verified) — rejected as incomplete.
- Dropping the recompile-request mechanism entirely (nothing writes `RECOMPILE_REQUEST` today): a larger behavioral change that is the maintainer's call; happy to follow up if preferred.
