### PR TITLE
ci: bootstrap promotion readiness gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,51 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!--
+  Thanks for contributing to zi! Please read the checklist below.
+
+  Branch model:
+    - Ordinary work: create feature-<id> or bug-<id> from next and target next
+    - Urgent production fixes: use a same-repository hotfix-<id> from main to main
+    - Promote next to main only after integration checks pass
+    - For next-to-main promotions, use:
+      ?template=promotion.md
+
+  Commit messages must follow Conventional Commits:
+    type(scope): short description   (≤72 chars, imperative mood)
+    Types: feat  fix  perf  refactor  docs  test  build  ci  style  chore  revert
+    Example: fix(self-update): correctly propagate exit code on failure
+
+  See AGENTS.md for the repository contribution guidelines.
+-->
 
 ## Description
 
-<!--- Describe your changes in detail -->
+<!-- Describe your changes clearly. What problem does this solve? -->
 
-## Motivation and Context
+## Related issues
 
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
+<!-- Closes #NNN  /  Part of #NNN  /  N/A -->
 
-## How Has This Been Tested?
+## Type of change
 
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+<!-- Put an `x` in all boxes that apply -->
 
-## Screenshots (if appropriate):
+- [ ] `fix` — bug fix (non-breaking)
+- [ ] `feat` — new feature (non-breaking)
+- [ ] `feat!` / `fix!` — breaking change
+- [ ] `perf` — performance improvement
+- [ ] `refactor` — code change with no functional impact
+- [ ] `docs` — documentation only
+- [ ] `test` — test addition or correction
+- [ ] `build` — build system or dependency change
+- [ ] `ci` — CI/workflow change
+- [ ] `style` — formatting with no behavior change
+- [ ] `chore` — maintenance / dependency bump
+- [ ] `revert` — revert of an earlier change
 
-## Types of changes
+## Checklist
 
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update (if none of the other choices apply)
-- [ ] Chore (general maintenance, refactoring, or code style update)
-
-## Checklist:
-
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-
-- [ ] My code follows the code style of this project.
-- [ ] I have read the **CONTRIBUTING** document.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
-- [ ] I have updated the documentation accordingly.
-
-## Other information (if applicable)
-
-<!--- Any other information that is important to this PR such as environment variables, special considerations, etc. -->
+- [ ] Ordinary work targets `next`; only same-repository hotfixes target `main`
+- [ ] Commit messages follow Conventional Commits format
+- [ ] No `Co-authored-by` trailers in commit messages
+- [ ] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
+- [ ] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
+- [ ] Documentation updated if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,51 +1,44 @@
-<!--
-  Thanks for contributing to zi! Please read the checklist below.
-
-  Branch model:
-    - Ordinary work: create feature-<id> or bug-<id> from next and target next
-    - Urgent production fixes: use a same-repository hotfix-<id> from main to main
-    - Promote next to main only after integration checks pass
-    - For next-to-main promotions, use:
-      ?template=promotion.md
-
-  Commit messages must follow Conventional Commits:
-    type(scope): short description   (≤72 chars, imperative mood)
-    Types: feat  fix  perf  refactor  docs  test  build  ci  style  chore  revert
-    Example: fix(self-update): correctly propagate exit code on failure
-
-  See AGENTS.md for the repository contribution guidelines.
--->
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- For next-to-main promotions, open the PR with ?template=promotion.md -->
 
 ## Description
 
-<!-- Describe your changes clearly. What problem does this solve? -->
+<!--- Describe your changes in detail -->
 
-## Related issues
+## Motivation and Context
 
-<!-- Closes #NNN  /  Part of #NNN  /  N/A -->
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
 
-## Type of change
+## How Has This Been Tested?
 
-<!-- Put an `x` in all boxes that apply -->
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
 
-- [ ] `fix` — bug fix (non-breaking)
-- [ ] `feat` — new feature (non-breaking)
-- [ ] `feat!` / `fix!` — breaking change
-- [ ] `perf` — performance improvement
-- [ ] `refactor` — code change with no functional impact
-- [ ] `docs` — documentation only
-- [ ] `test` — test addition or correction
-- [ ] `build` — build system or dependency change
-- [ ] `ci` — CI/workflow change
-- [ ] `style` — formatting with no behavior change
-- [ ] `chore` — maintenance / dependency bump
-- [ ] `revert` — revert of an earlier change
+## Screenshots (if appropriate):
 
-## Checklist
+## Types of changes
 
-- [ ] Ordinary work targets `next`; only same-repository hotfixes target `main`
-- [ ] Commit messages follow Conventional Commits format
-- [ ] No `Co-authored-by` trailers in commit messages
-- [ ] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
-- [ ] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
-- [ ] Documentation updated if needed
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update (if none of the other choices apply)
+- [ ] Chore (general maintenance, refactoring, or code style update)
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] My code follows the code style of this project.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+- [ ] I have updated the documentation accordingly.
+
+## Other information (if applicable)
+
+<!--- Any other information that is important to this PR such as environment variables, special considerations, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -1,0 +1,101 @@
+# Promotion readiness record
+
+Use this template only for a same-repository `next` to `main` promotion.
+Ordinary work continues to target `next`; urgent production fixes use a
+same-repository `hotfix-*` branch.
+
+## Candidate identity
+
+- Prior `main` SHA: `____________________________`
+- Candidate `next` SHA: `____________________________`
+- Complete compare:
+  [`main...next`](https://github.com/z-shell/zi/compare/BASE_SHA...HEAD_SHA)
+
+Replace `BASE_SHA` and `HEAD_SHA` in the compare link with the exact SHAs above.
+The PR head SHA must still equal the recorded candidate SHA before merge.
+
+## Required validation
+
+The `Promotion gate` check is the ruleset context. It directly depends on every
+constituent below and fails if any constituent fails, is cancelled, or is
+skipped.
+
+| Validation                                | Stable job name             | Result  |
+| ----------------------------------------- | --------------------------- | ------- |
+| Zsh syntax and compile                    | `Zsh syntax and compile`    | Pending |
+| ZD ZUnit integration                      | `ZD integration`            | Pending |
+| Trunk                                     | `Trunk`                     | Pending |
+| CodeQL                                    | `CodeQL`                    | Pending |
+| Exact-candidate clean install and startup | `Clean install and startup` | Pending |
+| Aggregate                                 | `Promotion gate`            | Pending |
+
+- [ ] `z-shell/zd#95` is merged and the reusable workflow pin represents its
+      immutable Zi-SHA contract.
+- [ ] `z-shell/zd#96` is merged and the reusable workflow pin includes its
+      focused compatibility tests.
+- [ ] The candidate SHA has not changed since all required checks completed.
+
+## Readiness review
+
+### Unresolved issues
+
+List each unresolved issue and its disposition. Write `None` only after checking
+the promotion candidate and linked release work.
+
+### User-facing and migration notes
+
+Summarize behavioral changes. If no migration is required, state why.
+
+### Public-contract follow-ups
+
+Link documentation and consumer follow-ups identified by the
+[#376 public-contract impact review](https://github.com/z-shell/zi/issues/376).
+Write `None` only with a rationale.
+
+## Rollback readiness
+
+- Rollback owner: `@________________`
+- Observable rollback criteria:
+  - `____________________________________________________________`
+- [ ] The prior `main` SHA above is confirmed immediately before merge.
+- [ ] The owner can open a same-repository `hotfix-*` PR that reverts the
+      promotion commit through protected `main`.
+- [ ] The revert PR will run `Guard main branch source` and `Promotion gate`.
+- [ ] After a revert, clean install and startup will be confirmed at the new
+      `main` head.
+
+Never force-push `main`. Roll back with a reviewed revert commit through the
+protected-branch hotfix path so the incident and recovery remain auditable.
+
+## Publication boundary
+
+Merging this promotion updates the Git-consumed `main` branch. It does not
+create a semantic tag or GitHub release. Tagging remains a separately approved
+publication action under [#346](https://github.com/z-shell/zi/issues/346), with
+its own release notes and green validation.
+
+## Bootstrap and post-merge ruleset change
+
+Do not change repository settings from the implementation PR. GitHub evaluates
+`pull_request` workflow definitions from the default branch, so merging this
+file only into `next` cannot activate it for a `next` to `main` PR.
+
+After the implementation and both ZD dependencies are merged:
+
+1. Create `hotfix-377` from `main`.
+2. Copy the reviewed promotion workflow and templates from `next` without other
+   pending `next` changes.
+3. Open the same-repository hotfix PR into protected `main`. The existing exact
+   context `Guard main branch source` must pass. Do not bypass or force-push.
+4. Merge the bootstrap PR, then open the `next` to `main` promotion PR. Confirm
+   that all constituent jobs and the exact context `Promotion gate` run.
+5. Update only the active `main` ruleset's required status checks: keep
+   `Guard main branch source` and add `Promotion gate`.
+6. Keep strict required-status-check policy disabled unless maintainers approve
+   a separate policy change.
+7. Do not add constituent contexts; `Promotion gate` owns their dependency
+   semantics, and the ZD reusable workflow expands to matrix checks.
+
+Leave the `next` ruleset unchanged. Promotion validation runs only for PRs into
+`main`, so ordinary PRs into `next` remain lightweight. After the promotion,
+reconcile `main` back into `next` through the protected pull-request process.

--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -1,0 +1,174 @@
+---
+name: Promotion Readiness
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zsh:
+    name: Zsh syntax and compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install -yq zsh
+
+      - name: Check and compile Zsh sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          checked=0
+          while IFS= read -r -d '' file; do
+            zsh -n "${file}"
+            zsh -fc 'zcompile "$1"' _ "${file}"
+            rm -f "${file}.zwc"
+            checked=$((checked + 1))
+          done < <(
+            find . -type d -name doc -prune -o \
+              -type f \( -name '*.zsh' -o -name '_zi' \) -print0
+          )
+          if ((checked == 0)); then
+            echo "::error::No Zsh sources were found."
+            exit 1
+          fi
+
+  zd:
+    name: ZD integration
+    uses: z-shell/zd/.github/workflows/test-native.yml@191642eaf9587e64f910c79aaf750d2cfe237241 # z-shell/zd#95, #96
+    with:
+      zi_repo: ${{ github.event.pull_request.head.repo.full_name }}
+      zi_ref: ${{ github.event.pull_request.head.sha }}
+
+  trunk:
+    name: Trunk
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Trunk
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Check out the candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          build-mode: none
+          languages: actions
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: /language:actions
+
+  clean-install:
+    name: Clean install and startup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install -yq zsh
+
+      - name: Install and start the exact candidate
+        shell: bash
+        env:
+          CANDIDATE_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          checkout="${RUNNER_TEMP}/zi-candidate"
+          data_root="${RUNNER_TEMP}/zi-fresh-data"
+
+          test ! -e "${checkout}"
+          test ! -e "${data_root}"
+
+          git init "${checkout}"
+          git -C "${checkout}" remote add origin \
+            "https://github.com/${CANDIDATE_REPOSITORY}.git"
+          git -C "${checkout}" fetch --no-tags --depth 1 origin -- \
+            "${CANDIDATE_SHA}"
+          git -C "${checkout}" checkout --detach FETCH_HEAD
+          test "$(git -C "${checkout}" rev-parse HEAD)" = "${CANDIDATE_SHA}"
+
+          mkdir -p \
+            "${data_root}/home" \
+            "${data_root}/cache" \
+            "${data_root}/config"
+          env \
+            CANDIDATE_SHA="${CANDIDATE_SHA}" \
+            HOME="${data_root}/home" \
+            XDG_CACHE_HOME="${data_root}/cache" \
+            XDG_CONFIG_HOME="${data_root}/config" \
+            XDG_DATA_HOME="${data_root}/data" \
+            ZDOTDIR="${data_root}/zdotdir" \
+            ZI_CHECKOUT="${checkout}" \
+            zsh -f <<'ZSH'
+          builtin source "${ZI_CHECKOUT}/zi.zsh" || exit 1
+          [[ ${ZI[BIN_DIR]} = ${ZI_CHECKOUT} ]] || exit 1
+          [[ "$(git -C "${ZI[BIN_DIR]}" rev-parse HEAD)" = ${CANDIDATE_SHA} ]] ||
+            exit 1
+          (( ${+functions[zi]} )) || exit 1
+          .zi-prepare-home || exit 1
+          [[ -d ${ZI[HOME_DIR]} ]] || exit 1
+          zi -V >/dev/null || exit 1
+          ZSH
+
+  gate:
+    name: Promotion gate
+    if: ${{ always() }}
+    needs: [zsh, zd, trunk, codeql, clean-install]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require every promotion validation
+        env:
+          ZSH_RESULT: ${{ needs.zsh.result }}
+          ZD_RESULT: ${{ needs.zd.result }}
+          TRUNK_RESULT: ${{ needs.trunk.result }}
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+          CLEAN_INSTALL_RESULT: ${{ needs.clean-install.result }}
+        run: |
+          failed=0
+          for result_name in \
+            ZSH_RESULT \
+            ZD_RESULT \
+            TRUNK_RESULT \
+            CODEQL_RESULT \
+            CLEAN_INSTALL_RESULT
+          do
+            result="${!result_name}"
+            if [[ "${result}" != success ]]; then
+              echo "::error::${result_name} was '${result}', not 'success'."
+              failed=1
+            fi
+          done
+          exit "${failed}"

--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -47,10 +47,11 @@ jobs:
 
   zd:
     name: ZD integration
-    uses: z-shell/zd/.github/workflows/test-native.yml@191642eaf9587e64f910c79aaf750d2cfe237241 # z-shell/zd#95, #96
+    uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107
     with:
       zi_repo: ${{ github.event.pull_request.head.repo.full_name }}
       zi_ref: ${{ github.event.pull_request.head.sha }}
+      include_compat: ${{ github.head_ref == 'next' }}
 
   trunk:
     name: Trunk
@@ -62,7 +63,7 @@ jobs:
       - name: Check out the candidate
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Run Trunk
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b
@@ -139,7 +140,6 @@ jobs:
           (( ${+functions[zi]} )) || exit 1
           .zi-prepare-home || exit 1
           [[ -d ${ZI[HOME_DIR]} ]] || exit 1
-          zi -V >/dev/null || exit 1
           ZSH
 
   gate:


### PR DESCRIPTION
## Summary

- bootstrap the reviewed Promotion Readiness workflow onto the default branch
- add the promotion readiness record with minimal default-template routing
- pin ZD integration to the merged immutable-ref and compatibility suite

## Validation

- actionlint
- Trunk actionlint, markdownlint, Prettier, and git-diff-check
- reviewed workflow and promotion template copied from `next`; default template change limited to one routing comment

Part of #377. This bootstrap does not promote `next` and does not publish a tag.