### PR TITLE
fix(pmspec): drop the unallocated X capability letter

### DIFF
--- a/zi.zsh
+++ b/zi.zsh
@@ -13,7 +13,7 @@ typeset -gAH ZI ZI_SNIPPETS ZI_REPORTS ZI_ICES ZI_SICE ZI_CUR_BIND_MAP ZI_EXTS Z
 typeset -gaH ZI_COMPDEF_REPLAY
 
 # The specified names are marked for automatic export to the environment of subsequently executed commands.
-typeset -gx ZPFX XDG_ZI_HOME XDG_ZI_CACHE XDG_ZI_CONFIG PMSPEC=0fuUpiPsX
+typeset -gx ZPFX XDG_ZI_HOME XDG_ZI_CACHE XDG_ZI_CONFIG PMSPEC=0fuUpiPs
 
 # Compatibility for previous versions.
 typeset -gAH ZINIT


### PR DESCRIPTION
Closes #393.

## Problem

Zi advertises `PMSPEC=0fuUpiPsX`. The `X` means nothing.

Four independent checks, all negative:

| Check | Result |
| --- | --- |
| `X` defined in Zi source or docs? | No |
| Does Zi read `PMSPEC` at all? | No, it only ever sets it |
| Does Zinit use `X`? | No, it sets `0uUpiPsf` |
| Consumers across the organization? | Zero, from a scan of all 57 plugin and library entrypoints |

## It looks like edit damage, not a feature

`X` first appears in 6817af2 (#191, 2022-07-16). That pull request
self-describes as "Refactoring (no functional changes)" and ticks "no new
features", and its body never mentions `PMSPEC` or a capability. The same
one-line edit spliced out a neighbouring `ZCDR` assignment:

```diff
-export ZPFX=${~ZPFX} ZCDR="${ZCDR:-…/zi}" PMSPEC=0fuUpiPs \
+export ZPFX=${~ZPFX} PMSPEC=0fuUpiPsX \
```

A capability letter appearing at the exact moment an adjacent assignment was
removed from the same line, in a commit that declared it added nothing, reads
as a slip rather than an allocation.

## Change

Drop `X`, returning Zi to the value it advertised before that refactor.

## Verification

- `zsh -n zi.zsh` passes
- Sourced `zi.zsh` and confirmed the exported value is now `0fuUpiPs`, that no
  `X` remains, and that all eight documented letters `0 f u U p i P s` are
  still present
- No test or other file references the string; `zi.zsh:16` was its only
  occurrence in the repository

## Why this is safe

Nothing reads `X`, so no guard can regress. The
[Zsh Plugin Standard](https://wiki.zshell.dev/community/zsh_plugin_standard#global-parameter-with-capabilities)
requires plugins to feature-test individual letters rather than match a set,
and it defines no conformance target, so a manager advertising one letter
fewer is not thereby non-conforming.

## Follow-up

The standard currently carries a paragraph explaining that Zi advertises an
unallocated letter. Once this merges, that paragraph can be removed and the
observed-values table updated. Tracked in z-shell/wiki#859.