### PR TITLE
ci: add promotion readiness gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,8 @@
     - Ordinary work: create feature-<id> or bug-<id> from next and target next
     - Urgent production fixes: use a same-repository hotfix-<id> from main to main
     - Promote next to main only after integration checks pass
+    - For next-to-main promotions, use:
+      ?template=promotion.md
 
   Commit messages must follow Conventional Commits:
     type(scope): short description   (≤72 chars, imperative mood)

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -1,0 +1,101 @@
+# Promotion readiness record
+
+Use this template only for a same-repository `next` to `main` promotion.
+Ordinary work continues to target `next`; urgent production fixes use a
+same-repository `hotfix-*` branch.
+
+## Candidate identity
+
+- Prior `main` SHA: `____________________________`
+- Candidate `next` SHA: `____________________________`
+- Complete compare:
+  [`main...next`](https://github.com/z-shell/zi/compare/BASE_SHA...HEAD_SHA)
+
+Replace `BASE_SHA` and `HEAD_SHA` in the compare link with the exact SHAs above.
+The PR head SHA must still equal the recorded candidate SHA before merge.
+
+## Required validation
+
+The `Promotion gate` check is the ruleset context. It directly depends on every
+constituent below and fails if any constituent fails, is cancelled, or is
+skipped.
+
+| Validation                                | Stable job name             | Result  |
+| ----------------------------------------- | --------------------------- | ------- |
+| Zsh syntax and compile                    | `Zsh syntax and compile`    | Pending |
+| ZD ZUnit integration                      | `ZD integration`            | Pending |
+| Trunk                                     | `Trunk`                     | Pending |
+| CodeQL                                    | `CodeQL`                    | Pending |
+| Exact-candidate clean install and startup | `Clean install and startup` | Pending |
+| Aggregate                                 | `Promotion gate`            | Pending |
+
+- [ ] `z-shell/zd#95` is merged and the reusable workflow pin represents its
+      immutable Zi-SHA contract.
+- [ ] `z-shell/zd#96` is merged and the reusable workflow pin includes its
+      focused compatibility tests.
+- [ ] The candidate SHA has not changed since all required checks completed.
+
+## Readiness review
+
+### Unresolved issues
+
+List each unresolved issue and its disposition. Write `None` only after checking
+the promotion candidate and linked release work.
+
+### User-facing and migration notes
+
+Summarize behavioral changes. If no migration is required, state why.
+
+### Public-contract follow-ups
+
+Link documentation and consumer follow-ups identified by the
+[#376 public-contract impact review](https://github.com/z-shell/zi/issues/376).
+Write `None` only with a rationale.
+
+## Rollback readiness
+
+- Rollback owner: `@________________`
+- Observable rollback criteria:
+  - `____________________________________________________________`
+- [ ] The prior `main` SHA above is confirmed immediately before merge.
+- [ ] The owner can open a same-repository `hotfix-*` PR that reverts the
+      promotion commit through protected `main`.
+- [ ] The revert PR will run `Guard main branch source` and `Promotion gate`.
+- [ ] After a revert, clean install and startup will be confirmed at the new
+      `main` head.
+
+Never force-push `main`. Roll back with a reviewed revert commit through the
+protected-branch hotfix path so the incident and recovery remain auditable.
+
+## Publication boundary
+
+Merging this promotion updates the Git-consumed `main` branch. It does not
+create a semantic tag or GitHub release. Tagging remains a separately approved
+publication action under [#346](https://github.com/z-shell/zi/issues/346), with
+its own release notes and green validation.
+
+## Bootstrap and post-merge ruleset change
+
+Do not change repository settings from the implementation PR. GitHub evaluates
+`pull_request` workflow definitions from the default branch, so merging this
+file only into `next` cannot activate it for a `next` to `main` PR.
+
+After the implementation and both ZD dependencies are merged:
+
+1. Create `hotfix-377-promotion-bootstrap` from `main`.
+2. Copy the reviewed promotion workflow and templates from `next` without other
+   pending `next` changes.
+3. Open the same-repository hotfix PR into protected `main`. The existing exact
+   context `Guard main branch source` must pass. Do not bypass or force-push.
+4. Merge the bootstrap PR, then open the `next` to `main` promotion PR. Confirm
+   that all constituent jobs and the exact context `Promotion gate` run.
+5. Update only the active `main` ruleset's required status checks: keep
+   `Guard main branch source` and add `Promotion gate`.
+6. Keep strict required-status-check policy disabled unless maintainers approve
+   a separate policy change.
+7. Do not add constituent contexts; `Promotion gate` owns their dependency
+   semantics, and the ZD reusable workflow expands to matrix checks.
+
+Leave the `next` ruleset unchanged. Promotion validation runs only for PRs into
+`main`, so ordinary PRs into `next` remain lightweight. After the promotion,
+reconcile `main` back into `next` through the protected pull-request process.

--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -1,0 +1,174 @@
+---
+name: Promotion Readiness
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zsh:
+    name: Zsh syntax and compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install -yq zsh
+
+      - name: Check and compile Zsh sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          checked=0
+          while IFS= read -r -d '' file; do
+            zsh -n "${file}"
+            zsh -fc 'zcompile "$1"' _ "${file}"
+            rm -f "${file}.zwc"
+            checked=$((checked + 1))
+          done < <(
+            find . -type d -name doc -prune -o \
+              -type f \( -name '*.zsh' -o -name '_zi' \) -print0
+          )
+          if ((checked == 0)); then
+            echo "::error::No Zsh sources were found."
+            exit 1
+          fi
+
+  zd:
+    name: ZD integration
+    uses: z-shell/zd/.github/workflows/test-native.yml@da915fd260112430aa34981aed3d4e0262f33b87 # z-shell/zd#95
+    with:
+      zi_repo: ${{ github.event.pull_request.head.repo.full_name }}
+      zi_ref: ${{ github.event.pull_request.head.sha }}
+
+  trunk:
+    name: Trunk
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Trunk
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          build-mode: none
+          languages: actions
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: /language:actions
+
+  clean-install:
+    name: Clean install and startup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install -yq zsh
+
+      - name: Install and start the exact candidate
+        shell: bash
+        env:
+          CANDIDATE_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          checkout="${RUNNER_TEMP}/zi-candidate"
+          data_root="${RUNNER_TEMP}/zi-fresh-data"
+
+          test ! -e "${checkout}"
+          test ! -e "${data_root}"
+
+          git init "${checkout}"
+          git -C "${checkout}" remote add origin \
+            "https://github.com/${CANDIDATE_REPOSITORY}.git"
+          git -C "${checkout}" fetch --no-tags --depth 1 origin -- \
+            "${CANDIDATE_SHA}"
+          git -C "${checkout}" checkout --detach FETCH_HEAD
+          test "$(git -C "${checkout}" rev-parse HEAD)" = "${CANDIDATE_SHA}"
+
+          mkdir -p \
+            "${data_root}/home" \
+            "${data_root}/cache" \
+            "${data_root}/config"
+          env \
+            CANDIDATE_SHA="${CANDIDATE_SHA}" \
+            HOME="${data_root}/home" \
+            XDG_CACHE_HOME="${data_root}/cache" \
+            XDG_CONFIG_HOME="${data_root}/config" \
+            XDG_DATA_HOME="${data_root}/data" \
+            ZDOTDIR="${data_root}/zdotdir" \
+            ZI_CHECKOUT="${checkout}" \
+            zsh -f <<'ZSH'
+          builtin source "${ZI_CHECKOUT}/zi.zsh" || exit 1
+          [[ ${ZI[BIN_DIR]} = ${ZI_CHECKOUT} ]] || exit 1
+          [[ "$(git -C "${ZI[BIN_DIR]}" rev-parse HEAD)" = ${CANDIDATE_SHA} ]] ||
+            exit 1
+          (( ${+functions[zi]} )) || exit 1
+          .zi-prepare-home || exit 1
+          [[ -d ${ZI[HOME_DIR]} ]] || exit 1
+          zi -V >/dev/null || exit 1
+          ZSH
+
+  gate:
+    name: Promotion gate
+    if: ${{ always() }}
+    needs: [zsh, zd, trunk, codeql, clean-install]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require every promotion validation
+        env:
+          ZSH_RESULT: ${{ needs.zsh.result }}
+          ZD_RESULT: ${{ needs.zd.result }}
+          TRUNK_RESULT: ${{ needs.trunk.result }}
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+          CLEAN_INSTALL_RESULT: ${{ needs.clean-install.result }}
+        run: |
+          failed=0
+          for result_name in \
+            ZSH_RESULT \
+            ZD_RESULT \
+            TRUNK_RESULT \
+            CODEQL_RESULT \
+            CLEAN_INSTALL_RESULT
+          do
+            result="${!result_name}"
+            if [[ "${result}" != success ]]; then
+              echo "::error::${result_name} was '${result}', not 'success'."
+              failed=1
+            fi
+          done
+          exit "${failed}"

--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   zd-test:
-    uses: z-shell/zd/.github/workflows/test-native.yml@cbb1211f6a39f9d89a600297883b3766d4fa8ab9 # main
+    uses: z-shell/zd/.github/workflows/test-native.yml@da915fd260112430aa34981aed3d4e0262f33b87 # z-shell/zd#95
     with:
       zi_repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      zi_ref: ${{ github.head_ref || github.ref_name }}
+      zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary

- add a dedicated `main` PR workflow that directly runs Zsh syntax/compile, immutable-SHA ZD integration, Trunk, CodeQL, and an exact-candidate clean-install/startup smoke test
- expose `Promotion gate`, which fails unless every constituent job reports `success`
- add a promotion readiness record covering candidate SHAs, compare link, unresolved issues, migration and contract notes, rollback ownership, and the separate semantic-tag boundary
- update ordinary ZD integration to use the PR head SHA for pull requests and `github.sha` for pushes with read-only contents permission

Part of #377

## Validation

- `trunk check --no-fix --filter=actionlint,markdownlint,prettier,git-diff-check .github/workflows/promotion-readiness.yml .github/workflows/zd-integration.yml .github/PULL_REQUEST_TEMPLATE.md .github/PULL_REQUEST_TEMPLATE/promotion.md`
- Zsh syntax and compile validation for all 9 discovered sources
- fresh-home Zi source/startup smoke test
- aggregate gate positive and skipped-constituent negative tests
- `git diff --check`

## Dependencies and activation

This PR remains draft while [z-shell/zd#95](https://github.com/z-shell/zd/pull/95) and the stacked compatibility suite in [z-shell/zd#96](https://github.com/z-shell/zd/pull/96) are unmerged. The current immutable pin is the reviewed #95 commit; it must be updated to the reviewed commit containing #96 before promotion readiness can be considered complete.

GitHub reads `pull_request` workflow definitions from the default branch. After this change and both ZD dependencies are merged, the reviewed promotion infrastructure must be bootstrapped onto `main` through a same-repository `hotfix-377-promotion-bootstrap` PR before opening the large `next` to `main` promotion. No rulesets are changed by this PR.

After the bootstrap workflow has run on a real promotion PR, keep `Guard main branch source` and add the exact required context `Promotion gate` to the active `main` ruleset. Leave the `next` ruleset unchanged so ordinary PRs remain lightweight.