### PR TITLE
test(self-update): isolate reload environment

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -49,7 +49,7 @@ jobs:
         run: zsh tests/version-reporting.zsh
 
       - name: Test self-update reload
-        run: zsh tests/self-update-reload.zsh
+        run: zsh -f tests/self-update-reload.zsh
 
       - name: Test archive extraction
         run: zsh tests/archive-extraction.zsh

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Zsh
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test self-update reload
-        run: zsh tests/self-update-reload.zsh
+        run: zsh -f tests/self-update-reload.zsh
 
   archive-extraction:
     name: Archive extraction

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -11,6 +11,22 @@ typeset temp_root
 temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-self-update-test.XXXXXXXX")"
 trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
 
+typeset -gx HOME="${temp_root}/home"
+typeset -gx ZDOTDIR="${temp_root}/zdotdir"
+typeset -gx XDG_DATA_HOME="${temp_root}/data"
+typeset -gx XDG_CACHE_HOME="${temp_root}/cache"
+typeset -gx XDG_CONFIG_HOME="${temp_root}/config"
+typeset -gx TMPDIR="${temp_root}/tmp"
+typeset -gx ZPFX="${temp_root}/prefix"
+command mkdir -p -- \
+  "$HOME" \
+  "$ZDOTDIR" \
+  "$XDG_DATA_HOME" \
+  "$XDG_CACHE_HOME" \
+  "$XDG_CONFIG_HOME" \
+  "$TMPDIR" \
+  "$ZPFX"
+
 fail() {
   print -u2 -r -- "not ok - $1"
   exit 1
@@ -49,6 +65,10 @@ load_zi() {
   ZI[BIN_DIR]="$1"
   builtin source "${ZI[BIN_DIR]}/zi.zsh" >/dev/null || fail "source Zi fixture"
   builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload fixture"
+  [[ ${ZI[HOME_DIR]} == "${HOME}/.zi" ]] || fail "Zi fixture uses isolated home"
+  [[ ${ZI[CACHE_DIR]} == "${XDG_CACHE_HOME}/zi" ]] || fail "Zi fixture uses isolated cache"
+  [[ ${ZI[CONFIG_DIR]} == "${XDG_CONFIG_HOME}/zi" ]] || fail "Zi fixture uses isolated config"
+  [[ -d ${ZI[HOME_DIR]} ]] || fail "Zi fixture prepares isolated home"
 }
 
 # A current checkout is a true no-op: it neither compiles nor changes the


### PR DESCRIPTION
## Summary

- isolate `HOME`, `ZDOTDIR`, `TMPDIR`, `ZPFX`, and the XDG data, cache, and config paths inside the self-update test root
- assert that Zi resolves and prepares the isolated home, cache, and configuration paths
- invoke the focused suite with `zsh -f` in both development and promotion-readiness workflows

## Why

Follow-up review of #373 found that inherited XDG paths could make fixture setup write outside the test root. Those setup operations could fail while every focused assertion still reported success, allowing a false-green result.

## Verification

- self-update reload suite passes all 11 scenarios with deliberately hostile inherited home and XDG paths
- version-reporting, public-contract-impact, archive-extraction, and completion-refresh tests pass
- 29 Zsh sources pass native syntax and temporary compilation checks
- `actionlint` 1.7.12 passes for both changed workflows
- `git diff --check` passes

Refs #373