### PR TITLE
fix(runtime): restore documented compatibility helpers

### DIFF
--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1740,6 +1740,9 @@ ziextract() {
   }
   return 0
 } # ]]]
+# FUNCTION: zpextract [[[
+zpextract() { ziextract "$@"; }
+# ]]]
 # FUNCTION: .zi-extract() [[[
 .zi-extract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1740,9 +1740,6 @@ ziextract() {
   }
   return 0
 } # ]]]
-# FUNCTION: zpextract [[[
-zpextract() { ziextract "$@"; }
-# ]]]
 # FUNCTION: .zi-extract() [[[
 .zi-extract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}

--- a/zi.zsh
+++ b/zi.zsh
@@ -2646,7 +2646,7 @@ zi() {
             .zi-unload "${2%%(///|//|/)}" "${${3:#-q}%%(///|//|/)}" "${${(M)4:#-q}:-${(M)3:#-q}}"; ___retval=$?
           fi
           ;;
-        (version)
+        (-V|--version|version)
           +zi-message "Zi version: ${ZI[VERSION]}"
           ;;
         (bindkeys)
@@ -2908,6 +2908,13 @@ zicompinit_fast() {
 # Stores compdef for a replay with `zicdreplay' (turbo mode) or with `zi cdreplay' (normal mode).
 # An utility function of an undefined use case.
 zicompdef() { ZI_COMPDEF_REPLAY+=( "${(j: :)${(q)@}}" ); }
+# ]]]
+# Compatibility functions. [[[
+❮▼❯() { zi "$@"; }
+zpcdreplay() { zicdreplay "$@"; }
+zpcdclear() { zicdclear "$@"; }
+zpcompinit() { zicompinit "$@"; }
+zpcompdef() { zicompdef "$@"; }
 # ]]]
 # FUNCTION: @autoload. [[[
 @autoload() {

--- a/zi.zsh
+++ b/zi.zsh
@@ -2915,6 +2915,10 @@ zpcdreplay() { zicdreplay "$@"; }
 zpcdclear() { zicdclear "$@"; }
 zpcompinit() { zicompinit "$@"; }
 zpcompdef() { zicompdef "$@"; }
+zpextract() {
+  (( ${+functions[ziextract]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/install.zsh" || return 1
+  ziextract "$@"
+}
 # ]]]
 # FUNCTION: @autoload. [[[
 @autoload() {


### PR DESCRIPTION
## Summary

- restore documented `zpcdreplay`, `zpcdclear`, `zpcompinit`, and `zpcompdef` wrappers
- restore the `❮▼❯` command wrapper and `zpextract` compatibility name
- dispatch `zi -V`, `zi --version`, and `zi version` identically

## Validation

- `zsh -n zi.zsh lib/zsh/install.zsh`
- `git diff --check`
- clean-shell startup exposes every documented compatibility helper
- `zi -V` and `zi --version` report the current checkout version
- `zpcompdef` delegates to the current completion replay implementation
- signed commit verified locally

Closes #369.
