### PR TITLE
fix(module): support CMake build in .zi-module with autotools fallback

### DIFF
--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -2973,8 +2973,11 @@ EOF
       +zi-message "{warn}Warning{warn}{ehi}:{rst} {lhi}recompilation{rst} of the {bcmd}zpmod{rst} module has been requested…"
       (( ${+functions[.zi-confirm]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" || return 1
       .zi-confirm "Do you want to proceed?" || return 1
-      command make -C "${ZI[ZMODULES_DIR]}/zpmod" distclean &>/dev/null
-      .zi-module --build
+      if [[ -f "${ZI[ZMODULES_DIR]}/zpmod/Makefile" ]]; then
+        command make -C "${ZI[ZMODULES_DIR]}/zpmod" distclean &>/dev/null
+      fi
+      command rm -rf "${ZI[ZMODULES_DIR]}/zpmod/build-cmake" "${ZI[ZMODULES_DIR]}/zpmod/build" 2>/dev/null
+      .zi-module --build --clean
     fi
   elif [[ "$1" = (-B|--build|build) ]]; then
     builtin autoload -Uz is-at-least
@@ -2986,7 +2989,7 @@ EOF
           +zi-message "{error}-- Failed to update module repository --{rst}"; return 1
         }
         if [[ "$2" = "--clean" ]]; then
-          +zi-message "{p}-- Module {ok}source is clean{p}, {cmd}make distclean{p} not required --{rst}"
+          +zi-message "{p}-- Module {ok}source is clean{p}, {cmd}clean{p} not required --{rst}"
         fi
       else
         if ! test -d "${${ZI[ZMODULES_DIR]}}/zpmod"; then
@@ -2999,38 +3002,83 @@ EOF
       fi
       ( builtin cd -q "${ZI[ZMODULES_DIR]}/zpmod"
         +zi-message "{p}-- The module sources are located at{ehi}:{rst} {dir}"${ZI[ZMODULES_DIR]}/zpmod"{p} --{rst}"
-        if [[ -f Makefile ]]; then
-          if [[ "$2" = "--clean" ]]; then
-            +zi-message "{p}-- Building module {bcmd}zi/zpmod{p}, running: {cmd}make distclean{p}, then {cmd}./configure{p} and then {cmd}make{p} --{rst}"
-            +zi-message "{p}-- make distclean --{rst}"
-            command make distclean
-            ((1))
-          else
-            +zi-message "{p}-- Building module {bcmd}zi/zpmod{p}, running: {cmd}make clean{p}, then {cmd}./configure{p} and then {cmd}make{p} --{rst}"
-            +zi-message "{p}-- make clean --{rst}"
-            command make clean
-          fi
-        fi
-        +zi-message "{p}-- ./configure --{rst}"
-        ./configure --enable-cflags='-g -Wall -Wextra -O3' --disable-gdbm --without-tcsetpgrp --quiet
-        +zi-message "{p}-- make --{rst}"
-        local cores=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || command getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
         local build_log="${ZI[LOG_DIR]}/zpmod/${EPOCHSECONDS}-build.log"
         command mkdir -p "${ZI[LOG_DIR]}/zpmod" 2>/dev/null
-        command make --jobs=$cores -C "${ZI[ZMODULES_DIR]}/zpmod" 2>&1 | command tee "$build_log" >/dev/null
-        if (( pipestatus[1] == 0 )); then
-          [[ -f Src/zi/zpmod.so ]] && command cp -vf Src/zi/zpmod.so Src/zi/zpmod.bundle
-          builtin print "$EPOCHSECONDS" >! "${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT"
-          +zi-message "{ok}-- Build successful! --{rst}"
-          +zi-message "{faint}-- Build log{ehi}:{rst} {file}$build_log{faint} --{rst}"
-          .zi-module --info
-          return 0
-        else
+        local cores=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || command getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
+        if [[ -f CMakeLists.txt ]]; then
+          +zi-message "{p}-- Building module {bcmd}zi/zpmod{p} with {cmd}CMake{p} --{rst}"
+          local build_rc=0
+          if [[ -x scripts/cmake.configure.zsh ]]; then
+            local -a cmake_opts
+            cmake_opts=( --generator make --build-type Release -j "$cores" )
+            [[ "$2" = "--clean" ]] && cmake_opts+=( --clean )
+            ./scripts/cmake.configure.zsh "${cmake_opts[@]}" 2>&1 | command tee "$build_log" >/dev/null
+            build_rc=${pipestatus[1]}
+          else
+            [[ "$2" = "--clean" ]] && command rm -rf build-cmake
+            command cmake -S . -B build-cmake -DCMAKE_BUILD_TYPE=Release 2>&1 | command tee "$build_log" >/dev/null && \
+            command cmake --build build-cmake -j "$cores" 2>&1 | command tee -a "$build_log" >/dev/null && \
+            command cmake --install build-cmake --prefix build-cmake/stage 2>&1 | command tee -a "$build_log" >/dev/null
+            build_rc=${pipestatus[1]}
+          fi
+          if (( build_rc == 0 )); then
+            local f="" staged_file=""
+            for f in build-cmake/stage/lib/zsh/site-modules/zpmod.*(N) build-cmake/out/lib/zpmod.*(N) build/out/lib/zpmod.*(N) Src/zi/zpmod.so(N); do
+              [[ -f $f ]] && { staged_file="$f"; break; }
+            done
+            if [[ -n $staged_file ]]; then
+              command mkdir -p Src/zi 2>/dev/null
+              command cp -vf "$staged_file" Src/zi/zpmod.so
+              command cp -vf "$staged_file" Src/zi/zpmod.bundle
+              command cp -vf "$staged_file" zpmod.so
+              builtin print "$EPOCHSECONDS" >! "${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT"
+              +zi-message "{ok}-- Build successful! --{rst}"
+              +zi-message "{faint}-- Build log{ehi}:{rst} {file}$build_log{faint} --{rst}"
+              .zi-module --info
+              return 0
+            fi
+          fi
           +zi-message "{error}Build failed{rst}…" \
           "To report an issue at GitHub, please provide error messages from{ehi}:{rst}{nl}" \
           "{ndsh} Build log{rst} {dir}${build_log}{rst} if exists{nl}" \
-          "{ndsh} Run '{cmd}make -C ${ZI[ZMODULES_DIR]}/zpmod{rst}' to reproduce{rst}{nl}" \
+          "{ndsh} Run '{cmd}cmake --build build-cmake{rst}' to reproduce{rst}{nl}" \
           "{ndsh}{rst} {var}URL{rst} to submit{rst} {url}https://github.com/z-shell/zpmod/issues{rst}"
+          return 1
+        elif [[ -f Makefile || -f configure || -f configure.ac ]]; then
+          if [[ -f Makefile ]]; then
+            if [[ "$2" = "--clean" ]]; then
+              +zi-message "{p}-- Building module {bcmd}zi/zpmod{p}, running: {cmd}make distclean{p}, then {cmd}./configure{p} and then {cmd}make{p} --{rst}"
+              +zi-message "{p}-- make distclean --{rst}"
+              command make distclean
+              ((1))
+            else
+              +zi-message "{p}-- Building module {bcmd}zi/zpmod{p}, running: {cmd}make clean{p}, then {cmd}./configure{p} and then {cmd}make{p} --{rst}"
+              +zi-message "{p}-- make clean --{rst}"
+              command make clean
+            fi
+          fi
+          +zi-message "{p}-- ./configure --{rst}"
+          ./configure --enable-cflags='-g -Wall -Wextra -O3' --disable-gdbm --without-tcsetpgrp --quiet
+          +zi-message "{p}-- make --{rst}"
+          command make --jobs=$cores -C "${ZI[ZMODULES_DIR]}/zpmod" 2>&1 | command tee "$build_log" >/dev/null
+          if (( pipestatus[1] == 0 )); then
+            [[ -f Src/zi/zpmod.so ]] && command cp -vf Src/zi/zpmod.so Src/zi/zpmod.bundle
+            builtin print "$EPOCHSECONDS" >! "${ZI[ZMODULES_DIR]}/zpmod/COMPILED_AT"
+            +zi-message "{ok}-- Build successful! --{rst}"
+            +zi-message "{faint}-- Build log{ehi}:{rst} {file}$build_log{faint} --{rst}"
+            .zi-module --info
+            return 0
+          else
+            +zi-message "{error}Build failed{rst}…" \
+            "To report an issue at GitHub, please provide error messages from{ehi}:{rst}{nl}" \
+            "{ndsh} Build log{rst} {dir}${build_log}{rst} if exists{nl}" \
+            "{ndsh} Run '{cmd}make -C ${ZI[ZMODULES_DIR]}/zpmod{rst}' to reproduce{rst}{nl}" \
+            "{ndsh}{rst} {var}URL{rst} to submit{rst} {url}https://github.com/z-shell/zpmod/issues{rst}"
+            return 1
+          fi
+        else
+          +zi-message "{error}No supported build system found in ${ZI[ZMODULES_DIR]}/zpmod (expected CMakeLists.txt or configure){rst}"
           return 1
         fi
       )

--- a/zi.zsh
+++ b/zi.zsh
@@ -1690,7 +1690,7 @@ builtin setopt noaliases
 .zi-add-report() {
   # Use zi binary module if available.
   [[ -n $1 ]] && { (( ${+builtins[zpmod]} && 0 )) && zpmod report-append "$1" "$2"$'\n' || ZI_REPORTS[$1]+="$2"$'\n'; }
-  [[ ${ZI[DTRACE]} = 1 ]] && { (( ${+builtins[zpmod]} )) && zpmod report-append _dtrace/_dtrace "$2"$'\n' || ZI_REPORTS[_dtrace/_dtrace]+="$2"$'\n'; }
+  [[ ${ZI[DTRACE]} = 1 ]] && { (( ${+builtins[zpmod]} && 0 )) && zpmod report-append _dtrace/_dtrace "$2"$'\n' || ZI_REPORTS[_dtrace/_dtrace]+="$2"$'\n'; }
   return 0
 } # ]]]
 # FUNCTION: .zi-add-fpath. [[[


### PR DESCRIPTION
Closes #385

## Summary

- Add CMake build detection and support in `.zi-module()` (`lib/zsh/autoload.zsh`)
- Prefer `scripts/cmake.configure.zsh` if present, falling back to standard `cmake` invocations
- Use nullglob qualifiers `(N)` when discovering built shared objects to prevent unbound glob errors
- Maintain legacy `./configure && make` fallback for classic autotools repositories
- Clean CMake caches on `.zi-module -r` / `--reset`
- Align DTRACE report append fallback condition in `zi.zsh`

## Verification

- `zsh -n zi.zsh` and `zsh -n lib/zsh/autoload.zsh` pass syntax verification
- End-to-end `.zi-module --build` verified against both `zpmod:main` (legacy autotools) and `zpmod:develop` (modern CMake)
- Built module successfully loaded via `zmodload zi/zpmod`