### PR TITLE
chore(contracts): track F-Sy-H as a commands-surface consumer

### DIFF
--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -192,7 +192,7 @@
       "repository": "z-shell/F-Sy-H",
       "path": "chroma/-zi.ch",
       "surfaces": ["commands", "ices"],
-      "evidence": "https://github.com/z-shell/F-Sy-H/blob/84d964944b1d0297264b668e469473f15083071c/chroma/-zi.ch"
+      "evidence": "https://github.com/z-shell/F-Sy-H/blob/2d2eedd8e0aa3eb1ba70aae54680c106777c2f8d/chroma/-zi.ch"
     },
     {
       "repository": "z-shell/zsh-lint",

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_version": 1,
-  "evidence_reviewed": "2026-08-15",
+  "evidence_reviewed": "2026-08-24",
   "renames": [],
   "surfaces": [
     {
@@ -191,8 +191,8 @@
     {
       "repository": "z-shell/F-Sy-H",
       "path": "chroma/-zi.ch",
-      "surfaces": ["ices"],
-      "evidence": "https://github.com/z-shell/F-Sy-H/blob/e9f6487a654ae870154fd9e3384853f37ae01087/chroma/-zi.ch"
+      "surfaces": ["commands", "ices"],
+      "evidence": "https://github.com/z-shell/F-Sy-H/blob/84d964944b1d0297264b668e469473f15083071c/chroma/-zi.ch"
     },
     {
       "repository": "z-shell/zsh-lint",


### PR DESCRIPTION
## Problem

`contracts/public-contract-v1.json` only registered
`z-shell/F-Sy-H:chroma/-zi.ch` as a consumer of the `ices` surface
(`ZI[ice-list]`), not `commands` (`ZI[cmd-list]`) — even though `-zi.ch` has
always depended on the subcommand list. That dependency was an untracked,
hand-copied literal that silently drifted (missing `version`, added in
b8248aa) until z-shell/F-Sy-H#52 made it a genuine runtime read of
`ZI[cmd-list]`.

## Fix

Add `commands` to the existing F-Sy-H consumer entry and point its evidence
at z-shell/F-Sy-H#52's merged `main` commit
(z-shell/F-Sy-H@2d2eedd8e0aa3eb1ba70aae54680c106777c2f8d).

## Verification

- `jq .` validates the manifest.
- Ran this repo's own `scripts/public-contract-impact.zsh --base origin/next --head bug-410` locally: reports only two `informational` impacts (`consumer-evidence-refresh` on `ices`, `consumer-evidence-addition` on `commands`), no breaking-change gate triggered.
- `zsh tests/public-contract-impact.zsh` passes.

Fixes #410
