### PR TITLE
test(version): cover reporting across checkout states

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -52,6 +52,11 @@ Link documentation and consumer follow-ups identified by the
 [#376 public-contract impact review](https://github.com/z-shell/zi/issues/376).
 Write `None` only with a rationale.
 
+- [ ] If the candidate introduces monitoring for a contract surface that is
+      absent from the base, manually inventory that surface across the complete
+      compare. The detector can report the new monitoring definition, but it
+      cannot classify changes that predate that baseline.
+
 ## Rollback readiness
 
 - Rollback owner: `@________________`

--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -45,6 +45,9 @@ jobs:
             exit 1
           fi
 
+      - name: Test version reporting
+        run: zsh tests/version-reporting.zsh
+
   zd:
     name: ZD integration
     uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107

--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-caller
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/zd-integration.yml
+++ b/.github/workflows/zd-integration.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main, next]
     paths:
+      - ".github/workflows/zd-integration.yml"
       - "zi.zsh"
       - "lib/**"
   pull_request:
     paths:
+      - ".github/workflows/zd-integration.yml"
       - "zi.zsh"
       - "lib/**"
   workflow_dispatch: {}
@@ -22,7 +24,8 @@ permissions:
 
 jobs:
   zd-test:
-    uses: z-shell/zd/.github/workflows/test-native.yml@191642eaf9587e64f910c79aaf750d2cfe237241 # z-shell/zd#95, #96
+    uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107
     with:
       zi_repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      include_compat: false

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -9,10 +9,12 @@ on:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/version-reporting.zsh"
   pull_request:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
 concurrency:
@@ -59,3 +61,14 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+
+  version-reporting:
+    name: Version reporting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test version reporting
+        run: zsh tests/version-reporting.zsh

--- a/tests/version-reporting.zsh
+++ b/tests/version-reporting.zsh
@@ -35,7 +35,7 @@ run_case() {
     ZI_TEST_EXPECTED="$expected" \
     zsh -f <<'ZSH' || fail "$label"
 builtin emulate -LR zsh
-setopt errexit pipefail
+setopt pipefail
 
 typeset -gAH ZI
 ZI[BIN_DIR]="$ZI_TEST_CHECKOUT"

--- a/tests/version-reporting.zsh
+++ b/tests/version-reporting.zsh
@@ -1,0 +1,76 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+setopt errexit nounset pipefail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-version-test.XXXXXXXX")"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  print -u2 "not ok - $1"
+  exit 1
+}
+
+run_case() {
+  local label="$1" checkout="$2" expected="$3"
+  local case_root="${temp_root}/${label}"
+  command mkdir -p \
+    "${case_root}/home" \
+    "${case_root}/cache" \
+    "${case_root}/config" \
+    "${case_root}/data" \
+    "${case_root}/zdotdir"
+
+  env \
+    HOME="${case_root}/home" \
+    XDG_CACHE_HOME="${case_root}/cache" \
+    XDG_CONFIG_HOME="${case_root}/config" \
+    XDG_DATA_HOME="${case_root}/data" \
+    ZDOTDIR="${case_root}/zdotdir" \
+    ZI_TEST_CHECKOUT="$checkout" \
+    ZI_TEST_EXPECTED="$expected" \
+    zsh -f <<'ZSH' || fail "$label"
+builtin emulate -LR zsh
+setopt errexit pipefail
+
+typeset -gAH ZI
+ZI[BIN_DIR]="$ZI_TEST_CHECKOUT"
+builtin source "${ZI[BIN_DIR]}/zi.zsh"
+
+[[ ${ZI[VERSION]} == "$ZI_TEST_EXPECTED" ]]
+
+typeset argument output
+for argument in version --version -V; do
+  output="$(zi "$argument")"
+  [[ $output == *"Zi version: ${ZI_TEST_EXPECTED}"* ]]
+done
+ZSH
+
+  print "ok - ${label}"
+}
+
+typeset untagged_checkout="${temp_root}/untagged-checkout"
+command git clone -q --no-hardlinks "$project_root" "$untagged_checkout"
+command git -C "$untagged_checkout" config user.name "Version Test"
+command git -C "$untagged_checkout" config user.email "version-test@example.invalid"
+command git -C "$untagged_checkout" commit -qm "test: create untagged fixture" --allow-empty
+typeset untagged_version
+untagged_version="$(command git -C "$untagged_checkout" rev-parse --short HEAD)"
+run_case untagged "$untagged_checkout" "$untagged_version"
+
+typeset tagged_checkout="${temp_root}/tagged-checkout"
+command git clone -q --no-hardlinks "$project_root" "$tagged_checkout"
+command git -C "$tagged_checkout" config user.name "Version Test"
+command git -C "$tagged_checkout" config user.email "version-test@example.invalid"
+command git -C "$tagged_checkout" commit -qm "test: create tagged fixture" --allow-empty
+command git -C "$tagged_checkout" tag zi-version-test
+run_case tagged "$tagged_checkout" zi-version-test
+
+typeset archive_checkout="${temp_root}/archive-checkout"
+command cp -R "$project_root" "$archive_checkout"
+command rm -f -- "$archive_checkout/.git"
+run_case archive "$archive_checkout" unknown

--- a/tests/version-reporting.zsh
+++ b/tests/version-reporting.zsh
@@ -41,12 +41,18 @@ typeset -gAH ZI
 ZI[BIN_DIR]="$ZI_TEST_CHECKOUT"
 builtin source "${ZI[BIN_DIR]}/zi.zsh"
 
-[[ ${ZI[VERSION]} == "$ZI_TEST_EXPECTED" ]]
+if [[ ${ZI[VERSION]} != "$ZI_TEST_EXPECTED" ]]; then
+  print -u2 -r -- "expected ZI[VERSION] '$ZI_TEST_EXPECTED', got '${ZI[VERSION]}'"
+  return 1
+fi
 
 typeset argument output
 for argument in version --version -V; do
   output="$(zi "$argument")"
-  [[ $output == *"Zi version: ${ZI_TEST_EXPECTED}"* ]]
+  if [[ $output != *"Zi version: ${ZI_TEST_EXPECTED}"* ]]; then
+    print -u2 -r -- "expected '$argument' to report '$ZI_TEST_EXPECTED', got '${(q)output}'"
+    return 1
+  fi
 done
 ZSH
 
@@ -71,6 +77,6 @@ command git -C "$tagged_checkout" tag zi-version-test
 run_case tagged "$tagged_checkout" zi-version-test
 
 typeset archive_checkout="${temp_root}/archive-checkout"
-command cp -R "$project_root" "$archive_checkout"
-command rm -f -- "$archive_checkout/.git"
+command mkdir -p "$archive_checkout"
+command git -C "$project_root" archive HEAD | command tar -x -C "$archive_checkout"
 run_case archive "$archive_checkout" unknown


### PR DESCRIPTION
## Summary

- cover `zi version`, `zi --version`, and `zi -V` across tagged, untagged, and archive checkouts
- run the focused test in ordinary Zsh CI and the `next` to `main` promotion gate
- require a manual historical inventory when contract monitoring is introduced without a base definition

## Validation

- `zsh tests/version-reporting.zsh`
- `zsh tests/public-contract-impact.zsh`
- Zsh syntax and compile sweep across 24 files
- `actionlint .github/workflows/zsh-n.yml .github/workflows/promotion-readiness.yml`
- `git diff --check`

Refs #377.
