### PR TITLE
fix(extract): process nested archives safely

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install Zsh
-        run: sudo apt-get update && sudo apt-get install -yq zsh
+      - name: Install Zsh and archive tools
+        run: sudo apt-get update && sudo apt-get install -yq zsh zip unzip
 
       - name: Check and compile Zsh sources
         shell: bash
@@ -50,6 +50,9 @@ jobs:
 
       - name: Test self-update reload
         run: zsh tests/self-update-reload.zsh
+
+      - name: Test archive extraction
+        run: zsh tests/archive-extraction.zsh
 
   zd:
     name: ZD integration

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -9,12 +9,14 @@ on:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/archive-extraction.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/archive-extraction.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
@@ -85,3 +87,14 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test self-update reload
         run: zsh tests/self-update-reload.zsh
+
+  archive-extraction:
+    name: Archive extraction
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh and archive tools
+        run: sudo apt update && sudo apt-get install -yq zsh zip unzip
+      - name: Test archive extraction
+        run: zsh tests/archive-extraction.zsh

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1519,27 +1519,40 @@ ziextract() {
           local infname=$fname
           [[ -f $fname.out ]] && fname=$fname.out
           files=( *.tar(ND) )
-          if [[ -f $fname || -f ${fname:r} ]] {
-            local -aU output2 archives2
-            output2=( ${(@f)"$(command file -- "$fname"(N) "${fname:r}"(N) $files[1](N) 2>&1)"} )
+          if [[ -f $fname || -f ${fname:r} || ${#files} -gt 0 ]] {
+            local -aU output2 archives2 stage2_candidates
+            local stage2_output file2 type2
+            local -i nested_status nested_failed=0
+            stage2_candidates=( "$fname"(N) "${fname:r}"(N) "${files[@]}" )
+            stage2_output=$(command file -- "${stage2_candidates[@]}" 2>&1)
+            nested_status=$?
+            if (( nested_status )) {
+              ret_val+=nested_status
+              continue
+            }
+            output2=( ${(@f)stage2_output} )
             archives2=( ${(M)output2[@]:#(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) *} )
-            local file2
             for file2 ( $archives2 ) {
               fname=${file2%:*} desc=${file2##*:}
-              local type2=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
+              type2=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
               if [[ $type != $type2 && $type2 = (zip|rar|xz|7-zip|gzip|bzip2|tar) ]] {
-                # TODO: #115 If multiple archives are really in the archive, this might delete too soon… However, it's unusual case.
-                [[ $fname != $infname && $norm -eq 0 ]] && command rm -f "$infname"
                 (( !OPTS[opt_-q,--quiet] )) && \
                 +zi-message "{annex}ziextract{ehi}:{rst} {note}Detected a {obj2}${type2}{note} archive in the file{ehi}:{rst} {file}${fname}{rst}"
-                ziextract "$fname" "$type2" $opt_move $opt_move2 $opt_norm ${${${#archives}:#1}:+--nobkp}
-                ret_val+=$?
+                # The outer extraction already applied the requested backup policy.
+                # Re-backing up here can hide sibling archives before they run.
+                ziextract "$fname" "$type2" $opt_move $opt_move2 $opt_norm --nobkp
+                nested_status=$?
+                ret_val+=nested_status
+                (( nested_status )) && nested_failed=1
                 stage2_processed+=( $fname )
                 if [[ $fname == *.out ]] {
                   [[ -f $fname ]] && command mv -f "$fname" "${fname%.out}"
                   stage2_processed+=( ${fname%.out} )
                 }
               }
+            }
+            if (( !nested_failed && !norm )) && [[ -e $infname ]] {
+              command rm -f -- "$infname" || (( ++ret_val ))
             }
           }
         }

--- a/tests/archive-extraction.zsh
+++ b/tests/archive-extraction.zsh
@@ -1,0 +1,127 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-archive-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  print -r -- "ok - $1"
+}
+
+for dependency in file tar zip; do
+  (( ${+commands[$dependency]} )) || fail "missing test dependency: $dependency"
+done
+
+prepare_unzip() {
+  builtin emulate -L zsh
+  if (( ${+commands[unzip]} )); then
+    return 0
+  fi
+  (( ${+commands[bsdtar]} )) || fail "missing test dependency: unzip"
+
+  typeset shim_dir="${temp_root}/unzip-shim"
+  command mkdir -p -- "$shim_dir" || fail "create unzip shim directory"
+  {
+    print -r -- '#!/bin/sh'
+    print -r -- 'exec bsdtar -xf "$2"'
+  } >| "${shim_dir}/unzip" || fail "write unzip shim"
+  command chmod +x -- "${shim_dir}/unzip" || fail "make unzip shim executable"
+  path=( "$shim_dir" "${path[@]}" )
+  rehash
+}
+
+new_fixture() {
+  builtin emulate -L zsh
+  typeset label="$1"
+  REPLY="${temp_root}/${label}"
+  command mkdir -p -- \
+    "$REPLY/home" \
+    "$REPLY/zdot" \
+    "$REPLY/data" \
+    "$REPLY/cache" \
+    "$REPLY/config" \
+    "$REPLY/one" \
+    "$REPLY/two" \
+    "$REPLY/staging" \
+    "$REPLY/work" || fail "create $label fixture directories"
+
+  print -r -- one >| "$REPLY/one/one.txt" || fail "write first payload"
+  print -r -- two >| "$REPLY/two/two.txt" || fail "write second payload"
+  command tar -cf "$REPLY/staging/one.tar" -C "$REPLY/one" . || fail "create first nested archive"
+  command tar -cf "$REPLY/staging/two.tar" -C "$REPLY/two" . || fail "create second nested archive"
+  (
+    builtin cd -- "$REPLY/staging" || exit 1
+    command zip -q "$REPLY/work/outer.bin" one.tar two.tar
+  ) || fail "create outer archive"
+}
+
+load_zi() {
+  builtin emulate -L zsh
+  typeset fixture_root="$1"
+  typeset -gx HOME="$fixture_root/home"
+  typeset -gx ZDOTDIR="$fixture_root/zdot"
+  typeset -gx XDG_DATA_HOME="$fixture_root/data"
+  typeset -gx XDG_CACHE_HOME="$fixture_root/cache"
+  typeset -gx XDG_CONFIG_HOME="$fixture_root/config"
+  typeset -gAH ZI OPTS
+  ZI[BIN_DIR]="$project_root"
+  builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+  builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || fail "source install library"
+}
+
+prepare_unzip
+
+# Every nested archive is extracted before the outer archive is removed.
+(
+  new_fixture success
+  typeset fixture_root="$REPLY"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter success fixture"
+
+  ziextract --auto >/dev/null || fail "extract nested archives"
+  [[ -f one.txt ]] || fail "extract first nested payload"
+  [[ -f two.txt ]] || fail "extract second nested payload"
+  [[ ! -e outer.bin ]] || fail "remove outer archive after success"
+  [[ ! -e ._backup/two.tar ]] || fail "do not back up a nested sibling"
+) || exit 1
+pass "extract every nested archive"
+
+# A nested failure leaves the outer archive available for retry.
+(
+  new_fixture failure
+  typeset fixture_root="$REPLY"
+  typeset real_tar="${commands[tar]}"
+  typeset shim_dir="$fixture_root/tar-shim"
+  command mkdir -p -- "$shim_dir" || fail "create tar shim directory"
+  {
+    print -r -- '#!/bin/sh'
+    print -r -- 'if [ "$2" = "two.tar" ]; then exit 42; fi'
+    print -r -- "exec ${(q)real_tar} \"\$@\""
+  } >| "$shim_dir/tar" || fail "write tar shim"
+  command chmod +x -- "$shim_dir/tar" || fail "make tar shim executable"
+
+  load_zi "$fixture_root"
+  path=( "$shim_dir" "${path[@]}" )
+  rehash
+  builtin cd -- "$fixture_root/work" || fail "enter failure fixture"
+
+  if ziextract --auto >/dev/null 2>&1; then
+    fail "nested extraction failure returns nonzero"
+  fi
+  [[ -f outer.bin ]] || fail "preserve outer archive after failure"
+  [[ -f two.tar ]] || fail "preserve failed nested archive"
+  [[ ! -e ._backup/two.tar ]] || fail "do not back up failed nested archive"
+) || exit 1
+pass "preserve outer archive after nested failure"


### PR DESCRIPTION
## Description

Process every nested tar archive discovered after stage-one extraction. Preserve the original outer archive when nested classification or extraction fails, and only remove it after all nested work succeeds.

Add regression coverage for multiple nested archives and failure preservation, then run that coverage in the Zsh and promotion-readiness workflows.

## Related issues

Fixes #115

## Type of change

- [x] `fix` - bug fix (non-breaking)
- [ ] `feat` - new feature (non-breaking)
- [ ] `feat!` / `fix!` - breaking change
- [ ] `perf` - performance improvement
- [ ] `refactor` - code change with no functional impact
- [ ] `docs` - documentation only
- [x] `test` - test addition or correction
- [ ] `build` - build system or dependency change
- [x] `ci` - CI/workflow change
- [ ] `style` - formatting with no behavior change
- [ ] `chore` - maintenance / dependency bump
- [ ] `revert` - revert of an earlier change

## Verification

- `zsh tests/archive-extraction.zsh`
- `zsh tests/version-reporting.zsh`
- `zsh tests/self-update-reload.zsh`
- `zsh tests/public-contract-impact.zsh`
- Native Zsh syntax and temporary `zcompile` checks across 28 Zsh files
- `actionlint` on both changed workflows
- `git diff --check`

The new regression test fails against `origin/next` because the second nested payload is not extracted.

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailers in commit messages
- [x] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Existing relevant tests and static checks pass
- [x] Documentation updated if needed

## Migration plan

Not required. Public Contract Impact reported no destructive change.