### PR TITLE
fix(ci): repair ZD integration workflow

### DIFF
--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-caller
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main, next]
     paths:
+      - ".github/workflows/zd-integration.yml"
       - "zi.zsh"
       - "lib/**"
   pull_request:
     paths:
+      - ".github/workflows/zd-integration.yml"
       - "zi.zsh"
       - "lib/**"
   workflow_dispatch: {}
@@ -22,7 +24,8 @@ permissions:
 
 jobs:
   zd-test:
-    uses: z-shell/zd/.github/workflows/test-native.yml@191642eaf9587e64f910c79aaf750d2cfe237241 # z-shell/zd#95, #96
+    uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107
     with:
       zi_repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      include_compat: false


### PR DESCRIPTION
## Summary

- separate caller and reusable-workflow concurrency groups to prevent GitHub Actions deadlock cancellation
- update the standalone ZD integration job to the current passing reusable-workflow revision
- keep promotion-only compatibility tests disabled for ordinary integration runs
- trigger the workflow when its own definition changes so future pin updates receive live validation

## Root cause

The caller and reusable workflow both resolved `github.workflow` and `github.ref` to the same concurrency key. GitHub canceled the reusable job as a detected deadlock before creating matrix jobs.

## Verification

- `actionlint .github/workflows/zd-integration.yml`
- `trunk check --ci .github/workflows/zd-integration.yml`
- `git diff --check`
- verified the pinned workflow SHA and `include_compat` input contract
- all five ZD ZUnit matrices passed on the exact branch commit: https://github.com/z-shell/zi/actions/runs/32586257686
- all PR checks passed, including the self-triggered ZD Integration matrix

Part of #377.