### PR TITLE
fix(self-update): make reload failure-safe

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test version reporting
         run: zsh tests/version-reporting.zsh
 
+      - name: Test self-update reload
+        run: zsh tests/self-update-reload.zsh
+
   zd:
     name: ZD integration
     uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -9,11 +9,13 @@ on:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/self-update-reload.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/self-update-reload.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -72,3 +74,14 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test version reporting
         run: zsh tests/version-reporting.zsh
+
+  self-update-reload:
+    name: Self-update reload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test self-update reload
+        run: zsh tests/self-update-reload.zsh

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -628,47 +628,99 @@ ZI[EXTENDED_GLOB]=""
     return 0
   fi
 } # ]]]
+# FUNCTION: .zi-self-update-lock-path [[[
+# Resolves the repository-local advisory lock used for checkout and dump changes.
+.zi-self-update-lock-path() {
+  local lock_path
+  lock_path="$(command git -C "${ZI[BIN_DIR]}" rev-parse --git-path zi-self-update.lock 2>/dev/null)" || return 1
+  [[ $lock_path = /* ]] || lock_path="${ZI[BIN_DIR]}/${lock_path}"
+  command touch -- "$lock_path" || return 1
+  REPLY="$lock_path"
+} # ]]]
 # FUNCTION: .zi-auto-reload [[[
-# Function checks sum of all files that are used to calculate the mtime
-# and if it is different from the stored one, then recompile, and reload.
+# Recompiles and re-sources Zi when the checkout revision differs from the
+# revision loaded by this shell. Re-sourcing cannot remove definitions deleted
+# by an update; restarting the shell is required for a completely clean state.
 .zi-auto-reload() {
-  builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin setopt extended_glob typeset_silent no_short_loops
 
-  [[ $1 == (-q|--quiet) ]] && { local quiet=1; } || { local quiet=0; };
+  [[ $1 == (-q|--quiet) ]] && { local quiet=1; } || { local quiet=0; }
 
-  # The sum of all files that are used to calculate the mtime
-  local file rm_file comp_file src_file
-  integer sum ela elb
-  .zi-get-mtime-into "${ZI[BIN_DIR]}/zi.zsh" ela; (( sum += ela ))
-  for file ( side install autoload additional ) {
-    .zi-get-mtime-into "${ZI[BIN_DIR]}/lib/zsh/${file}.zsh" elb; (( sum += elb ))
+  local checkout_revision lock_file comp_file src_file
+  local -a compile_files source_files
+  integer lock_fd reload_status=0
+
+  zmodload zsh/system 2>/dev/null || {
+    builtin print -u2 -r -- "Zi self-update: zsh/system is required for reload locking"
+    return 1
   }
-
-  # If the sum of all mtime is different from the stored one,
-  # then remove all compiled files then recompile new ones and reload.
-  if (( ZI[mtime] + ZI[mtime-side] + ZI[mtime-install] + ZI[mtime-autoload] + ZI[mtime-additional] != sum )); then
-
-    # Remove all compiled files
-    for rm_file ( ${ZI[BIN_DIR]}/**/*.zwc(DN) ) {
-      command rm -f -- "${rm_file}" > /dev/null 2>&1
-    }
-
-    # Recompile new ones
-    (( quiet )) || +zi-message -n "{mmdsh}{happy} Zi{rst} » {profile}recompiling codebase{rst}{…}"
-    for comp_file ( ${ZI[BIN_DIR]}/**/*.zsh*~*.zwc ) {
-      zcompile -U -- ${comp_file} > /dev/null 2>&1
-    } && { (( quiet )) || +zi-message " {term}✔{rst}"; }
-
-    # Reload Zi
-    (( quiet )) || +zi-message -n "{mmdsh}{happy} Zi{rst} » {profile}reloading{rst}{…}"
-    for src_file ( zi side install autoload additional ) {
-      builtin source ${ZI[BIN_DIR]}/**/${src_file}.zsh > /dev/null 2>&1
-    } && { (( quiet )) || +zi-message " {term}✔{rst}"; }
-
-    # Update the stored mtime
-    .zi-set-mtime && return 0
+  .zi-self-update-lock-path || {
+    builtin print -u2 -r -- "Zi self-update: cannot create the reload lock"
+    return 1
+  }
+  lock_file="$REPLY"
+  zsystem flock -t "${ZI[SELF_UPDATE_LOCK_TIMEOUT]:-5}" -f lock_fd "$lock_file" || {
+    builtin print -u2 -r -- "Zi self-update: timed out waiting for reload lock ${lock_file}"
+    return 1
+  }
+  checkout_revision="$(command git -C "${ZI[BIN_DIR]}" rev-parse HEAD 2>/dev/null)" || {
+    builtin print -u2 -r -- "Zi self-update: cannot determine checkout revision after locking ${ZI[BIN_DIR]}"
+    zsystem flock -u "$lock_fd"
+    return 1
+  }
+  if [[ $checkout_revision == ${ZI[LOADED_REVISION]} ]]; then
+    zsystem flock -u "$lock_fd"
+    return 0
   fi
+
+  compile_files=(
+    "${ZI[BIN_DIR]}/zi.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/side.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/install.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/git-process-output.zsh"
+  )
+  source_files=(
+    "${ZI[BIN_DIR]}/zi.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/side.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/install.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh"
+    "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
+  )
+
+  (( quiet )) || +zi-message -n "{mmdsh}{happy} Zi{rst} » {profile}recompiling codebase{rst}{…}"
+  for comp_file in "${compile_files[@]}"; do
+    if ! zcompile -U -- "$comp_file" >/dev/null 2>&1; then
+      builtin print -u2 -r -- "Zi self-update: failed to compile ${comp_file}"
+      reload_status=1
+      break
+    fi
+  done
+  (( reload_status || quiet )) || +zi-message " {term}✔{rst}"
+
+  if (( ! reload_status )); then
+    (( quiet )) || +zi-message -n "{mmdsh}{happy} Zi{rst} » {profile}reloading{rst}{…}"
+    for src_file in "${source_files[@]}"; do
+      if ! builtin source "$src_file" >/dev/null 2>&1; then
+        builtin print -u2 -r -- "Zi self-update: failed to source ${src_file}"
+        reload_status=1
+        break
+      fi
+    done
+  fi
+
+  if (( ! reload_status )); then
+    ZI[LOADED_REVISION]="$checkout_revision"
+    (( quiet )) || {
+      +zi-message " {term}✔{rst}"
+      +zi-message "{mmdsh}{happy} Zi{rst} » {faint}restart the shell to remove definitions deleted by the update{rst}"
+    }
+  fi
+
+  zsystem flock -u "$lock_fd"
+  return "$reload_status"
 } # ]]]
 # FUNCTION: .zi-self-update [[[
 # Function manages self-update of Zi codebase.
@@ -695,10 +747,25 @@ ZI[EXTENDED_GLOB]=""
     sysctl -n hw.ncpu 2>/dev/null || command getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 
   (
+    zmodload zsh/system 2>/dev/null || {
+      builtin print -u2 -r -- "Zi self-update: zsh/system is required for update locking"
+      exit 1
+    }
+    .zi-self-update-lock-path || {
+      builtin print -u2 -r -- "Zi self-update: cannot create the update lock"
+      exit 1
+    }
+    integer update_lock_fd
+    zsystem flock -t "${ZI[SELF_UPDATE_LOCK_TIMEOUT]:-5}" -f update_lock_fd "$REPLY" || {
+      builtin print -u2 -r -- "Zi self-update: timed out waiting for update lock ${REPLY}"
+      exit 1
+    }
+
     # Fetch the latest changes from the upstream repository
     (( quiet )) || +zi-message "{mmdsh}{happy} Zi{rst} » {profile}fetching updates{rst}{…}"
-    builtin cd -q $ZI[BIN_DIR] && command git fetch $opt --jobs $cores --tags --prune --force $origin_url refs/heads/main && \
-      lines=( ${(f)"$(command git log --color --abbrev-commit --decorate --date=short --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cd) %C(bold blue)<%an>%Creset' ..FETCH_HEAD)"} )
+    builtin cd -q $ZI[BIN_DIR] || exit 1
+    command git fetch $opt --jobs $cores --tags --prune --force $origin_url refs/heads/main || exit $?
+    lines=( ${(f)"$(command git log --color --abbrev-commit --decorate --date=short --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cd) %C(bold blue)<%an>%Creset' ..FETCH_HEAD)"} ) || exit $?
 
     # If there are any changes then update the codebase and reload Zi
     if (( ${#lines} > 0 )); then
@@ -720,7 +787,7 @@ ZI[EXTENDED_GLOB]=""
     fi
   )
   local update_status=$?
-  if (( update_status == 10 )); then
+  if (( (update_status == 0 || update_status == 10) && !dry_run )); then
     .zi-auto-reload $opt
     return $?
   fi

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -72,7 +72,7 @@ pass "no-op reload"
 (
   new_checkout current-shell
   typeset checkout="$REPLY"
-  "$git_bin" -C "$checkout" branch -M main
+  "$git_bin" -C "$checkout" switch -q -C main
   typeset remote="${temp_root}/current-shell-remote.git"
   typeset publisher="${temp_root}/current-shell-publisher"
   "$git_bin" clone -q --bare "$checkout" "$remote"
@@ -141,7 +141,7 @@ pass "log failure"
 (
   new_checkout second-shell
   typeset checkout="$REPLY"
-  "$git_bin" -C "$checkout" branch -M main
+  "$git_bin" -C "$checkout" switch -q -C main
   typeset remote="${temp_root}/second-shell-remote.git"
   "$git_bin" clone -q --bare "$checkout" "$remote"
   "$git_bin" -C "$checkout" remote set-url origin "$remote"

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -30,7 +30,9 @@ new_checkout() {
   command cp -- "$project_root/zi.zsh" "$REPLY/zi.zsh"
   command cp -- "$project_root/lib/zsh/autoload.zsh" "$REPLY/lib/zsh/autoload.zsh"
   "$git_bin" -C "$REPLY" add zi.zsh lib/zsh/autoload.zsh
-  "$git_bin" -C "$REPLY" commit -qm "test: install self-update code under test"
+  if ! "$git_bin" -C "$REPLY" diff --cached --quiet; then
+    "$git_bin" -C "$REPLY" commit -qm "test: install self-update code under test"
+  fi
   command rm -f -- "$REPLY"/*.zwc(N) "$REPLY"/lib/zsh/*.zwc(N)
 }
 

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -47,8 +47,8 @@ commit_change() {
 load_zi() {
   typeset -gAH ZI
   ZI[BIN_DIR]="$1"
-  builtin source "${ZI[BIN_DIR]}/zi.zsh" >/dev/null
-  builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null
+  builtin source "${ZI[BIN_DIR]}/zi.zsh" >/dev/null || fail "source Zi fixture"
+  builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload fixture"
 }
 
 # A current checkout is a true no-op: it neither compiles nor changes the

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -141,6 +141,10 @@ pass "log failure"
 (
   new_checkout second-shell
   typeset checkout="$REPLY"
+  "$git_bin" -C "$checkout" branch -M main
+  typeset remote="${temp_root}/second-shell-remote.git"
+  "$git_bin" clone -q --bare "$checkout" "$remote"
+  "$git_bin" -C "$checkout" remote set-url origin "$remote"
   load_zi "$checkout"
   commit_change "$checkout" lib/zsh/additional.zsh '# second-shell revision'
   typeset changed_revision="$REPLY"

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -1,0 +1,314 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+setopt errexit pipefail
+
+typeset project_root="${0:A:h:h}"
+typeset git_bin="${commands[git]}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-self-update-test.XXXXXXXX")"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  print -r -- "ok - $1"
+}
+
+new_checkout() {
+  local label="$1"
+  REPLY="${temp_root}/${label}"
+  "$git_bin" clone -q --no-hardlinks "$project_root" "$REPLY"
+  "$git_bin" -C "$REPLY" config user.name "Self Update Test"
+  "$git_bin" -C "$REPLY" config user.email "self-update-test@example.invalid"
+  "$git_bin" -C "$REPLY" config commit.gpgsign false
+  command cp -- "$project_root/zi.zsh" "$REPLY/zi.zsh"
+  command cp -- "$project_root/lib/zsh/autoload.zsh" "$REPLY/lib/zsh/autoload.zsh"
+  "$git_bin" -C "$REPLY" add zi.zsh lib/zsh/autoload.zsh
+  "$git_bin" -C "$REPLY" commit -qm "test: install self-update code under test"
+  command rm -f -- "$REPLY"/*.zwc(N) "$REPLY"/lib/zsh/*.zwc(N)
+}
+
+commit_change() {
+  local checkout="$1" file_path="$2" content="$3"
+  print -r -- "$content" >> "${checkout}/${file_path}"
+  "$git_bin" -C "$checkout" add "$file_path"
+  "$git_bin" -C "$checkout" commit -qm "test: change reload fixture"
+  REPLY="$("$git_bin" -C "$checkout" rev-parse HEAD)"
+}
+
+load_zi() {
+  typeset -gAH ZI
+  ZI[BIN_DIR]="$1"
+  builtin source "${ZI[BIN_DIR]}/zi.zsh" >/dev/null
+  builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null
+}
+
+# A current checkout is a true no-op: it neither compiles nor changes the
+# revision baseline.
+(
+  new_checkout no-op
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}"
+  typeset checkout_revision="$("$git_bin" -C "$checkout" rev-parse HEAD)"
+
+  [[ $loaded == "$checkout_revision" ]] || fail "initial load records checkout revision"
+  .zi-auto-reload --quiet || fail "no-op reload returns success"
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "no-op preserves loaded revision"
+  [[ ! -e "${checkout}/zi.zsh.zwc" ]] || fail "no-op does not compile"
+)
+pass "no-op reload"
+
+# A successful fast-forward initiated by this shell reloads the merged revision
+# before self-update returns.
+(
+  new_checkout current-shell
+  typeset checkout="$REPLY"
+  "$git_bin" -C "$checkout" branch -M main
+  typeset remote="${temp_root}/current-shell-remote.git"
+  typeset publisher="${temp_root}/current-shell-publisher"
+  "$git_bin" clone -q --bare "$checkout" "$remote"
+  "$git_bin" -C "$checkout" remote set-url origin "$remote"
+  "$git_bin" clone -q "$remote" "$publisher"
+  "$git_bin" -C "$publisher" config user.name "Self Update Publisher"
+  "$git_bin" -C "$publisher" config user.email "publisher@example.invalid"
+  "$git_bin" -C "$publisher" config commit.gpgsign false
+
+  load_zi "$checkout"
+  print -r -- '# current-shell revision' >> "${publisher}/lib/zsh/additional.zsh"
+  "$git_bin" -C "$publisher" add lib/zsh/additional.zsh
+  "$git_bin" -C "$publisher" commit -qm "test: publish self-update fixture"
+  "$git_bin" -C "$publisher" push -q origin main
+  typeset published_revision="$("$git_bin" -C "$publisher" rev-parse HEAD)"
+  typeset output_file="${temp_root}/current-shell-output" output
+
+  zi self-update --quiet >"$output_file" 2>&1 || fail "current-shell self-update returns success"
+  output="$(<"$output_file")"
+  [[ -z $output ]] || fail "current-shell quiet update emits no progress output"
+  [[ $("$git_bin" -C "$checkout" rev-parse HEAD) == "$published_revision" ]] || fail "self-update fast-forwards checkout"
+  [[ ${ZI[LOADED_REVISION]} == "$published_revision" ]] || fail "self-update loads merged revision"
+)
+pass "current-shell self-update"
+
+# Fetch failures must propagate instead of falling through to the up-to-date
+# path and reporting success.
+(
+  new_checkout fetch-failure
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}"
+  "$git_bin" -C "$checkout" remote set-url origin "${temp_root}/missing-remote.git"
+
+  if zi self-update --quiet >/dev/null 2>&1; then
+    fail "fetch failure returns nonzero"
+  fi
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "fetch failure preserves baseline"
+)
+pass "fetch failure"
+
+# A failed changelog query after a successful fetch must also propagate rather
+# than being mistaken for an empty, up-to-date log.
+(
+  new_checkout log-failure
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}"
+  typeset fake_bin="${temp_root}/fake-git-bin"
+  command mkdir -p "$fake_bin"
+  print -r -- '#!/bin/sh' > "${fake_bin}/git"
+  print -r -- 'if [ "$1" = log ]; then exit 42; fi' >> "${fake_bin}/git"
+  print -r -- "exec ${(q)git_bin} \"\$@\"" >> "${fake_bin}/git"
+  command chmod +x "${fake_bin}/git"
+
+  PATH="${fake_bin}:${PATH}"
+  if zi self-update --quiet >/dev/null 2>&1; then
+    fail "log failure returns nonzero"
+  fi
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "log failure preserves baseline"
+)
+pass "log failure"
+
+# A revision installed by another shell is detected even when no fetch or merge
+# is needed in this process.
+(
+  new_checkout second-shell
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  commit_change "$checkout" lib/zsh/additional.zsh '# second-shell revision'
+  typeset changed_revision="$REPLY"
+
+  zi self-update --quiet >/dev/null 2>&1 || fail "second-shell self-update returns success"
+  [[ ${ZI[LOADED_REVISION]} == "$changed_revision" ]] || fail "second-shell revision becomes loaded"
+  [[ -e "${checkout}/zi.zsh.zwc" ]] || fail "second-shell reload compiles exact sources"
+)
+pass "update performed by another shell"
+
+# Quiet mode suppresses successful progress output while still performing the
+# reload and updating the revision baseline.
+(
+  new_checkout quiet
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  commit_change "$checkout" lib/zsh/additional.zsh '# quiet revision'
+  typeset changed_revision="$REPLY" output
+  typeset output_file="${temp_root}/quiet-output"
+
+  .zi-auto-reload --quiet >"$output_file" 2>&1 || fail "quiet reload returns success"
+  output="$(<"$output_file")"
+  [[ -z $output ]] || fail "quiet reload emits no progress output"
+  [[ ${ZI[LOADED_REVISION]} == "$changed_revision" ]] || fail "quiet reload updates baseline"
+)
+pass "quiet reload"
+
+# A compilation error identifies the exact file, returns nonzero, and leaves
+# the old revision baseline in place so a later attempt can retry.
+(
+  new_checkout compile-failure
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}" output
+  commit_change "$checkout" lib/zsh/git-process-output.zsh 'if then'
+  typeset output_file="${temp_root}/compile-failure-output"
+
+  if .zi-auto-reload --quiet >"$output_file" 2>&1; then
+    fail "compile failure returns nonzero"
+  fi
+  output="$(<"$output_file")"
+  [[ $output == *"lib/zsh/git-process-output.zsh"* ]] || fail "compile failure names path"
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "compile failure preserves baseline"
+)
+pass "compile failure"
+
+# All files compile before any source is attempted. A source error then names
+# the exact file and does not advance the revision baseline.
+(
+  new_checkout source-failure
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}" output
+  commit_change "$checkout" lib/zsh/additional.zsh 'return 42'
+  typeset output_file="${temp_root}/source-failure-output"
+
+  if .zi-auto-reload --quiet >"$output_file" 2>&1; then
+    fail "source failure returns nonzero"
+  fi
+  output="$(<"$output_file")"
+  [[ $output == *"lib/zsh/additional.zsh"* ]] || fail "source failure names path"
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "source failure preserves baseline"
+)
+pass "source failure"
+
+# Even an apparently current checkout must synchronize before accepting the
+# no-op. Another updater can already hold the lock and be about to advance HEAD.
+(
+  new_checkout no-op-race
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset lock_file="${checkout}/.git/zi-self-update.lock"
+  typeset ready_file="${temp_root}/no-op-race-ready"
+  : > "$lock_file"
+
+  zsh -fc '
+    zmodload zsh/system || exit 1
+    zsystem flock -f lock_fd "$1" || exit 1
+    print -r -- ready > "$2"
+    sleep 0.2
+    print -r -- "# no-op race revision" >> "$3/lib/zsh/additional.zsh"
+    "$4" -C "$3" add lib/zsh/additional.zsh
+    "$4" -C "$3" commit -qm "test: advance an apparently current checkout"
+  ' _ "$lock_file" "$ready_file" "$checkout" "$git_bin" &
+  typeset holder_pid=$!
+  integer attempts=0
+  while [[ ! -e $ready_file && attempts -lt 50 ]]; do
+    sleep 0.02
+    (( ++attempts ))
+  done
+  [[ -e $ready_file ]] || fail "no-op race lock holder becomes ready"
+
+  .zi-auto-reload --quiet || fail "no-op race reload returns success"
+  wait "$holder_pid" || fail "no-op race checkout update succeeds"
+  typeset final_revision="$("$git_bin" -C "$checkout" rev-parse HEAD)"
+  [[ ${ZI[LOADED_REVISION]} == "$final_revision" ]] || fail "no-op waits for concurrent checkout update"
+)
+pass "concurrent update starts during no-op check"
+
+# Re-read HEAD after acquiring the lock. A concurrent updater may advance the
+# checkout while this shell waits, and the loaded baseline must match the files
+# that were actually compiled and sourced.
+(
+  new_checkout revision-during-lock-wait
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  commit_change "$checkout" lib/zsh/additional.zsh '# first waiting revision'
+  typeset lock_file="${checkout}/.git/zi-self-update.lock"
+  typeset ready_file="${temp_root}/revision-wait-ready"
+  : > "$lock_file"
+
+  zsh -fc '
+    zmodload zsh/system || exit 1
+    zsystem flock -f lock_fd "$1" || exit 1
+    print -r -- ready > "$2"
+    sleep 0.2
+    print -r -- "# newer waiting revision" >> "$3/lib/zsh/additional.zsh"
+    "$4" -C "$3" add lib/zsh/additional.zsh
+    "$4" -C "$3" commit -qm "test: advance checkout while lock is held"
+  ' _ "$lock_file" "$ready_file" "$checkout" "$git_bin" &
+  typeset holder_pid=$!
+  integer attempts=0
+  while [[ ! -e $ready_file && attempts -lt 50 ]]; do
+    sleep 0.02
+    (( ++attempts ))
+  done
+  [[ -e $ready_file ]] || fail "revision lock holder becomes ready"
+
+  .zi-auto-reload --quiet || fail "reload after lock wait returns success"
+  wait "$holder_pid" || fail "concurrent checkout update succeeds"
+  typeset final_revision="$("$git_bin" -C "$checkout" rev-parse HEAD)"
+  [[ ${ZI[LOADED_REVISION]} == "$final_revision" ]] || fail "reload records post-lock revision"
+)
+pass "revision changes during lock wait"
+
+# A contending process holds the same advisory lock. The reload times out,
+# returns nonzero, and remains retryable.
+(
+  new_checkout lock-contention
+  typeset checkout="$REPLY"
+  load_zi "$checkout"
+  typeset loaded="${ZI[LOADED_REVISION]}"
+  commit_change "$checkout" lib/zsh/additional.zsh '# lock contention revision'
+  typeset lock_file="${checkout}/.git/zi-self-update.lock"
+  typeset ready_file="${temp_root}/lock-ready" output
+  : > "$lock_file"
+
+  zsh -fc '
+    zmodload zsh/system || exit 1
+    zsystem flock -f lock_fd "$1" || exit 1
+    print -r -- ready > "$2"
+    sleep 5
+  ' _ "$lock_file" "$ready_file" &
+  typeset holder_pid=$!
+  integer attempts=0
+  while [[ ! -e $ready_file && attempts -lt 50 ]]; do
+    sleep 0.02
+    (( ++attempts ))
+  done
+  [[ -e $ready_file ]] || fail "lock holder becomes ready"
+
+  ZI[SELF_UPDATE_LOCK_TIMEOUT]=0.1
+  typeset output_file="${temp_root}/lock-contention-output"
+  if .zi-auto-reload --quiet >"$output_file" 2>&1; then
+    fail "lock contention returns nonzero"
+  fi
+  output="$(<"$output_file")"
+  kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+  [[ $output == *"lock"* ]] || fail "lock contention is reported"
+  [[ ${ZI[LOADED_REVISION]} == "$loaded" ]] || fail "lock contention preserves baseline"
+)
+pass "lock contention"

--- a/zi.zsh
+++ b/zi.zsh
@@ -59,8 +59,12 @@ if [[ -d ${ZI[BIN_DIR]}/.git || -e ${ZI[BIN_DIR]}/.git ]]; then
   ZI[VERSION]=$(git -C "${ZI[BIN_DIR]}" describe --tags --exact-match 2>/dev/null) || \
     ZI[VERSION]=$(git -C "${ZI[BIN_DIR]}" rev-parse --short HEAD 2>/dev/null) || \
     ZI[VERSION]="unknown"
+  [[ -n ${ZI[LOADED_REVISION]} ]] || \
+    ZI[LOADED_REVISION]=$(git -C "${ZI[BIN_DIR]}" rev-parse HEAD 2>/dev/null) || \
+    ZI[LOADED_REVISION]="unknown"
 else
   ZI[VERSION]="unknown"
+  [[ -n ${ZI[LOADED_REVISION]} ]] || ZI[LOADED_REVISION]="unknown"
 fi
 
 # Zi home path for creating working directories.
@@ -2249,17 +2253,6 @@ return retval
   [[ ${ZI[lro-data]##*:} = on ]] && return 0 || return ___ret
 } # ]]]
 
-# FUNCTION: .zi-set-mtime. [[[
-# Stores mtime of zi.zsh and its lib files into ZI[mtime] and ZI[mtime-{side,install,autoload,additional}].
-# This is used to determine if the files were changed and need to be reloaded.
-.zi-set-mtime() {
-  local set_mtime
-  .zi-get-mtime-into "${ZI[BIN_DIR]}/zi.zsh" "ZI[mtime]"
-  for set_mtime ( side install autoload additional ) {
-  .zi-get-mtime-into "${ZI[BIN_DIR]}/lib/zsh/${set_mtime}.zsh" "ZI[mtime-${set_mtime}]"
-  }
-}
-
 #
 # Exposed functions.
 #
@@ -2955,7 +2948,6 @@ zmodload -F zsh/stat b:zstat 2>/dev/null && ZI[HAVE_ZSTAT]=1
 (( ZI[INTERNAL_ALIASES] )) && builtin alias zini=zi zinit=zi zplugin=zi
 
 .zi-prepare-home
-.zi-set-mtime
 
 # Simulate existence of _local/zi plugin. This will allow to cuninstall of its completion
 ZI_REGISTERED_PLUGINS=( _local/zi "${(u)ZI_REGISTERED_PLUGINS[@]:#_local/zi}" )


### PR DESCRIPTION
## Problem

Self-update reloads used an arithmetic mtime sum and recursive globs, could miss updates performed by another shell, masked compile/source failures, and allowed concurrent checkout and `.zwc` mutation.

## Approach

- record the full Git revision loaded by each shell
- check the checkout revision after every successful/no-op self-update
- serialize fetch/merge and recompilation with a repository-local `zsystem flock`
- compile and source explicit, quoted file lists
- compile the complete set before sourcing and preserve the loaded baseline on failure
- report that restarting the shell is required to remove definitions deleted by an update
- propagate fetch and changelog failures instead of treating them as an up-to-date checkout

## Tests

- `zsh tests/self-update-reload.zsh`
- `zsh tests/version-reporting.zsh`
- `zsh tests/public-contract-impact.zsh`
- Zsh compilation of changed runtime/test files
- `actionlint .github/workflows/zsh-n.yml .github/workflows/promotion-readiness.yml`
- `git diff --check`

The focused suite covers no-op reloads, current-shell fast-forward updates, failed fetches and changelog queries, updates performed by another shell, quiet mode, compile failures, source failures, concurrent updates during an apparent no-op, revision changes while waiting for the lock, and lock contention.

## Risk and rollback

The reload remains best-effort for the current process: re-sourcing cannot remove definitions deleted by an update, so a clean restart is explicitly recommended. Reverting this PR restores the prior mtime/glob behavior.

Fixes #373
