### PR TITLE
ci: refresh workflow actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,7 +15,7 @@ jobs:
       )
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -28,7 +28,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Set matrix output"
         id: set-matrix
         run: |
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{ fromJSON(needs.zsh-matrix.outputs.matrix) }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "⚡ Install dependencies"
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: "⚡ zsh -n: ${{ matrix.file }}"

--- a/.github/workflows/zunit.yml
+++ b/.github/workflows/zunit.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: "z-shell/zd"
@@ -41,12 +41,12 @@ jobs:
       matrix: ${{ fromJSON(needs.zunit-matrix.outputs.matrix) }}
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: "z-shell/zd"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of key actions. The main focus is on upgrading the `actions/checkout`, `actions/labeler`, and `docker/login-action` actions to improve security, reliability, and compatibility with the latest GitHub features.

**Workflow action version upgrades:**

* Upgraded all instances of `actions/checkout` from `v3` to `v4` in `.github/workflows/rebase.yml`, `.github/workflows/zsh-n.yml`, and `.github/workflows/zunit.yml` to use the latest features and security patches. [[1]](diffhunk://#diff-63e050857aa8769f33e42aef9b82d1516c410dca42b52632f4e2d395a86abf92L18-R18) [[2]](diffhunk://#diff-8aff63d7438ddbf2768f78ef6f1ca2f2aff9bd78f193f36476df2a0e3bfeb656L31-R31) [[3]](diffhunk://#diff-8aff63d7438ddbf2768f78ef6f1ca2f2aff9bd78f193f36476df2a0e3bfeb656L47-R47) [[4]](diffhunk://#diff-1e36409960052e0f33a2aacb6872fd5123ea832b0e76d65e0d56a2f6cf62d670L24-R24) [[5]](diffhunk://#diff-1e36409960052e0f33a2aacb6872fd5123ea832b0e76d65e0d56a2f6cf62d670L44-R49)
* Updated `actions/labeler` from `v5` to `v7` in `.github/workflows/labeler.yml` for improved label automation and bug fixes.
* Upgraded `docker/login-action` from `v3` to `v4` in `.github/workflows/zunit.yml` to ensure compatibility with the latest Docker registry authentication changes.