### PR TITLE
ci: add main branch source guard

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -2,12 +2,11 @@
 name: Main Branch Source Guard
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize, edited]
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -28,9 +27,9 @@ jobs:
             echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
             exit 1
           fi
-          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* || "${HEAD_REF}" == copilot/* ]]; then
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
             echo "Head branch '${HEAD_REF}' is allowed to target main."
             exit 0
           fi
-          echo "::error::Pull requests into main must come from 'next', 'hotfix-*', or a temporary 'copilot/*' maintenance branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
           exit 1

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,35 @@
+name: Main Branch Source Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard main branch source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [[ "${HEAD_REPOSITORY}" != "${REPOSITORY}" ]]; then
+            echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
+            exit 1
+          fi
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
+            echo "Head branch '${HEAD_REF}' is allowed to target main."
+            exit 0
+          fi
+          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          exit 1

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,3 +1,4 @@
+---
 name: Main Branch Source Guard
 
 on:

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -28,9 +28,9 @@ jobs:
             echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
             exit 1
           fi
-          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* || "${HEAD_REF}" == copilot/* ]]; then
             echo "Head branch '${HEAD_REF}' is allowed to target main."
             exit 0
           fi
-          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          echo "::error::Pull requests into main must come from 'next', 'hotfix-*', or a temporary 'copilot/*' maintenance branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
           exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce branch source rules for pull requests targeting the `main` branch. The workflow ensures that only pull requests from the same repository and from either the `next` branch or a branch matching the `hotfix-*` pattern are allowed.

**Branch protection enforcement:**

* Added `.github/workflows/main-branch-guard.yml` to automatically check that pull requests into `main` come from the same repository and only from the `next` or `hotfix-*` branches, blocking all others.