### PR TITLE
ci(contract): add public impact gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,8 @@
 # Changes here affect every Zi user; require TSC review.
 /zi.zsh                             @z-shell/tsc
 /lib/                               @z-shell/tsc
+/contracts/                         @z-shell/tsc
+/scripts/public-contract-impact.zsh @z-shell/tsc
 
 # ── CI / Workflows ───────────────────────────────────────────────────────────
 # Workflow changes reviewed by primary maintainer; no TSC sign-off required.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,3 +47,15 @@
 - [ ] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
 - [ ] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
 - [ ] Documentation updated if needed
+
+## Migration plan
+
+<!--
+Required only when Public Contract Impact reports a destructive change.
+Link or describe the migration, then add one line per reported impact:
+
+[contract-impact:reported-id] updated here
+[contract-impact:reported-id] follow-up issue linked: https://github.com/OWNER/REPO/issues/NNN
+[contract-impact:reported-id] not affected: rationale
+[contract-impact:reported-id] deprecated with removal target: version/date/issue
+-->

--- a/.github/workflows/public-contract-impact.yml
+++ b/.github/workflows/public-contract-impact.yml
@@ -27,22 +27,29 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -yq jq zsh
 
-      - name: Test public contract detector
-        run: zsh tests/public-contract-impact.zsh
-
       - name: Prepare trusted detector
         id: detector
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          trusted_root="$RUNNER_TEMP/trusted-contract"
+          mkdir -p "$trusted_root"
           if git cat-file -e "${BASE_SHA}:scripts/public-contract-impact.zsh" 2>/dev/null; then
-            git show "${BASE_SHA}:scripts/public-contract-impact.zsh" > "$RUNNER_TEMP/public-contract-impact.zsh"
+            git archive "$BASE_SHA" \
+              contracts/public-contract-v1.json \
+              scripts/public-contract-impact.zsh \
+              tests |
+              tar -x -C "$trusted_root"
             echo "policy_arg=" >> "$GITHUB_OUTPUT"
+            echo "has_trusted_tests=true" >> "$GITHUB_OUTPUT"
           else
-            cp scripts/public-contract-impact.zsh "$RUNNER_TEMP/public-contract-impact.zsh"
+            mkdir -p "$trusted_root/scripts"
+            cp scripts/public-contract-impact.zsh "$trusted_root/scripts/public-contract-impact.zsh"
             echo "policy_arg=--no-policy" >> "$GITHUB_OUTPUT"
+            echo "has_trusted_tests=false" >> "$GITHUB_OUTPUT"
             echo "::notice title=Public contract bootstrap::The base branch has no trusted detector; this introducing run is informational-only."
           fi
+          echo "root=$trusted_root" >> "$GITHUB_OUTPUT"
 
       - name: Compare public contract
         env:
@@ -51,4 +58,27 @@ jobs:
           POLICY_ARG: ${{ steps.detector.outputs.policy_arg }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: zsh "$RUNNER_TEMP/public-contract-impact.zsh" --base "$BASE_SHA" --head "$HEAD_SHA" ${POLICY_ARG:+"$POLICY_ARG"}
+          TRUSTED_ROOT: ${{ steps.detector.outputs.root }}
+        run: zsh "$TRUSTED_ROOT/scripts/public-contract-impact.zsh" --base "$BASE_SHA" --head "$HEAD_SHA" ${POLICY_ARG:+"$POLICY_ARG"}
+
+      - name: Test trusted public contract detector
+        if: steps.detector.outputs.has_trusted_tests == 'true'
+        env:
+          TRUSTED_ROOT: ${{ steps.detector.outputs.root }}
+        run: cd "$TRUSTED_ROOT" && zsh tests/public-contract-impact.zsh
+
+  detector-head-tests:
+    name: Public contract detector tests
+    needs: contract-impact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -yq jq zsh
+
+      - name: Test pull request detector
+        run: zsh tests/public-contract-impact.zsh

--- a/.github/workflows/public-contract-impact.yml
+++ b/.github/workflows/public-contract-impact.yml
@@ -1,0 +1,54 @@
+---
+name: Public Contract Impact
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+concurrency:
+  group: public-contract-impact-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  contract-impact:
+    name: Public contract impact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -yq jq zsh
+
+      - name: Test public contract detector
+        run: zsh tests/public-contract-impact.zsh
+
+      - name: Prepare trusted detector
+        id: detector
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git cat-file -e "${BASE_SHA}:scripts/public-contract-impact.zsh" 2>/dev/null; then
+            git show "${BASE_SHA}:scripts/public-contract-impact.zsh" > "$RUNNER_TEMP/public-contract-impact.zsh"
+            echo "policy_arg=" >> "$GITHUB_OUTPUT"
+          else
+            cp scripts/public-contract-impact.zsh "$RUNNER_TEMP/public-contract-impact.zsh"
+            echo "policy_arg=--no-policy" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Public contract bootstrap::The base branch has no trusted detector; this introducing run is informational-only."
+          fi
+
+      - name: Compare public contract
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          POLICY_ARG: ${{ steps.detector.outputs.policy_arg }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: zsh "$RUNNER_TEMP/public-contract-impact.zsh" --base "$BASE_SHA" --head "$HEAD_SHA" ${POLICY_ARG:+"$POLICY_ARG"}

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -66,7 +66,7 @@
     {
       "repository": "z-shell/wiki",
       "path": "ecosystem/annexes/0_overview.mdx",
-      "surfaces": ["annex-registration", "hook-registration"],
+      "surfaces": ["annex-registration"],
       "evidence": "https://github.com/z-shell/wiki/blob/7fca4272b6fbb40afeaa2c25288c1089d887c7d4/ecosystem/annexes/0_overview.mdx"
     },
     {

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,0 +1,204 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "evidence_reviewed": "2026-08-15",
+  "renames": [],
+  "surfaces": [
+    {
+      "id": "commands",
+      "kind": "token-set",
+      "file": "zi.zsh",
+      "assignment": "ZI[cmd-list]",
+      "description": "Tokens accepted as Zi subcommands"
+    },
+    {
+      "id": "ices",
+      "kind": "token-set",
+      "file": "zi.zsh",
+      "assignment": "ZI[ice-list]",
+      "description": "Built-in ice modifier tokens"
+    },
+    {
+      "id": "annex-registration",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "@zi-register-annex",
+      "description": "Annex registration API positional signature"
+    },
+    {
+      "id": "hook-registration",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "@zi-register-hook",
+      "description": "Hook registration API positional signature"
+    },
+    {
+      "id": "compatibility-functions",
+      "kind": "function-region",
+      "file": "zi.zsh",
+      "start_marker": "# Compatibility functions. [[[",
+      "end_marker": "# ]]]",
+      "description": "Named compatibility wrapper functions"
+    },
+    {
+      "id": "prezto-compatibility",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "pmodload",
+      "presence_only": true,
+      "description": "Prezto compatibility function"
+    },
+    {
+      "id": "compatibility-aliases",
+      "kind": "aliases",
+      "file": "zi.zsh",
+      "target": "zi",
+      "description": "Deprecated command-name aliases targeting zi (currently zini, zinit, and zplugin)"
+    },
+    {
+      "id": "installer-git-output",
+      "kind": "path",
+      "path": "lib/zsh/git-process-output.zsh",
+      "description": "Installer-facing progress filter consumed by z-shell/src"
+    }
+  ],
+  "consumers": [
+    {
+      "repository": "z-shell/wiki",
+      "path": "ecosystem/annexes/0_overview.mdx",
+      "surfaces": ["annex-registration", "hook-registration"],
+      "evidence": "https://github.com/z-shell/wiki/blob/7fca4272b6fbb40afeaa2c25288c1089d887c7d4/ecosystem/annexes/0_overview.mdx"
+    },
+    {
+      "repository": "z-shell/docs",
+      "path": "code/zsdoc/asciidoc/zi.zsh.adoc",
+      "surfaces": [
+        "commands",
+        "ices",
+        "annex-registration",
+        "hook-registration",
+        "compatibility-functions",
+        "prezto-compatibility",
+        "compatibility-aliases"
+      ],
+      "evidence": "https://github.com/z-shell/docs/blob/77f0d7d30eb090ce335fcb6fe21fd09c55dc6bd7/code/zsdoc/asciidoc/zi.zsh.adoc"
+    },
+    {
+      "repository": "z-shell/src",
+      "path": "public/sh/install.sh",
+      "surfaces": ["installer-git-output"],
+      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/sh/install.sh"
+    },
+    {
+      "repository": "z-shell/src",
+      "path": "public/zsh/init.zsh",
+      "surfaces": ["installer-git-output"],
+      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/zsh/init.zsh"
+    },
+    {
+      "repository": "z-shell/zd",
+      "path": "tests/helpers.zsh",
+      "surfaces": [
+        "commands",
+        "ices",
+        "annex-registration",
+        "hook-registration",
+        "compatibility-functions",
+        "prezto-compatibility",
+        "compatibility-aliases",
+        "installer-git-output"
+      ],
+      "evidence": "https://github.com/z-shell/zd/blob/3380ddef839309c5886ee0addb4fcb114639d7c4/tests/helpers.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-rust",
+      "path": "z-a-rust.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-rust/blob/c896c792baf4bc5d24468e0109534a174316afb9/z-a-rust.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-patch-dl",
+      "path": "z-a-patch-dl.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-patch-dl/blob/abd2e081725ccc4d50924a88ad6214178abe138c/z-a-patch-dl.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-submods",
+      "path": "z-a-submods.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-submods/blob/a2fe5a60260879470dc7d4dc2c2ca6c05e145623/z-a-submods.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-readurl",
+      "path": "z-a-readurl.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-readurl/blob/60a2dfdfcc7f9fd416c894b2f875c582d2b45c64/z-a-readurl.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-bin-gem-node",
+      "path": "z-a-bin-gem-node.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-bin-gem-node/blob/5584f8a451b175c466a2d3f1b620b7187868226f/z-a-bin-gem-node.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-default-ice",
+      "path": "z-a-default-ice.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-default-ice/blob/9a5eda0d6eedc8a6c3af1fbbda1c444d47062fe1/z-a-default-ice.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-linkman",
+      "path": "z-a-linkman.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-linkman/blob/81e91309ab490c4e6167e7eeab20d1e925a7eb30/z-a-linkman.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-unscope",
+      "path": "z-a-unscope.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-unscope/blob/137dad6ff2fa552015d274e23f91beabe93b0d1c/z-a-unscope.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-man",
+      "path": "z-a-man.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-man/blob/d8ab407a445d394a7738296daf2fcb7951d9cc93/z-a-man.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-meta-plugins",
+      "path": "z-a-meta-plugins.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-meta-plugins/blob/caf156e15148031df6a144f0a8f8c88627eda78a/z-a-meta-plugins.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/z-a-test",
+      "path": "z-a-test.plugin.zsh",
+      "surfaces": ["annex-registration"],
+      "evidence": "https://github.com/z-shell/z-a-test/blob/7a75709aab32988279676b1574bf24a824acb2ff/z-a-test.plugin.zsh"
+    },
+    {
+      "repository": "z-shell/F-Sy-H",
+      "path": "chroma/-zi.ch",
+      "surfaces": ["ices"],
+      "evidence": "https://github.com/z-shell/F-Sy-H/blob/e9f6487a654ae870154fd9e3384853f37ae01087/chroma/-zi.ch"
+    },
+    {
+      "repository": "z-shell/zsh-lint",
+      "path": "legacy/functions/zsh-lint",
+      "surfaces": ["ices"],
+      "evidence": "https://github.com/z-shell/zsh-lint/blob/5c6cf1337803921a062560eec477cc93f2e590b8/legacy/functions/zsh-lint"
+    },
+    {
+      "repository": "z-shell/pm-perf-test",
+      "path": "zi-turbo/.zshrc",
+      "surfaces": ["compatibility-functions"],
+      "evidence": "https://github.com/z-shell/pm-perf-test/blob/c705f881837f8e3cc6c04a3efebcd1ba9c338742/zi-turbo/.zshrc"
+    },
+    {
+      "repository": "z-shell/subversion",
+      "path": "docs/README.md",
+      "surfaces": ["compatibility-functions"],
+      "evidence": "https://github.com/z-shell/subversion/blob/6d4f18be2b0c61790bf94325d8bc857625328253/docs/README.md"
+    }
+  ]
+}

--- a/scripts/public-contract-impact.zsh
+++ b/scripts/public-contract-impact.zsh
@@ -84,9 +84,32 @@ validate_manifest() {
     and (.surfaces | type == "array")
     and (.consumers | type == "array")
     and all(.surfaces[];
-      (.id | type == "string" and length > 0)
+      . as $surface
+      | (.id | type == "string" and test("^[a-z0-9][a-z0-9._-]*$"))
       and (.kind | IN("token-set", "function", "function-region", "aliases", "path"))
       and (.description | type == "string" and length > 0)
+      and (
+        if $surface.kind == "token-set" then
+          ($surface.file | type == "string" and length > 0)
+          and ($surface.assignment | type == "string" and length > 0)
+        elif $surface.kind == "function" then
+          ($surface.file | type == "string" and length > 0)
+          and ($surface.symbol | type == "string" and length > 0)
+          and (($surface.presence_only // false) | type == "boolean")
+        elif $surface.kind == "function-region" then
+          ($surface.file | type == "string" and length > 0)
+          and ($surface.start_marker | type == "string" and length > 0)
+          and ($surface.end_marker | type == "string" and length > 0)
+        elif $surface.kind == "aliases" then
+          ($surface.file | type == "string" and length > 0)
+          and ($surface.target | type == "string" and length > 0)
+        elif $surface.kind == "path" then
+          ($surface.path | type == "string" and length > 0)
+          and (($surface.path | startswith("/")) | not)
+        else
+          false
+        end
+      )
     )
     and ([.surfaces[].id] | length == (unique | length))
     and all(.consumers[];
@@ -138,7 +161,7 @@ extract_token_set() {
       rest="${rest[2,-1]}"
       collecting=1
     else
-      rest="$line"
+      rest="${line##[[:space:]]#}"
     fi
 
     trimmed="${rest%%[[:space:]]#}"
@@ -157,15 +180,21 @@ extract_token_set() {
 
 function_body_arity() {
   local source_file="$1" symbol="$2"
-  local line code compact body=""
+  local line code compact pending="" body=""
   local needle="${symbol}(){"
   integer found=0
 
   while IFS= read -r line; do
     code="${line%%\#*}"
+    if [[ $code == *\\ ]]; then
+      pending+="${code%\\}"
+      continue
+    fi
+    code="${pending}${code}"
+    pending=""
     compact="${code//[ $'\t']/}"
     if (( ! found )); then
-      [[ $compact == *"$needle"* ]] || continue
+      [[ $compact == "$needle"* || $compact == *'||'"$needle"* ]] || continue
       found=1
     fi
     body+="${code}"$'\n'
@@ -184,7 +213,7 @@ function_body_arity() {
 
 extract_function_region() {
   local source_file="$1" start_marker="$2" end_marker="$3" output="$4"
-  local line code compact name
+  local line code compact declaration name pending=""
   integer in_region=0
 
   while IFS= read -r line; do
@@ -194,10 +223,24 @@ extract_function_region() {
     fi
     [[ $line == *"$end_marker"* ]] && break
     code="${line%%\#*}"
+    if [[ $code == *\\ ]]; then
+      pending+="${code%\\}"
+      continue
+    fi
+    code="${pending}${code}"
+    pending=""
     compact="${code//[ $'\t']/}"
-    if [[ $compact == (#b)(*)'(){'* ]]; then
-      name="${match[1]}"
-      [[ -n $name ]] && print -r -- "${name}"$'\t'"variadic"
+    if [[ $compact =~ '^([^()]*)\(\)\{' ]]; then
+      declaration="${match[1]}"
+      if [[ $declaration == *'||'* ]]; then
+        name="${declaration##*'||'}"
+      elif [[ $declaration == *('&&'|'|'|';')* ]]; then
+        continue
+      else
+        name="$declaration"
+      fi
+      [[ -n $name && $name != *('&&'|'|'|';')* ]] &&
+        print -r -- "${name}"$'\t'"variadic"
     fi
   done < "$source_file" | LC_ALL=C sort -u > "$output"
 }
@@ -442,9 +485,20 @@ if (( $(jq -r '.contract_version' "$base_manifest") > 0 )); then
 fi
 
 typeset consumers_manifest="$temp_dir/consumers.json"
-jq -s '{
-  consumers: ([.[].consumers[]] | unique_by([.repository, .path, .surfaces, .evidence]))
-}' "$base_manifest" "$head_manifest" > "$consumers_manifest"
+jq -s '
+  def by_identity:
+    map({
+      key: (.repository + "\u001f" + .path),
+      value: .
+    })
+    | from_entries;
+
+  (.[0].consumers | by_identity) as $base
+  | (.[1].consumers | by_identity) as $head
+  | {
+      consumers: (($base + $head) | to_entries | map(.value))
+    }
+' "$base_manifest" "$head_manifest" > "$consumers_manifest"
 
 typeset report="$temp_dir/report.md"
 typeset consumer_lines
@@ -526,12 +580,17 @@ if (( enforce_policy && ${#breaking_impacts} )); then
     (( policy_failures += 1 ))
   fi
 
-  typeset migration_section="" visible_migration="" migration=""
+  typeset migration_section="" visible_migration="" migration_guidance="" migration=""
   if [[ $pr_body == *"## Migration plan"* ]]; then
     migration_section="${pr_body#*"## Migration plan"}"
     migration_section="${migration_section%%$'\n## '*}"
     visible_migration="${migration_section//<!--*-->/}"
-    migration="${visible_migration//[[:space:]]/}"
+    for body_line in "${(@f)visible_migration}"; do
+      trimmed_line="${body_line##[[:space:]]#}"
+      [[ $trimmed_line == '[contract-impact:'* ]] && continue
+      migration_guidance+="${trimmed_line}"
+    done
+    migration="${migration_guidance//[[:space:]]/}"
   fi
   if (( ${#migration} < 20 )); then
     print "::error title=Migration plan required::Add a linked or descriptive ## Migration plan section to the PR body."

--- a/scripts/public-contract-impact.zsh
+++ b/scripts/public-contract-impact.zsh
@@ -1,0 +1,588 @@
+#!/usr/bin/env zsh
+
+emulate -LR zsh
+setopt errexit nounset pipefail extendedglob
+
+typeset repository="."
+typeset manifest_path="contracts/public-contract-v1.json"
+typeset base_ref="" head_ref=""
+integer enforce_policy=1
+
+usage() {
+  print "usage: ${0:t} --base REF --head REF [--repository DIR] [--manifest PATH] [--no-policy]"
+}
+
+while (( $# )); do
+  case "$1" in
+    --base)
+      base_ref="${2-}"
+      shift 2
+      ;;
+    --head)
+      head_ref="${2-}"
+      shift 2
+      ;;
+    --repository)
+      repository="${2-}"
+      shift 2
+      ;;
+    --manifest)
+      manifest_path="${2-}"
+      shift 2
+      ;;
+    --no-policy)
+      enforce_policy=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      print -u2 "public-contract-impact: unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n $base_ref && -n $head_ref ]] || {
+  print -u2 "public-contract-impact: --base and --head are required"
+  exit 2
+}
+
+for command_name in git jq sort tr; do
+  (( $+commands[$command_name] )) || {
+    print -u2 "public-contract-impact: required command not found: $command_name"
+    exit 2
+  }
+done
+
+repository="$(command git -C "$repository" rev-parse --show-toplevel)"
+typeset temp_dir
+temp_dir="$(command mktemp -d "${TMPDIR:-/tmp}/zi-contract.XXXXXXXX")"
+trap 'command rm -rf -- "$temp_dir"' EXIT INT TERM
+
+typeset empty_manifest='{"schema_version":1,"contract_version":0,"renames":[],"surfaces":[],"consumers":[]}'
+typeset base_manifest="$temp_dir/base-manifest.json"
+typeset head_manifest="$temp_dir/head-manifest.json"
+
+materialize_manifest() {
+  local ref="$1" destination="$2"
+  if ! command git -C "$repository" show "${ref}:${manifest_path}" > "$destination" 2>/dev/null; then
+    print -r -- "$empty_manifest" > "$destination"
+  fi
+}
+
+validate_manifest() {
+  local file="$1" label="$2"
+  jq -e '
+    . as $manifest
+    | .schema_version == 1
+    and (.contract_version | type == "number")
+    and (.renames | type == "array")
+    and (.surfaces | type == "array")
+    and (.consumers | type == "array")
+    and all(.surfaces[];
+      (.id | type == "string" and length > 0)
+      and (.kind | IN("token-set", "function", "function-region", "aliases", "path"))
+      and (.description | type == "string" and length > 0)
+    )
+    and ([.surfaces[].id] | length == (unique | length))
+    and all(.consumers[];
+      . as $consumer
+      | ("https://github.com/" + $consumer.repository + "/blob/") as $prefix
+      | ($consumer.evidence | ltrimstr($prefix)) as $evidence_path
+      | ($consumer.repository | test("^z-shell/[A-Za-z0-9_.-]+$"))
+      and ($consumer.path | type == "string" and length > 0)
+      and (($consumer.path | startswith("/")) | not)
+      and ($consumer.surfaces | type == "array" and length > 0)
+      and ($consumer.evidence | startswith($prefix))
+      and ($evidence_path | test("^[0-9a-f]{40}/"))
+      and ($evidence_path[41:] == $consumer.path)
+    )
+    and ([.consumers[].surfaces[]] - [.surfaces[].id] | length == 0)
+    and ([
+      .surfaces[].id
+      | . as $id
+      | any($manifest.consumers[]; .surfaces | index($id))
+    ] | all)
+  ' "$file" >/dev/null || {
+    print -u2 "public-contract-impact: invalid ${label} manifest: ${manifest_path}"
+    exit 2
+  }
+}
+
+materialize_manifest "$base_ref" "$base_manifest"
+materialize_manifest "$head_ref" "$head_manifest"
+validate_manifest "$base_manifest" base
+validate_manifest "$head_manifest" head
+
+materialize_file() {
+  local ref="$1" file_path="$2" destination="$3"
+  command git -C "$repository" show "${ref}:${file_path}" > "$destination" 2>/dev/null
+}
+
+extract_token_set() {
+  local source_file="$1" assignment="$2" output="$3"
+  local line trimmed rest value="" token
+  integer collecting=0
+
+  while IFS= read -r line; do
+    if (( ! collecting )); then
+      trimmed="${line##[[:space:]]#}"
+      [[ ${trimmed%%=*} == "$assignment" ]] || continue
+      rest="${trimmed#*=}"
+      rest="${rest##[[:space:]]#}"
+      [[ ${rest[1]-} == '"' ]] || continue
+      rest="${rest[2,-1]}"
+      collecting=1
+    else
+      rest="$line"
+    fi
+
+    trimmed="${rest%%[[:space:]]#}"
+    if [[ ${trimmed[-1]-} == '"' ]]; then
+      value+="${trimmed[1,-2]}"
+      collecting=0
+      break
+    fi
+    value+="${trimmed%\\}"
+  done < "$source_file"
+
+  for token in "${(@s:|:)value}"; do
+    [[ -n $token ]] && print -r -- "${token}"$'\t'"${token}"
+  done | LC_ALL=C sort -u > "$output"
+}
+
+function_body_arity() {
+  local source_file="$1" symbol="$2"
+  local line code compact body=""
+  local needle="${symbol}(){"
+  integer found=0
+
+  while IFS= read -r line; do
+    code="${line%%\#*}"
+    compact="${code//[ $'\t']/}"
+    if (( ! found )); then
+      [[ $compact == *"$needle"* ]] || continue
+      found=1
+    fi
+    body+="${code}"$'\n'
+    [[ $compact == '}' ]] && break
+  done < "$source_file"
+
+  (( found )) || return 1
+  local arity
+  arity="$(print -r -- "$body" |
+    command grep -oE '\$\{?[0-9]+' 2>/dev/null |
+    command grep -oE '[0-9]+' 2>/dev/null |
+    LC_ALL=C sort -n |
+    command tail -1 || true)"
+  print -r -- "${arity:-0}"
+}
+
+extract_function_region() {
+  local source_file="$1" start_marker="$2" end_marker="$3" output="$4"
+  local line code compact name
+  integer in_region=0
+
+  while IFS= read -r line; do
+    if (( ! in_region )); then
+      [[ $line == *"$start_marker"* ]] && in_region=1
+      continue
+    fi
+    [[ $line == *"$end_marker"* ]] && break
+    code="${line%%\#*}"
+    compact="${code//[ $'\t']/}"
+    if [[ $compact == (#b)(*)'(){'* ]]; then
+      name="${match[1]}"
+      [[ -n $name ]] && print -r -- "${name}"$'\t'"variadic"
+    fi
+  done < "$source_file" | LC_ALL=C sort -u > "$output"
+}
+
+extract_aliases() {
+  local source_file="$1" target="$2" output="$3"
+  local line code token name alias_target
+
+  while IFS= read -r line; do
+    code="${line%%\#*}"
+    [[ $code == *"builtin alias"* ]] || continue
+    for token in ${(z)code}; do
+      [[ $token == *=* ]] || continue
+      name="${token%%=*}"
+      alias_target="${token#*=}"
+      [[ $alias_target == "$target" ]] || continue
+      print -r -- "${name}"$'\t'"${alias_target}"
+    done
+  done < "$source_file" | LC_ALL=C sort -u > "$output"
+}
+
+extract_surface() {
+  local ref="$1" definition="$2" output="$3"
+  local kind file source_file symbol arity
+  : > "$output"
+  kind="$(jq -r '.kind' <<< "$definition")"
+
+  case "$kind" in
+    path)
+      file="$(jq -r '.path' <<< "$definition")"
+      if command git -C "$repository" cat-file -e "${ref}:${file}" 2>/dev/null; then
+        print -r -- "${file}"$'\t'"exists" > "$output"
+      fi
+      ;;
+    token-set|function|function-region|aliases)
+      file="$(jq -r '.file' <<< "$definition")"
+      source_file="$temp_dir/source-${RANDOM}-${RANDOM}"
+      materialize_file "$ref" "$file" "$source_file" || return 0
+      case "$kind" in
+        token-set)
+          extract_token_set "$source_file" "$(jq -r '.assignment' <<< "$definition")" "$output"
+          ;;
+        function)
+          symbol="$(jq -r '.symbol' <<< "$definition")"
+          if arity="$(function_body_arity "$source_file" "$symbol")"; then
+            if [[ $(jq -r '.presence_only // false' <<< "$definition") == true ]]; then
+              arity="present"
+            fi
+            print -r -- "${symbol}"$'\t'"${arity}" > "$output"
+          fi
+          ;;
+        function-region)
+          extract_function_region \
+            "$source_file" \
+            "$(jq -r '.start_marker' <<< "$definition")" \
+            "$(jq -r '.end_marker' <<< "$definition")" \
+            "$output"
+          ;;
+        aliases)
+          extract_aliases "$source_file" "$(jq -r '.target' <<< "$definition")" "$output"
+          ;;
+      esac
+      ;;
+    *)
+      print -u2 "public-contract-impact: unsupported surface kind: $kind"
+      exit 2
+      ;;
+  esac
+}
+
+typeset -a impacts=()
+
+impact_id() {
+  local raw="$1"
+  local id
+  id="$(print -rn -- "$raw" |
+    LC_ALL=C tr '[:upper:]' '[:lower:]' |
+    LC_ALL=C tr -cs '[:alnum:]._/-' '-')"
+  id="${id##-##}"
+  id="${id%%-##}"
+  print -r -- "$id"
+}
+
+record_impact() {
+  local severity="$1" classification="$2" surface="$3" before="$4" after="$5" summary="$6"
+  local id
+  id="$(impact_id "${surface}/${classification}/${before:-none}-to-${after:-none}")"
+  impacts+=( "${severity}"$'\x1f'"${id}"$'\x1f'"${classification}"$'\x1f'"${surface}"$'\x1f'"${before}"$'\x1f'"${after}"$'\x1f'"${summary}" )
+}
+
+compare_surface() {
+  local surface_id="$1" kind="$2" base_snapshot="$3" head_snapshot="$4"
+  typeset -A base_items=() head_items=()
+  typeset -a additions=() removals=()
+  local item detail
+
+  while IFS=$'\t' read -r item detail; do
+    [[ -n $item ]] && base_items[$item]="$detail"
+  done < "$base_snapshot"
+  while IFS=$'\t' read -r item detail; do
+    [[ -n $item ]] && head_items[$item]="$detail"
+  done < "$head_snapshot"
+
+  for item in ${(ok)base_items}; do
+    (( ${+head_items[$item]} )) || removals+=( "$item" )
+  done
+  for item in ${(ok)head_items}; do
+    (( ${+base_items[$item]} )) || additions+=( "$item" )
+  done
+
+  if (( ${#removals} == 1 && ${#additions} == 1 )) &&
+    jq -e \
+      --arg surface "$surface_id" \
+      --arg from "$removals[1]" \
+      --arg to "$additions[1]" \
+      'any(.renames[]?; .surface == $surface and .from == $from and .to == $to)' \
+      "$head_manifest" >/dev/null; then
+    record_impact breaking rename "$surface_id" "$removals[1]" "$additions[1]" \
+      "\`${removals[1]}\` was replaced by \`${additions[1]}\`."
+  else
+    for item in "${removals[@]}"; do
+      record_impact breaking removal "$surface_id" "$item" "" "\`${item}\` was removed."
+    done
+    for item in "${additions[@]}"; do
+      record_impact info addition "$surface_id" "" "$item" "\`${item}\` was added."
+    done
+  fi
+
+  for item in ${(ok)base_items}; do
+    (( ${+head_items[$item]} )) || continue
+    [[ ${base_items[$item]} == ${head_items[$item]} ]] && continue
+    case "$kind" in
+      function)
+        if [[ ${base_items[$item]} == <-> && ${head_items[$item]} == <-> ]] &&
+          (( head_items[$item] < base_items[$item] )); then
+          record_impact breaking signature-narrowing "$surface_id" \
+            "${item}/${base_items[$item]}-args" "${item}/${head_items[$item]}-args" \
+            "\`${item}\` narrowed from ${base_items[$item]} to ${head_items[$item]} positional arguments."
+        else
+          record_impact info compatible-signature-change "$surface_id" \
+            "${item}/${base_items[$item]}" "${item}/${head_items[$item]}" \
+            "\`${item}\` changed from ${base_items[$item]} to ${head_items[$item]}."
+        fi
+        ;;
+      aliases)
+        record_impact breaking retargeting "$surface_id" \
+          "${item}=${base_items[$item]}" "${item}=${head_items[$item]}" \
+          "\`${item}\` was retargeted from \`${base_items[$item]}\` to \`${head_items[$item]}\`."
+        ;;
+    esac
+  done
+}
+
+typeset -a surface_ids
+typeset surface_id base_definition head_definition base_semantics head_semantics kind
+typeset base_snapshot head_snapshot
+surface_ids=( "${(@f)$(jq -r -s '[.[].surfaces[].id] | unique[]' "$base_manifest" "$head_manifest")}" )
+for surface_id in "${surface_ids[@]}"; do
+  [[ -n $surface_id ]] || continue
+  base_definition="$(jq -c --arg id "$surface_id" '.surfaces[] | select(.id == $id)' "$base_manifest")"
+  head_definition="$(jq -c --arg id "$surface_id" '.surfaces[] | select(.id == $id)' "$head_manifest")"
+
+  if [[ -z $base_definition ]]; then
+    record_impact info contract-definition-addition "$surface_id" "" "$surface_id" \
+      "Monitoring for \`${surface_id}\` was added to contract version $(jq -r '.contract_version' "$head_manifest")."
+    continue
+  fi
+  if [[ -z $head_definition ]]; then
+    record_impact breaking contract-definition-removal "$surface_id" "$surface_id" "" \
+      "Monitoring for \`${surface_id}\` was removed from the versioned definition."
+    continue
+  fi
+
+  base_semantics="$(jq -Sc 'del(.description)' <<< "$base_definition")"
+  head_semantics="$(jq -Sc 'del(.description)' <<< "$head_definition")"
+  if [[ $base_semantics != "$head_semantics" ]]; then
+    record_impact breaking contract-definition-change "$surface_id" \
+      "base-definition" "head-definition" \
+      "The extraction definition changed; this requires explicit review because it can alter monitoring coverage."
+  fi
+
+  kind="$(jq -r '.kind' <<< "$head_definition")"
+  base_snapshot="$temp_dir/base-${surface_id}.tsv"
+  head_snapshot="$temp_dir/head-${surface_id}.tsv"
+  extract_surface "$base_ref" "$base_definition" "$base_snapshot"
+  extract_surface "$head_ref" "$head_definition" "$head_snapshot"
+  compare_surface "$surface_id" "$kind" "$base_snapshot" "$head_snapshot"
+done
+
+compare_consumers() {
+  local base_file="$1" head_file="$2"
+  typeset -A base_consumers=() head_consumers=()
+  local surface repository_name consumer_path evidence key
+
+  while IFS=$'\t' read -r surface repository_name consumer_path evidence; do
+    [[ -n $surface ]] || continue
+    key="${surface}"$'\t'"${repository_name}"$'\t'"${consumer_path}"
+    base_consumers[$key]="$evidence"
+  done < <(jq -r '
+    .consumers[]
+    | . as $consumer
+    | .surfaces[]
+    | [., $consumer.repository, $consumer.path, $consumer.evidence]
+    | @tsv
+  ' "$base_file")
+
+  while IFS=$'\t' read -r surface repository_name consumer_path evidence; do
+    [[ -n $surface ]] || continue
+    key="${surface}"$'\t'"${repository_name}"$'\t'"${consumer_path}"
+    head_consumers[$key]="$evidence"
+  done < <(jq -r '
+    .consumers[]
+    | . as $consumer
+    | .surfaces[]
+    | [., $consumer.repository, $consumer.path, $consumer.evidence]
+    | @tsv
+  ' "$head_file")
+
+  for key in ${(ok)base_consumers}; do
+    IFS=$'\t' read -r surface repository_name consumer_path <<< "$key"
+    if (( ! ${+head_consumers[$key]} )); then
+      record_impact breaking consumer-evidence-removal "$surface" \
+        "${repository_name}:${consumer_path}" "" \
+        "Checked-in consumer evidence for \`${repository_name}:${consumer_path}\` was removed."
+    elif [[ ${base_consumers[$key]} != ${head_consumers[$key]} ]]; then
+      record_impact info consumer-evidence-refresh "$surface" \
+        "${repository_name}:${consumer_path}" "${repository_name}:${consumer_path}" \
+        "Evidence for \`${repository_name}:${consumer_path}\` was refreshed."
+    fi
+  done
+  for key in ${(ok)head_consumers}; do
+    (( ${+base_consumers[$key]} )) && continue
+    IFS=$'\t' read -r surface repository_name consumer_path <<< "$key"
+    record_impact info consumer-evidence-addition "$surface" "" \
+      "${repository_name}:${consumer_path}" \
+      "Checked-in consumer evidence for \`${repository_name}:${consumer_path}\` was added."
+  done
+}
+
+if (( $(jq -r '.contract_version' "$base_manifest") > 0 )); then
+  compare_consumers "$base_manifest" "$head_manifest"
+fi
+
+typeset consumers_manifest="$temp_dir/consumers.json"
+jq -s '{
+  consumers: ([.[].consumers[]] | unique_by([.repository, .path, .surfaces, .evidence]))
+}' "$base_manifest" "$head_manifest" > "$consumers_manifest"
+
+typeset report="$temp_dir/report.md"
+typeset consumer_lines
+{
+  print "## Public contract impact"
+  print
+  print -r -- "- Base: \`${base_ref}\`"
+  print -r -- "- Head: \`${head_ref}\`"
+  print -r -- "- Definition: \`${manifest_path}\` (schema v1, contract v$(jq -r '.contract_version' "$head_manifest"))"
+  print
+  print "### Monitored contract"
+  print
+  jq -r '.surfaces[] | "- `\(.id)` — \(.description)"' "$head_manifest"
+  print
+
+  if (( ! ${#impacts} )); then
+    print "No public-contract changes detected."
+  else
+    print "### Impacts"
+    print
+    print "| Classification | Surface | Change | Policy |"
+    print "| --- | --- | --- | --- |"
+    for impact in "${impacts[@]}"; do
+      IFS=$'\x1f' read -r severity id classification surface before after summary <<< "$impact"
+      if [[ $severity == breaking ]]; then
+        policy="breaking gate"
+      else
+        policy="informational"
+      fi
+      print "| \`${classification}\` | \`${surface}\` | ${summary} | ${policy} |"
+    done
+    print
+    print "### Likely consumers"
+    print
+    typeset -A reported_surfaces=()
+    for impact in "${impacts[@]}"; do
+      IFS=$'\x1f' read -r severity id classification surface before after summary <<< "$impact"
+      (( ${+reported_surfaces[$surface]} )) && continue
+      reported_surfaces[$surface]=1
+      print "#### \`${surface}\`"
+      consumer_lines="$(jq -r --arg surface "$surface" '
+        .consumers[]
+        | select(.surfaces | index($surface))
+        | "- [`\(.repository):\(.path)`](\(.evidence))"
+      ' "$consumers_manifest")"
+      if [[ -n $consumer_lines ]]; then
+        print -r -- "$consumer_lines"
+      else
+        print -r -- "- No checked-in consumer reference is currently recorded."
+      fi
+      print
+    done
+  fi
+} > "$report"
+
+integer policy_failures=0
+typeset -a breaking_impacts=()
+typeset annotation_message
+for impact in "${impacts[@]}"; do
+  IFS=$'\x1f' read -r severity id classification surface before after summary <<< "$impact"
+  [[ $severity == breaking ]] && breaking_impacts+=( "$impact" )
+  annotation_message="${surface}: ${summary}"
+  annotation_message="${annotation_message//'%'/'%25'}"
+  annotation_message="${annotation_message//$'\r'/'%0D'}"
+  annotation_message="${annotation_message//$'\n'/'%0A'}"
+  if [[ $severity == breaking ]]; then
+    print "::error title=Public contract ${classification}::${annotation_message}"
+  else
+    print "::notice title=Public contract ${classification}::${annotation_message}"
+  fi
+done
+
+if (( enforce_policy && ${#breaking_impacts} )); then
+  typeset labels_json="${PR_LABELS_JSON-[]}"
+  typeset pr_body="${PR_BODY-}"
+  typeset marker disposition_line disposition body_line trimmed_line
+  if ! jq -e 'index("breaking-change") != null' <<< "$labels_json" >/dev/null 2>&1; then
+    print "::error title=Breaking-change label required::Add the breaking-change label."
+    (( policy_failures += 1 ))
+  fi
+
+  typeset migration_section="" visible_migration="" migration=""
+  if [[ $pr_body == *"## Migration plan"* ]]; then
+    migration_section="${pr_body#*"## Migration plan"}"
+    migration_section="${migration_section%%$'\n## '*}"
+    visible_migration="${migration_section//<!--*-->/}"
+    migration="${visible_migration//[[:space:]]/}"
+  fi
+  if (( ${#migration} < 20 )); then
+    print "::error title=Migration plan required::Add a linked or descriptive ## Migration plan section to the PR body."
+    (( policy_failures += 1 ))
+  fi
+
+  for impact in "${breaking_impacts[@]}"; do
+    IFS=$'\x1f' read -r severity id classification surface before after summary <<< "$impact"
+    marker="[contract-impact:${id}]"
+    disposition_line=""
+    for body_line in "${(@f)visible_migration}"; do
+      trimmed_line="${body_line##[[:space:]]#}"
+      if [[ ${trimmed_line[1,${#marker}]-} == "$marker" ]]; then
+        disposition_line="${trimmed_line[${#marker}+1,-1]-}"
+        break
+      fi
+    done
+    disposition="${disposition_line##[[:space:]]#}"
+    if [[ $disposition == "updated here"* ]]; then
+      continue
+    elif [[ $disposition == "follow-up issue linked:"*https://github.com/*/issues/<->* ]]; then
+      continue
+    elif [[ ${#disposition} -ge 24 && $disposition == "not affected:"?* ]]; then
+      continue
+    elif [[ $disposition == "deprecated with removal target:"?* ]]; then
+      continue
+    fi
+    print "::error title=Impact disposition required::Add ${marker} followed by an allowed disposition."
+    (( policy_failures += 1 ))
+  done
+fi
+
+if (( ${#breaking_impacts} )); then
+  {
+    print
+    print "### Breaking-change policy"
+    print
+    print "Destructive impacts require the \`breaking-change\` label, a descriptive \`## Migration plan\`, and one PR-body line per impact:"
+    print
+    for impact in "${breaking_impacts[@]}"; do
+      IFS=$'\x1f' read -r severity id classification surface before after summary <<< "$impact"
+      print -r -- "- \`[contract-impact:${id}] updated here\`"
+    done
+    print
+    print "Allowed dispositions are \`updated here\`, \`follow-up issue linked: <issue URL>\`, \`not affected: <rationale>\`, and \`deprecated with removal target: <target>\`."
+  } >> "$report"
+fi
+
+command cat "$report"
+if [[ -n ${GITHUB_STEP_SUMMARY-} ]]; then
+  command cat "$report" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+(( policy_failures == 0 ))

--- a/tests/fixtures/public-contract/addition/zi.zsh
+++ b/tests/fixtures/public-contract/addition/zi.zsh
@@ -1,0 +1,26 @@
+ZI[ice-list]="wait|load|atclone|debug"
+ZI[cmd-list]="help|load|update|doctor"
+
+@zi-register-annex() {
+  local name="$1" type="$2" handler="$3" helphandler="$4" icemods="$5"
+}
+
+@zi-register-hook() {
+  local name="$1" type="$2" handler="$3" icemods="$4"
+}
+
+(( ${+functions[pmodload]} )) || pmodload() {
+  print -r -- "$@"
+}
+
+# Compatibility functions. [[[
+❮▼❯() { zi "$@"; }
+zpcdreplay() { zicdreplay "$@"; }
+zpcdclear() { zicdclear "$@"; }
+zpcompinit() { zicompinit "$@"; }
+zpcompdef() { zicompdef "$@"; }
+zpextract() { ziextract "$@"; }
+zplegacy() { zi "$@"; }
+# ]]]
+
+(( ZI[INTERNAL_ALIASES] )) && builtin alias zini=zi zinit=zi zplugin=zi

--- a/tests/fixtures/public-contract/base/lib/zsh/git-process-output.zsh
+++ b/tests/fixtures/public-contract/base/lib/zsh/git-process-output.zsh
@@ -1,0 +1,3 @@
+#!/usr/bin/env zsh
+
+command cat

--- a/tests/fixtures/public-contract/base/zi.zsh
+++ b/tests/fixtures/public-contract/base/zi.zsh
@@ -1,0 +1,25 @@
+ZI[ice-list]="wait|load|atclone"
+ZI[cmd-list]="help|load|update"
+
+@zi-register-annex() {
+  local name="$1" type="$2" handler="$3" helphandler="$4" icemods="$5"
+}
+
+@zi-register-hook() {
+  local name="$1" type="$2" handler="$3" icemods="$4"
+}
+
+(( ${+functions[pmodload]} )) || pmodload() {
+  print -r -- "$@"
+}
+
+# Compatibility functions. [[[
+❮▼❯() { zi "$@"; }
+zpcdreplay() { zicdreplay "$@"; }
+zpcdclear() { zicdclear "$@"; }
+zpcompinit() { zicompinit "$@"; }
+zpcompdef() { zicompdef "$@"; }
+zpextract() { ziextract "$@"; }
+# ]]]
+
+(( ZI[INTERNAL_ALIASES] )) && builtin alias zini=zi zinit=zi zplugin=zi

--- a/tests/fixtures/public-contract/breaking/zi.zsh
+++ b/tests/fixtures/public-contract/breaking/zi.zsh
@@ -1,0 +1,24 @@
+ZI[ice-list]="wait|load|atclone"
+ZI[cmd-list]="help|fetch|update"
+
+@zi-register-annex() {
+  local name="$1" type="$2" handler="$3" helphandler="$4"
+}
+
+@zi-register-hook() {
+  local name="$1" type="$2" handler="$3" icemods="$4"
+}
+
+(( ${+functions[pmodload]} )) || pmodload() {
+  print -r -- "$@"
+}
+
+# Compatibility functions. [[[
+❮▼❯() { zi "$@"; }
+zpcdreplay() { zicdreplay "$@"; }
+zpcompinit() { zicompinit "$@"; }
+zpcompdef() { zicompdef "$@"; }
+zpextract() { ziextract "$@"; }
+# ]]]
+
+(( ZI[INTERNAL_ALIASES] )) && builtin alias zini=zi zinit=zi

--- a/tests/fixtures/public-contract/conditional/zi.zsh
+++ b/tests/fixtures/public-contract/conditional/zi.zsh
@@ -1,7 +1,5 @@
-ZI[ice-list]="wait|load|\
-  atclone"
-ZI[cmd-list]="help|load|\
-  update"
+ZI[ice-list]="wait|load|atclone"
+ZI[cmd-list]="help|load|update"
 
 @zi-register-annex() {
   local name="$1" type="$2" handler="$3" helphandler="$4" icemods="$5"
@@ -11,14 +9,16 @@ ZI[cmd-list]="help|load|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
-(( ${+functions[pmodload]} )) || pmodload() {
+false && \
+  pmodload() {
   print -r -- "$@"
 }
 
 # Compatibility functions. [[[
 ❮▼❯() { zi "$@"; }
 zpcdreplay() { zicdreplay "$@"; }
-zpcdclear() { zicdclear "$@"; }
+false && \
+  zpcdclear() { zicdclear "$@"; }
 zpcompinit() { zicompinit "$@"; }
 zpcompdef() { zicompdef "$@"; }
 zpextract() { ziextract "$@"; }

--- a/tests/fixtures/public-contract/refactor/zi.zsh
+++ b/tests/fixtures/public-contract/refactor/zi.zsh
@@ -1,0 +1,37 @@
+# A comment mentioning fake() and ZI[cmd-list]="removed" is not a contract.
+ZI[ice-list]="atclone|\
+wait|load"
+ZI[cmd-list]="update|help|\
+load"
+
+@zi-register-annex () {
+  # $99 in a comment must not narrow or widen the signature.
+  local name="$1"
+  local type="$2" handler="$3"
+  local helphandler="$4" icemods="$5"
+}
+
+@zi-register-hook() {
+  local name="$1"
+  local type="$2"
+  local handler="$3"
+  local icemods="$4"
+}
+
+(( ${+functions[pmodload]} )) || pmodload () {
+  print -r -- "$@"
+}
+
+# Compatibility functions. [[[
+❮▼❯ () { zi "$@"; }
+zpcdreplay () { zicdreplay "$@"; }
+zpcdclear () { zicdclear "$@"; }
+zpcompinit () { zicompinit "$@"; }
+zpcompdef () { zicompdef "$@"; }
+zpextract () { ziextract "$@"; }
+# fake-compat() { :; }
+# ]]]
+
+internal_helper() { :; }
+(( ZI[INTERNAL_ALIASES] )) &&
+  builtin alias zplugin=zi zini=zi zinit=zi

--- a/tests/fixtures/public-contract/refactor/zi.zsh
+++ b/tests/fixtures/public-contract/refactor/zi.zsh
@@ -1,8 +1,8 @@
 # A comment mentioning fake() and ZI[cmd-list]="removed" is not a contract.
 ZI[ice-list]="atclone|\
-wait|load"
+    wait|load"
 ZI[cmd-list]="update|help|\
-load"
+      load"
 
 @zi-register-annex () {
   # $99 in a comment must not narrow or widen the signature.

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -1,0 +1,179 @@
+#!/usr/bin/env zsh
+
+emulate -LR zsh
+setopt errexit nounset pipefail
+
+typeset project_root="${0:A:h:h}"
+typeset fixture_root="${project_root}/tests/fixtures/public-contract"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-contract-test.XXXXXXXX")"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  print -u2 "not ok - $1"
+  exit 1
+}
+
+assert_contains() {
+  local output="$1" expected="$2"
+  [[ $output == *"$expected"* ]] || fail "expected output to contain: $expected"
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2"
+  [[ $output != *"$unexpected"* ]] || fail "expected output not to contain: $unexpected"
+}
+
+new_case_repository() {
+  local name="$1"
+  local repository="${temp_root}/${name}"
+  command mkdir -p "$repository/contracts" "$repository/lib/zsh"
+  command cp "$project_root/contracts/public-contract-v1.json" "$repository/contracts/"
+  command cp "$fixture_root/base/zi.zsh" "$repository/zi.zsh"
+  command cp "$fixture_root/base/lib/zsh/git-process-output.zsh" "$repository/lib/zsh/"
+  command git -C "$repository" init -q
+  command git -C "$repository" config user.name "Contract Test"
+  command git -C "$repository" config user.email "contract-test@example.invalid"
+  command git -C "$repository" add .
+  command git -C "$repository" commit -qm "test: base contract"
+  command git -C "$repository" tag base
+  print -r -- "$repository"
+}
+
+run_detector() {
+  local repository="$1"
+  shift
+  zsh "$project_root/scripts/public-contract-impact.zsh" \
+    --repository "$repository" \
+    --base base \
+    --head HEAD \
+    "$@"
+}
+
+typeset repository output
+
+repository="$(new_case_repository refactor)"
+command cp "$fixture_root/refactor/zi.zsh" "$repository/zi.zsh"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "refactor: reformat internals"
+output="$(run_detector "$repository" --no-policy)"
+assert_contains "$output" "No public-contract changes detected."
+print "ok - comments, formatting, ordering, and internal refactors are ignored"
+
+repository="$(new_case_repository addition)"
+command cp "$fixture_root/addition/zi.zsh" "$repository/zi.zsh"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "feat: add contracts"
+output="$(run_detector "$repository")"
+assert_contains "$output" '`addition`'
+assert_contains "$output" '`doctor` was added'
+assert_contains "$output" '`debug` was added'
+assert_contains "$output" '`zplegacy` was added'
+print "ok - additions are informational"
+
+repository="$(new_case_repository replacement)"
+command cp "$fixture_root/breaking/zi.zsh" "$repository/zi.zsh"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "feat: remove and add independently"
+output="$(run_detector "$repository" --no-policy)"
+assert_contains "$output" '`load` was removed'
+assert_contains "$output" '`fetch` was added'
+assert_not_contains "$output" '`rename`'
+print "ok - independent removals and additions are not inferred as renames"
+
+repository="$(new_case_repository breaking)"
+command cp "$fixture_root/breaking/zi.zsh" "$repository/zi.zsh"
+command rm "$repository/lib/zsh/git-process-output.zsh"
+changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq '.renames += [{"surface":"commands","from":"load","to":"fetch"}]' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add -A
+command git -C "$repository" commit -qm "feat!: alter contracts"
+if output="$(run_detector "$repository" 2>&1)"; then
+  fail "breaking changes passed without policy metadata"
+fi
+assert_contains "$output" '`rename`'
+assert_contains "$output" '`signature-narrowing`'
+assert_contains "$output" '`removal`'
+assert_contains "$output" "Breaking-change label required"
+assert_contains "$output" "Migration plan required"
+
+typeset -a impact_markers
+impact_markers=( "${(@f)$(print -r -- "$output" | command grep -o '\[contract-impact:[^]]*\]' | LC_ALL=C sort -u)}" )
+typeset pr_body="## Migration plan
+Consumers migrate using https://github.com/z-shell/zi/issues/376."
+typeset marker
+for marker in "${impact_markers[@]}"; do
+  pr_body+=$'\n'"${marker} updated here"
+done
+
+typeset commented_body="## Migration plan
+Consumers migrate using https://github.com/z-shell/zi/issues/376."
+for marker in "${impact_markers[@]}"; do
+  commented_body+=$'\n'"<!-- ${marker} updated here -->"
+done
+if output="$(
+  PR_LABELS_JSON='["breaking-change"]' \
+  PR_BODY="$commented_body" \
+    run_detector "$repository" 2>&1
+)"; then
+  fail "hidden disposition comments passed the breaking-change gate"
+fi
+assert_contains "$output" "Impact disposition required"
+
+output="$(
+  PR_LABELS_JSON='["breaking-change"]' \
+  PR_BODY="$pr_body" \
+    run_detector "$repository"
+)"
+assert_contains "$output" "Breaking-change policy"
+print "ok - destructive changes require label, migration plan, and dispositions"
+
+repository="$(new_case_repository manifest-tampering)"
+typeset changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq '(.surfaces[] | select(.id == "annex-registration")).presence_only = true' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: weaken contract definition"
+output="$(run_detector "$repository" --no-policy)"
+assert_contains "$output" '`contract-definition-change`'
+print "ok - extraction-definition changes are destructive impacts"
+
+repository="$(new_case_repository invalid-evidence)"
+changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq '.consumers[0].evidence = "https://github.com/z-shell/wiki/blob/main/example"' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: unpin evidence"
+if output="$(run_detector "$repository" --no-policy 2>&1)"; then
+  fail "mutable consumer evidence passed manifest validation"
+fi
+assert_contains "$output" "invalid head manifest"
+print "ok - consumer evidence must be complete and SHA-pinned"
+
+repository="$(new_case_repository mismatched-evidence)"
+changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq '.consumers[0].repository = "z-shell/zd" | .consumers[0].path = "tests/helpers.zsh"' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: mismatch evidence identity"
+if output="$(run_detector "$repository" --no-policy 2>&1)"; then
+  fail "consumer evidence for another repo and path passed validation"
+fi
+assert_contains "$output" "invalid head manifest"
+print "ok - evidence URLs must match their declared repository and path"
+
+repository="$(new_case_repository consumer-removal)"
+changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq 'del(.consumers[] | select(.repository == "z-shell/pm-perf-test"))' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: remove consumer evidence"
+output="$(run_detector "$repository" --no-policy)"
+assert_contains "$output" '`consumer-evidence-removal`'
+print "ok - removing consumer evidence is a destructive impact"

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -60,6 +60,16 @@ output="$(run_detector "$repository" --no-policy)"
 assert_contains "$output" "No public-contract changes detected."
 print "ok - comments, formatting, ordering, and internal refactors are ignored"
 
+repository="$(new_case_repository conditional)"
+command cp "$fixture_root/conditional/zi.zsh" "$repository/zi.zsh"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: guard compatibility function with false"
+output="$(run_detector "$repository" --no-policy)"
+assert_contains "$output" '`zpcdclear` was removed'
+assert_contains "$output" '`pmodload` was removed'
+assert_not_contains "$output" 'false&&zpcdclear'
+print "ok - dead conditional function definitions are unavailable across logical lines"
+
 repository="$(new_case_repository addition)"
 command cp "$fixture_root/addition/zi.zsh" "$repository/zi.zsh"
 command git -C "$repository" add .
@@ -108,6 +118,19 @@ for marker in "${impact_markers[@]}"; do
   pr_body+=$'\n'"${marker} updated here"
 done
 
+typeset marker_only_body="## Migration plan"
+for marker in "${impact_markers[@]}"; do
+  marker_only_body+=$'\n'"${marker} updated here"
+done
+if output="$(
+  PR_LABELS_JSON='["breaking-change"]' \
+  PR_BODY="$marker_only_body" \
+    run_detector "$repository" 2>&1
+)"; then
+  fail "dispositions without migration guidance passed the breaking-change gate"
+fi
+assert_contains "$output" "Migration plan required"
+
 typeset commented_body="## Migration plan
 Consumers migrate using https://github.com/z-shell/zi/issues/376."
 for marker in "${impact_markers[@]}"; do
@@ -140,6 +163,42 @@ command git -C "$repository" commit -qm "test: weaken contract definition"
 output="$(run_detector "$repository" --no-policy)"
 assert_contains "$output" '`contract-definition-change`'
 print "ok - extraction-definition changes are destructive impacts"
+
+typeset malformed_id malformed_field
+for malformed_id malformed_field in \
+  commands assignment \
+  annex-registration symbol \
+  hook-registration file \
+  compatibility-functions start_marker \
+  compatibility-aliases target \
+  installer-git-output path; do
+  repository="$(new_case_repository "malformed-${malformed_id}-${malformed_field}")"
+  changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+  jq --arg id "$malformed_id" --arg field "$malformed_field" \
+    'del((.surfaces[] | select(.id == $id))[$field])' \
+    "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+  command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+  command git -C "$repository" add .
+  command git -C "$repository" commit -qm "test: remove required surface field"
+  if output="$(run_detector "$repository" --no-policy 2>&1)"; then
+    fail "malformed ${malformed_id}.${malformed_field} passed manifest validation"
+  fi
+  assert_contains "$output" "invalid head manifest"
+done
+print "ok - each surface kind requires its extraction fields"
+
+repository="$(new_case_repository unsafe-surface-id)"
+changed_manifest="${repository}/contracts/public-contract-v1.json.new"
+jq '.surfaces[0].id = "unsafe/id"' \
+  "$repository/contracts/public-contract-v1.json" > "$changed_manifest"
+command mv "$changed_manifest" "$repository/contracts/public-contract-v1.json"
+command git -C "$repository" add .
+command git -C "$repository" commit -qm "test: add unsafe surface id"
+if output="$(run_detector "$repository" --no-policy 2>&1)"; then
+  fail "unsafe surface ID passed manifest validation"
+fi
+assert_contains "$output" "invalid head manifest"
+print "ok - surface IDs are safe for deterministic snapshot paths"
 
 repository="$(new_case_repository invalid-evidence)"
 changed_manifest="${repository}/contracts/public-contract-v1.json.new"


### PR DESCRIPTION
## Description

Adds a deterministic public-contract impact check for Zi behavioral changes. The check compares normalized contract snapshots from the pull-request base and head, writes a job summary, emits annotations, and identifies checked-in likely consumers without searching or modifying other repositories at runtime.

The versioned `contracts/public-contract-v1.json` definition monitors:

- command tokens in `ZI[cmd-list]`;
- ice tokens in `ZI[ice-list]`;
- positional signatures of `@zi-register-annex` and `@zi-register-hook`;
- compatibility functions in the named compatibility region plus `pmodload`;
- deprecated aliases targeting `zi` (`zini`, `zinit`, and `zplugin`);
- installer-facing `lib/zsh/git-process-output.zsh`.

Additions are informational. Removals, explicitly declared renames, signature narrowing, monitor-definition weakening, and consumer-evidence removal require the `breaking-change` label, a visible migration plan, and one explicit disposition per impact. Consumer evidence is checked in with immutable SHA-bound repository/path links covering `wiki`, `docs`, `src`, `zd`, annexes, and known compatibility consumers.

The stable `Public Contract Impact / Public contract impact` check has only `contents: read`, disables persisted checkout credentials, and executes the detector from the trusted base branch after bootstrap. The introducing run is intentionally informational-only because `next` does not yet contain a trusted detector.

Known limitations: positional signatures are inferred from numbered argument references; renames require explicit manifest metadata rather than similarity guessing; the consumer manifest reflects reviewed in-organization evidence as of 2026-08-15 and must be maintained as references move.

## Related issues

Closes #376

## Type of change

- [ ] `fix` — bug fix (non-breaking)
- [ ] `feat` — new feature (non-breaking)
- [ ] `feat!` / `fix!` — breaking change
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change with no functional impact
- [x] `docs` — documentation only
- [x] `test` — test addition or correction
- [ ] `build` — build system or dependency change
- [x] `ci` — CI/workflow change
- [ ] `style` — formatting with no behavior change
- [ ] `chore` — maintenance / dependency bump
- [ ] `revert` — revert of an earlier change

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailers in commit messages
- [x] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
- [x] Documentation updated if needed

## Validation

- `zsh tests/public-contract-impact.zsh`
- `zsh -n` across repository Zsh sources and fixtures
- `zcompile` for the detector, test runner, and fixtures
- Trunk `actionlint` and `prettier`
- real `origin/next...HEAD` detector run (eight informational definition additions)

## Migration plan

N/A — this change adds monitoring and does not alter an existing Zi public contract.

