### PR TITLE
fix(ci): remove next promotion blockers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,8 +37,7 @@
 
 ## Checklist
 
-- [ ] My branch was created from `next` (not `main`)
-- [ ] This PR targets the `next` branch
+- [ ] Ordinary work branches from and targets `next`; hotfixes branch from and target `main`
 - [ ] Commit messages follow Conventional Commits format
 - [ ] No AI co-author trailers in commit messages
 - [ ] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
   Thanks for contributing to zi! Please read the checklist below.
 
   Branch model:
-    • Create your branch FROM next:  git checkout -b fix/my-fix next
-    • Open this PR TARGETING next — never target main directly
-    • main is only updated from next via a release PR
+    - Ordinary work: create feature-<id> or bug-<id> from next and target next
+    - Urgent production fixes: create hotfix-<id> from main and target main
+    - Promote next to main only after integration checks pass
 
   Commit messages must follow Conventional Commits:
     type(scope): short description   (≤72 chars, imperative mood)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
   Branch model:
     - Ordinary work: create feature-<id> or bug-<id> from next and target next
-    - Urgent production fixes: create hotfix-<id> from main and target main
+    - Urgent production fixes: use a same-repository hotfix-<id> from main to main
     - Promote next to main only after integration checks pass
 
   Commit messages must follow Conventional Commits:
@@ -37,7 +37,7 @@
 
 ## Checklist
 
-- [ ] Ordinary work branches from and targets `next`; hotfixes branch from and target `main`
+- [ ] Ordinary work targets `next`; only same-repository hotfixes target `main`
 - [ ] Commit messages follow Conventional Commits format
 - [ ] No AI co-author trailers in commit messages
 - [ ] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -40,6 +40,11 @@ jobs:
           checked=0
 
           while IFS= read -r sha; do
+            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
+              echo "❌ Disallowed trailer found (${sha:0:7}): remove before merging"
+              errors=$((errors + 1))
+            fi
+
             parent_count=$(git cat-file -p "$sha" | grep -c '^parent' || true)
             [ "$parent_count" -gt 1 ] && continue
 
@@ -48,11 +53,6 @@ jobs:
 
             if ! echo "$subject" | grep -qE "$CONVENTIONAL_PATTERN"; then
               echo "❌ Invalid commit message (${sha:0:7}): expected type(scope): description ≤72 chars"
-              errors=$((errors + 1))
-            fi
-
-            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
-              echo "❌ Disallowed trailer found (${sha:0:7}): remove before merging"
               errors=$((errors + 1))
             fi
           done < <(git log --format='%H' "${BASE_SHA}..${HEAD_SHA}")

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          DISALLOWED_TRAILER_PATTERN: ${{ secrets.DISALLOWED_TRAILER_PATTERN }}
+          DISALLOWED_TRAILER_PATTERN: "^[[:space:]]*Co-authored-by:"
         run: |
           set -euo pipefail
 
@@ -51,11 +51,9 @@ jobs:
               errors=$((errors + 1))
             fi
 
-            if [ -n "${DISALLOWED_TRAILER_PATTERN:-}" ]; then
-              if git show -s --format='%B' "$sha" | grep -qE "$DISALLOWED_TRAILER_PATTERN"; then
-                echo "❌ Disallowed trailer found (${sha:0:7}): remove before merging"
-                errors=$((errors + 1))
-              fi
+            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
+              echo "❌ Disallowed trailer found (${sha:0:7}): remove before merging"
+              errors=$((errors + 1))
             fi
           done < <(git log --format='%H' "${BASE_SHA}..${HEAD_SHA}")
 

--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -24,5 +24,5 @@ jobs:
   zd-test:
     uses: z-shell/zd/.github/workflows/test-native.yml@cbb1211f6a39f9d89a600297883b3766d4fa8ab9 # main
     with:
-      zi_repo: ${{ github.repository }}
+      zi_repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       zi_ref: ${{ github.head_ref || github.ref_name }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,21 +5,19 @@ Thank you for contributing! Please follow the guidelines below to keep the proje
 ## Branch model
 
 ````text
-main  ←─── production (tagged releases only)
-  ↑
-next  ←─── integration branch  ← open all PRs here
-  ↑
-  ├── feat/<name>      new features
-  ├── fix/<name>       bug fixes
-  ├── perf/<name>      performance improvements
-  ├── refactor/<name>  code refactors
-  ├── docs/<name>      documentation updates
-  └── ci/<name>        CI / workflow changes
+main       production and consumable ref
+  ^
+next       integration branch; ordinary PRs target here
+  ^
+  |-- feature-<id>  new features
+  |-- bug-<id>      bug fixes
+  `-- hotfix-<id>   urgent fixes that may target main
 ```text
 
-1. **Always branch from `next`**: `git checkout -b fix/my-issue next`
-2. **Open PRs targeting `next`** — never target `main` directly
-3. `next` → `main` happens via a release PR once `next` is stable
+1. Branch ordinary work from `next`: `git switch -c bug-123 next`.
+2. Target `next` from `feature-<id>` and `bug-<id>` branches.
+3. Use `hotfix-<id>` only for urgent fixes branched from and targeting `main`.
+4. Promote `next` to `main` once the integration branch is stable.
 
 ## Commit message format
 
@@ -48,7 +46,8 @@ To clean up commits before opening a PR: `git rebase -i $(git merge-base HEAD ne
 
 ## What not to add
 
-- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, or any AI-specific config files
+- Root `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, or duplicate agent policy files.
+  Extend the repository's `AGENTS.md` instead.
 - Secrets, credentials, or tokens of any kind
 
 ## Discussion and issues

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,9 @@ next       integration branch; ordinary PRs target here
 
 1. Branch ordinary work from `next`: `git switch -c bug-123 next`.
 2. Target `next` from `feature-<id>` and `bug-<id>` branches.
-3. Use `hotfix-<id>` only for urgent fixes branched from and targeting `main`.
+3. Use `hotfix-<id>` only for urgent fixes created in this repository,
+   branched from `main`, and targeting `main`. Fork pull requests must target
+   `next`.
 4. Promote `next` to `main` once the integration branch is stable.
 
 ## Commit message format

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,12 +6,12 @@ Thank you for contributing! Please follow the guidelines below to keep the proje
 
 ````text
 main       production and consumable ref
+  |-- hotfix-<id>   urgent fixes that may target main
   ^
 next       integration branch; ordinary PRs target here
   ^
   |-- feature-<id>  new features
-  |-- bug-<id>      bug fixes
-  `-- hotfix-<id>   urgent fixes that may target main
+  `-- bug-<id>      bug fixes
 ```text
 
 1. Branch ordinary work from `next`: `git switch -c bug-123 next`.
@@ -42,7 +42,8 @@ BREAKING CHANGE: description of what breaks
 - Breaking changes: use `!` suffix (`feat!:`) and add `BREAKING CHANGE:` footer
 - **No AI co-author trailers** — do not add `Co-authored-by: Copilot` or similar
 
-To clean up commits before opening a PR: `git rebase -i $(git merge-base HEAD next)`
+To clean up commits before opening a PR, rebase against the intended target:
+`next` for ordinary work and `main` for hotfixes.
 
 ## What not to add
 


### PR DESCRIPTION
## Summary

- run ZD integration against the pull request head repository so fork branches are fetchable
- enforce the organization-wide `Co-authored-by` ban for every commit, including merge commits, without relying on secrets unavailable to forks
- align contributor documentation and the PR template with canonical branch names and the hotfix exception

## Validation

- workflow YAML parses successfully
- `git diff --check`
- trailer pattern rejects `Co-authored-by` and permits unrelated trailers
- stale slash-style branch examples are absent from contributor-facing files
- signed commits verified locally

## Follow-up

The reusable ZD workflow still clones mutable branch names because its documented SHA input is not implemented by `git clone --branch`. z-shell/zd#93 tracks immutable SHA support; Zi can switch to pull-request head SHAs after that lands.

Refs #364.