### PR TITLE
fix(times): preserve lowercase seconds flag

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1959,7 +1959,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
       (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )) && sice=( "${(Q)tmp[@]}" ) || sice=()
     fi
     local attime=$(( ZI[$entry3] - ZI[START_TIME] ))
-    if (( OPTS[opt_-S,--seconds] )); then
+    if (( OPTS[opt_-S,--seconds] || OPTS[opt_-s,--snippets] )); then
       local time="$ZI[$entry] s"
       attime="${(M)attime#*.???} s"
     else

--- a/zi.zsh
+++ b/zi.zsh
@@ -2310,7 +2310,7 @@ zi() {
     --force    opt_-f,--force
     -p         opt_-p,--parallel:"Turn on concurrent, multi-thread update (of all objects)."
     --parallel opt_-p,--parallel
-    -s         opt_-s,--snippets:"Update only snippets (i.e.: skip updating plugins)."
+    -s         opt_-s,--snippets:"update:[Update only snippets (i.e.: skip updating plugins).] times:[Show times in seconds.]"
     --snippets opt_-s,--snippets
     -L         opt_-l,--plugins:"Update only plugins (i.e.: skip updating snippets)."
     -l         opt_-l,--plugins
@@ -2339,7 +2339,7 @@ zi() {
     cdclear       "-h|--help|-q|--quiet"
     cdreplay      "-h|--help|-q|--quiet"
     module        "-h|--help|-B|--build|-I|--info|-r|--reset"
-    times         "-h|--help|-m|--moments|-S|--seconds|-a|--all"
+    times         "-h|--help|-m|--moments|-s|-S|--seconds|-a|--all"
     light         "-h|--help|-b|--bindkeys"
     report        "-h|--help|-a|--all"
     snippet       "-h|--help|-f|--force|--command|-x"


### PR DESCRIPTION
## Summary

- preserve documented `zi times -s` behavior
- retain `zi times -S` and `zi times --seconds`
- keep `zi update -s` mapped to snippets through command-specific option handling

## Validation

- `zsh -n zi.zsh lib/zsh/autoload.zsh`
- `git diff --check`
- both `zi times -s` and `zi times -S` display seconds
- `zi update -s -h` still describes snippets-only updates
- signed commit verified locally

Closes #371.
