### PR TITLE
feat(snippets): add Git sparse-checkout backend

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
 
+      - name: Test snippet directory mirror
+        run: zsh -f tests/snippet-directory-mirror.zsh
+
   zd:
     name: ZD integration
     uses: z-shell/zd/.github/workflows/test-native.yml@fd0995d6f7958fea6c4abbc4fff81a6da2277b66 # z-shell/zd#95, #96, #107

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -12,6 +12,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/self-update-reload.zsh"
+      - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/self-update-reload.zsh"
+      - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -111,3 +113,14 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
+
+  snippet-directory-mirror:
+    name: Snippet directory mirror
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test snippet directory mirror
+        run: zsh -f tests/snippet-directory-mirror.zsh

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -2957,6 +2957,9 @@ EOF
 } # ]]]
 # FUNCTION: .zi-ls [[[
 .zi-ls() {
+  builtin emulate -L zsh
+  builtin setopt extendedglob
+
   if (( ${+commands[tree]} )); then
     ZI[TREE]="${commands[tree]} -L 3 -C --charset utf-8"
   elif (( ${+commands[eza]} )); then
@@ -2973,12 +2976,12 @@ EOF
     list=( "${(f@)"$(${=ZI[TREE]})"}" )
     # Oh-My-Zsh single file
     list=( "${list[@]//(#b)(https--github.com--(ohmyzsh|robbyrussel)l--oh-my-zsh--raw--master(--)(#c0,1)(*))/$ZI[col-info]Oh-My-Zsh$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](single-file)$ZI[col-rst] ${match[1]}}" )
-    # Oh-My-Zsh SVN
-    list=( "${list[@]//(#b)(https--github.com--(ohmyzsh|robbyrussel)l--oh-my-zsh--trunk(--)(#c0,1)(*))/$ZI[col-info]Oh-My-Zsh$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](SVN)$ZI[col-rst] ${match[1]}}" )
+    # Oh-My-Zsh Git sparse directory
+    list=( "${list[@]//(#b)(https--github.com--(ohmyzsh|robbyrussel)l--oh-my-zsh--trunk(--)(#c0,1)(*))/$ZI[col-info]Oh-My-Zsh$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](Git sparse)$ZI[col-rst] ${match[1]}}" )
     # Prezto single file
     list=( "${list[@]//(#b)(https--github.com--sorin-ionescu--prezto--raw--master(--)(#c0,1)(*))/$ZI[col-info]Prezto$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](single-file)$ZI[col-rst] ${match[1]}}" )
-    # Prezto SVN
-    list=( "${list[@]//(#b)(https--github.com--sorin-ionescu--prezto--trunk(--)(#c0,1)(*))/$ZI[col-info]Prezto$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](SVN)$ZI[col-rst] ${match[1]}}" )
+    # Prezto Git sparse directory
+    list=( "${list[@]//(#b)(https--github.com--sorin-ionescu--prezto--trunk(--)(#c0,1)(*))/$ZI[col-info]Prezto$ZI[col-error]${match[2]/--//}$ZI[col-pname]${match[3]//--/$ZI[col-error]/$ZI[col-pname]} $ZI[col-info](Git sparse)$ZI[col-rst] ${match[1]}}" )
     # First-level names
     list=( "${list[@]//(#b)(#s)(│   └──|    └──|    ├──|│   ├──) (*)/${match[1]} $ZI[col-p]${match[2]}$ZI[col-rst]}" )
     list[-1]+=", at ZI[SNIPPETS_DIR] - (${ZI[SNIPPETS_DIR]})"

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1721,6 +1721,8 @@ ZI[EXTENDED_GLOB]=""
 # $1 - "status" or "update"
 # $2 - snippet URL
 .zi-update-or-status-snippet() {
+  builtin emulate -L zsh
+  builtin setopt extendedglob
   local st="$1" URL="${2%/}" local_dir filename is_snippet
   (( ${#ICE[@]} > 0 )) && { ZI_SICE[$URL]=""; local nf="-nftid"; }
   local -A ICE2
@@ -1729,7 +1731,14 @@ ZI[EXTENDED_GLOB]=""
   if [[ "$st" = "status" ]]; then
     if (( ${+ICE2[svn]} )); then
       builtin print -r -- "${ZI[col-info]}Status for ${${${local_dir:h}:t}##*--}/${local_dir:t}${ZI[col-rst]}"
-      ( builtin cd -q "$local_dir"; command svn status -vu )
+      if [[ -f $local_dir/._zi/mirror-backend && "$(<$local_dir/._zi/mirror-backend)" = git-sparse ]]; then
+        (( ${+functions[.zi-mirror-using-git]} )) || builtin source ${ZI[BIN_DIR]}"/lib/zsh/install.zsh"
+        local mirror_url=${ICE2[teleid]:-$URL}
+        mirror_url=${mirror_url/(#s)(#m)(${(~kj.|.)ZI_1MAP})/$ZI_1MAP[$MATCH]}
+        .zi-mirror-using-git "$mirror_url" -s "$local_dir"
+      else
+        ( builtin cd -q "$local_dir"; command svn status -vu )
+      fi
       retval=$?
       builtin print
     else

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -683,8 +683,162 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 
   return 0
 } # ]]]
+# FUNCTION: .zi-parse-github-svn-url [[[
+# Parses a legacy GitHub Subversion trunk URL into a Git repository URL and
+# repository-relative directory.
+#
+# $1 - URL in https://github.com/OWNER/REPOSITORY/trunk/PATH form
+.zi-parse-github-svn-url() {
+  builtin emulate -L zsh
+  builtin setopt extendedglob
+
+  local url=${1%/}
+  [[ $url = http(|s)://github.com/* ]] || return 1
+  url=${url/#http:/https:}
+
+  local path=${url#https://github.com/}
+  local owner=${path%%/*}
+  path=${path#*/}
+  local repository=${path%%/*}
+  path=${path#*/}
+
+  repository=${repository%.git}
+  [[ $owner = [[:alnum:]][[:alnum:]._-]# && $repository = [[:alnum:]][[:alnum:]._-]# ]] || return 1
+  [[ $path = trunk/* ]] || return 1
+
+  local subpath=${path#trunk/}
+  local -a components
+  components=( ${(s:/:)subpath} )
+  [[ -n $subpath && $subpath != *[\?\#]* && ${components[(I)(|.|..)]} -eq 0 ]] || return 1
+
+  reply=( "https://github.com/$owner/$repository.git" "$subpath" )
+  return 0
+}
+# ]]]
+# FUNCTION: .zi-mirror-using-git [[[
+# Downloads a GitHub repository directory through a shallow sparse checkout.
+# The selected directory is activated as a complete snapshot, while Zi's
+# metadata is preserved under ._zi.
+#
+# $1 - legacy GitHub Subversion trunk URL
+# $2 - mode, "" - install, "-u" - update, "-t" - test, "-s" - status
+# $3 - installed directory
+.zi-mirror-using-git() {
+  builtin emulate -L zsh
+  builtin setopt extendedglob
+
+  local url=$1 mode=$2 directory=$3
+  (( ${+commands[git]} )) || {
+    +zi-message "{error}Error{ehi}:{rst} Git is required for GitHub directory snippets"
+    return 4
+  }
+
+  .zi-parse-github-svn-url "$url" || {
+    +zi-message "{error}Error{ehi}:{rst} Unsupported GitHub directory URL{ehi}:{rst} {url}$url{rst}"
+    +zi-message "{mmdsh}{rst} Expected {url}https://github.com/OWNER/REPOSITORY/trunk/PATH{rst}"
+    return 4
+  }
+  local repository_url=$reply[1] subpath=$reply[2]
+  local remote_output remote_revision local_revision
+
+  if [[ $mode = -t || $mode = -s ]]; then
+    remote_output=$(command git ls-remote --exit-code "$repository_url" HEAD 2>/dev/null) || {
+      +zi-message "{error}Error{ehi}:{rst} Cannot query GitHub directory snippet revision{ehi}:{rst} {url}$repository_url{rst}"
+      return 4
+    }
+    remote_revision=${remote_output%%[[:space:]]*}
+    [[ -n $remote_revision ]] || return 4
+    [[ -f $directory/._zi/mirror-revision ]] && local_revision="$(<$directory/._zi/mirror-revision)"
+
+    if [[ $mode = -s ]]; then
+      builtin print -r -- "Installed revision: ${local_revision:-unknown}"
+      builtin print -r -- "Remote revision:    $remote_revision"
+      [[ -n $local_revision && $local_revision = $remote_revision ]] && \
+        builtin print -r -- "Directory snapshot is up to date." || \
+        builtin print -r -- "Directory snapshot has an update available."
+      return 0
+    fi
+
+    [[ -n $local_revision && $local_revision = $remote_revision ]] && return 1
+    return 0
+  fi
+
+  [[ -z $mode || $mode = -u ]] || return 4
+  [[ -n $directory && $directory != (.|..) && $directory = ${directory:t} ]] || {
+    +zi-message "{error}Error{ehi}:{rst} Invalid GitHub directory snippet target{ehi}:{rst} {file}$directory{rst}"
+    return 4
+  }
+  [[ ! -L $directory && ! -L $directory/._zi ]] || {
+    +zi-message "{error}Error{ehi}:{rst} Refusing to replace a symlinked GitHub directory snippet or metadata directory"
+    return 4
+  }
+
+  local temp_root
+  temp_root=$(command mktemp -d ".zi-git-mirror.XXXXXXXX") || return 4
+  local repository_dir=$temp_root/repository payload_dir=$temp_root/payload
+  local previous_dir=$temp_root/previous source_dir
+  integer previous_moved=0 activated=0 restore_failed=0
+
+  {
+    command git clone --quiet --depth=1 --filter=blob:none --sparse --single-branch \
+      "$repository_url" "$repository_dir" || return 4
+    command git -C "$repository_dir" sparse-checkout set --cone -- "$subpath" || return 4
+    source_dir=$repository_dir/$subpath
+    [[ -d $source_dir ]] || return 4
+
+    remote_revision=$(command git -C "$repository_dir" rev-parse HEAD) || return 4
+    command mkdir -p -- "$payload_dir" || return 4
+    local -a entries
+    entries=( "$source_dir"/*(DN) )
+    (( ${#entries} )) || return 4
+    command mv -- "${entries[@]}" "$payload_dir/" || return 4
+
+    command rm -rf -- "$payload_dir/._zi" || return 4
+    if [[ -d $directory/._zi ]]; then
+      command cp -Rp -- "$directory/._zi" "$payload_dir/._zi" || return 4
+    else
+      command mkdir -p -- "$payload_dir/._zi" || return 4
+    fi
+    command rm -f -- \
+      "$payload_dir/._zi/mirror-backend" \
+      "$payload_dir/._zi/mirror-revision" || return 4
+    builtin print -r -- git-sparse >! "$payload_dir/._zi/mirror-backend" || return 4
+    builtin print -r -- "$remote_revision" >! "$payload_dir/._zi/mirror-revision" || return 4
+
+    if [[ -e $directory || -L $directory ]]; then
+      command mv -- "$directory" "$previous_dir" || return 4
+      previous_moved=1
+    fi
+    command mv -- "$payload_dir" "$directory" || return 4
+    activated=1
+  } always {
+    if (( previous_moved && !activated )) && [[ ! -e $directory && ! -L $directory && -e $previous_dir ]]; then
+      command mv -- "$previous_dir" "$directory" || {
+        restore_failed=1
+        +zi-message "{error}Error{ehi}:{rst} Could not restore the previous directory snippet; its recovery directory was retained"
+      }
+    fi
+    (( restore_failed )) || command rm -rf -- "$temp_root"
+  }
+
+  (( activated )) || return 4
+  return 0
+}
+# ]]]
+# FUNCTION: .zi-mirror-directory [[[
+# Selects Git sparse checkout for GitHub trunk URLs and preserves Subversion
+# compatibility for other directory-snippet sources.
+.zi-mirror-directory() {
+  builtin emulate -L zsh
+  if [[ $1 = http(|s)://github.com/* ]]; then
+    .zi-mirror-using-git "$@"
+  else
+    .zi-mirror-using-svn "$@"
+  fi
+}
+# ]]]
 # FUNCTION: .zi-mirror-using-svn [[[
-# Used to clone subdirectories from Github.
+# Used to clone subdirectories from non-GitHub Subversion servers.
 # If in update mode (see $2), then invokes `svn update',
 # in normal mode invokes `svn checkout --non-interactive -q <URL>'.
 # In test mode only compares remote and local revision and outputs true if update is needed.
@@ -693,11 +847,14 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - mode, "" - normal, "-u" - update, "-t" - test
 # $3 - subdirectory (not path) with working copy, needed for -t and -u
 .zi-mirror-using-svn() {
-  builtin setopt localoptions extendedglob warncreateglobal
+  builtin emulate -L zsh
+  builtin setopt extendedglob warncreateglobal
   local url="$1" update="$2" directory="$3"
 
-  (( ${+commands[svn]} )) || \
-    +zi-message "{error}Warning{ehi}:{rst} Subversion not found{nl}{mmdsh}{rst} {auto}Please install it to use \`svn' ice"
+  (( ${+commands[svn]} )) || {
+    +zi-message "{error}Error{ehi}:{rst} Subversion not found{nl}{mmdsh}{rst} {auto}Please install it for non-GitHub \`svn' ice sources"
+    return 4
+  }
 
   if [[ "$update" = "-t" ]]; then
     ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
@@ -840,9 +997,9 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   return 0
 } # ]]]
 # FUNCTION: .zi-download-snippet [[[
-# Downloads snippet – either a file – with curl, wget, lftp or lynx, or a directory,
-# with Subversion – when svn-ICE is active. Github supports Subversion protocol and allows
-# to clone subdirectories. This is used to provide a layer of support for Oh-My-Zsh and Prezto.
+# Downloads a snippet file with curl, wget, lftp or lynx. Directory snippets
+# use Git sparse checkout on GitHub and Subversion for other servers when the
+# svn ice is active. This provides a layer of support for Oh-My-Zsh and Prezto.
 .zi-download-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extendedglob warncreateglobal typesetsilent
@@ -910,20 +1067,26 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       # URL
       (
         () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
+        local mirror_name=Subversion
+        [[ $url = http(|s)://github.com/* ]] && mirror_name="Git sparse checkout"
         (( !OPTS[opt_-q,--quiet] )) && \
-        +zi-message "Downloading{ehi}:{rst} {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" ({p}with Subversion{rst})"}:-" ({p}with curl, wget, lftp{rst})"}{…}"
+        +zi-message "Downloading{ehi}:{rst} {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" ({p}with $mirror_name{rst})"}:-" ({p}with curl, wget, lftp{rst})"}{…}"
 
         if (( ${+ICE[svn]} )) {
           if [[ $update = -u ]] {
             # Test if update available
-            if ! .zi-mirror-using-svn "$url" "-t" "$dirname"; then
+            .zi-mirror-directory "$url" "-t" "$dirname"
+            integer mirror_rc=$?
+            if (( mirror_rc == 1 )); then
               if (( ${+ICE[run-atpull]} || OPTS[opt_-u,--urge] )) {
                 ZI[annex-multi-flag:pull-active]=1
               } else { return 0; }
               # Will return when no updates so atpull'' code below doesn't need any checks.
               # This return 0 statement also sets the pull-active flag outside this subshell.
-            else
+            elif (( mirror_rc == 0 )); then
               ZI[annex-multi-flag:pull-active]=2
+            else
+              return 4
             fi
             # Run annexes' atpull hooks (the before atpull-ice ones). The SVN block.
             reply=(
@@ -947,12 +1110,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
               if (( OPTS[opt_-q,--quiet] )); then
                 local id_msg_part="{…} ({p}identified as{ehi}: {id-as}$id_as{rst})"
                 +zi-message "{nl}{apo}Updating snippet{ehi}:{rst} {url}${sname}{rst}${ICE[id-as]:+$id_msg_part}"
-                +zi-message "Downloading{ehi}:{rst} {apo}\`{rst}$sname{apo}\`{rst} ({p}with Subversion{rst}){…}"
+                +zi-message "Downloading{ehi}:{rst} {apo}\`{rst}$sname{apo}\`{rst} ({p}with $mirror_name{rst}){…}"
               fi
-              .zi-mirror-using-svn "$url" "-u" "$dirname" || return 4
+              .zi-mirror-directory "$url" "-u" "$dirname" || return 4
             }
           } else {
-            .zi-mirror-using-svn "$url" "" "$dirname" || return 4
+            .zi-mirror-directory "$url" "" "$dirname" || return 4
           }
 
           # Redundant code, just to compile SVN snippet

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1118,7 +1118,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             .zi-mirror-directory "$url" "" "$dirname" || return 4
           }
 
-          # Redundant code, just to compile SVN snippet
+          # Redundant code, just to compile a directory snippet.
           if [[ ${ICE[as]} != command ]]; then
             if [[ -n ${ICE[pick]} ]]; then
               list=( ${(M)~ICE[pick]##/*}(DN) $local_dir/$dirname/${~ICE[pick]}(DN) )

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -126,12 +126,13 @@
 
   .zi-get-object-path snippet "$url1"
   local_dirA=$reply[-3] dirnameA=$reply[-2]
-  [[ -d "$local_dirA/$dirnameA/.svn" ]] && {
-    svn_dirA=".svn"
+  local mirror_marker="$local_dirA/$dirnameA/._zi/mirror-backend"
+  if [[ -d "$local_dirA/$dirnameA/.svn" || ( -f $mirror_marker && "$(<$mirror_marker)" = git-sparse ) ]]; then
+    [[ -d "$local_dirA/$dirnameA/.svn" ]] && svn_dirA=.svn || svn_dirA=._zi/mirror-backend
     if { .zi-first % "$local_dirA/$dirnameA"; } {
       fileB_there=( ${reply[-1]} )
     }
-  }
+  fi
 
   .zi-get-object-path snippet "$url2"
   local_dirB=$reply[-3] dirnameB=$reply[-2]

--- a/tests/snippet-directory-mirror.zsh
+++ b/tests/snippet-directory-mirror.zsh
@@ -36,6 +36,9 @@ typeset svn_log="$temp_root/svn.log"
 command mkdir -p -- \
   "$source_repo/plugins/example" \
   "$source_repo/plugins/sibling" \
+  "$source_repo/modules/archive/functions" \
+  "$source_repo/modules/directory" \
+  "$source_repo/modules/utility" \
   "$shim_dir" \
   "$install_parent" \
   "$temp_root/home" \
@@ -46,6 +49,9 @@ command mkdir -p -- \
 
 builtin print -r -- v1 >| "$source_repo/plugins/example/example.plugin.zsh"
 builtin print -r -- sibling >| "$source_repo/plugins/sibling/ignored.plugin.zsh"
+builtin print -r -- 'builtin print -r -- archive' >| "$source_repo/modules/archive/functions/archive"
+builtin print -r -- directory >| "$source_repo/modules/directory/init.zsh"
+builtin print -r -- utility >| "$source_repo/modules/utility/init.zsh"
 "$real_git" -C "$source_repo" init -q --initial-branch=main || fail "initialize source repository"
 "$real_git" -C "$source_repo" config user.name "Snippet Mirror Test"
 "$real_git" -C "$source_repo" config user.email "snippet-mirror@example.invalid"
@@ -86,7 +92,13 @@ builtin print -r -- sibling >| "$source_repo/plugins/sibling/ignored.plugin.zsh"
   builtin print -r -- 'exit 0'
 } >| "$shim_dir/svn" || fail "write Subversion shim"
 
-command chmod +x -- "$shim_dir/git" "$shim_dir/mv" "$shim_dir/svn" || fail "make command shims executable"
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- 'printf "%s\n" https--github.com--sorin-ionescu--prezto--trunk--modules--archive'
+} >| "$shim_dir/tree" || fail "write tree shim"
+
+command chmod +x -- "$shim_dir/git" "$shim_dir/mv" "$shim_dir/svn" "$shim_dir/tree" || \
+  fail "make command shims executable"
 
 typeset -gx HOME="$temp_root/home"
 typeset -gx ZDOTDIR="$temp_root/zdotdir"
@@ -115,6 +127,28 @@ mirror() {
   )
 }
 
+# The legacy PZTM shorthand still selects the GitHub directory URL when the
+# svn compatibility ice is present, then exposes the selected module's
+# functions from the Git sparse-checkout snapshot.
+typeset saved_snippets_dir=${ZI[SNIPPETS_DIR]}
+ZI[SNIPPETS_DIR]="$install_parent/prezto-objects"
+zi ice svn silent nocompile
+zi snippet PZTM::archive >/dev/null || fail "load PZTM archive directory snippet"
+.zi-get-object-path snippet PZTM::archive 2>/dev/null
+typeset prezto_local_dir=$reply[-3] prezto_dirname=$reply[-2]
+typeset prezto_object="$prezto_local_dir/$prezto_dirname"
+[[ $(<"$prezto_object/._zi/mirror-backend") = git-sparse ]] || fail "record PZTM Git backend"
+[[ -n ${fpath[(r)$prezto_object/functions]} ]] || fail "add PZTM functions directory to fpath"
+(( ${+functions[archive]} )) || fail "autoload PZTM archive function"
+[[ ! -e "$prezto_object/directory/init.zsh" ]] || fail "exclude sibling Prezto module"
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload library"
+typeset list_output
+list_output="$(.zi-ls)" || fail "list Git sparse directory snippet"
+[[ $list_output = *"(Git sparse)"* ]] || fail "label PZTM Git sparse backend"
+[[ $list_output != *"(SVN)"* ]] || fail "avoid stale PZTM Subversion label"
+ZI[SNIPPETS_DIR]=$saved_snippets_dir
+pass "load PZTM directory snippet through Git sparse checkout"
+
 # A fresh GitHub directory install contains only the selected subtree and
 # records enough metadata for later update and status checks.
 mirror "$github_url" "" installed || fail "install GitHub directory snippet"
@@ -128,7 +162,6 @@ pass "install selected GitHub directory"
 
 # Zi's object-path and status layers recognize the new metadata marker instead
 # of treating the copied snapshot as either a single file or an SVN checkout.
-typeset saved_snippets_dir=${ZI[SNIPPETS_DIR]}
 typeset status_output
 ZI[SNIPPETS_DIR]="$install_parent/object-paths"
 .zi-get-object-path snippet "$github_url" 2>/dev/null

--- a/tests/snippet-directory-mirror.zsh
+++ b/tests/snippet-directory-mirror.zsh
@@ -1,0 +1,243 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset real_git="${commands[git]}"
+typeset real_mv="${commands[mv]}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-mirror-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+for dependency in git mktemp; do
+  (( ${+commands[$dependency]} )) || fail "missing test dependency: $dependency"
+done
+
+typeset source_repo="$temp_root/source"
+typeset remote_repo="$temp_root/remote.git"
+typeset shim_dir="$temp_root/shims"
+typeset install_parent="$temp_root/snippets"
+typeset svn_log="$temp_root/svn.log"
+
+command mkdir -p -- \
+  "$source_repo/plugins/example" \
+  "$source_repo/plugins/sibling" \
+  "$shim_dir" \
+  "$install_parent" \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" || fail "create fixture directories"
+
+builtin print -r -- v1 >| "$source_repo/plugins/example/example.plugin.zsh"
+builtin print -r -- sibling >| "$source_repo/plugins/sibling/ignored.plugin.zsh"
+"$real_git" -C "$source_repo" init -q --initial-branch=main || fail "initialize source repository"
+"$real_git" -C "$source_repo" config user.name "Snippet Mirror Test"
+"$real_git" -C "$source_repo" config user.email "snippet-mirror@example.invalid"
+"$real_git" -C "$source_repo" config commit.gpgsign false
+"$real_git" -C "$source_repo" add .
+"$real_git" -C "$source_repo" commit -qm "test: add initial directory snippet" || fail "commit initial fixture"
+"$real_git" clone -q --bare "$source_repo" "$remote_repo" || fail "create fixture remote"
+"$real_git" -C "$remote_repo" config uploadpack.allowFilter true
+
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- 'if [ "$1" = clone ]; then'
+  builtin print -r -- '  [ "${ZI_TEST_FAIL_CLONE:-0}" = 1 ] && exit 42'
+  builtin print -r -- '  for last_arg do :; done'
+  builtin print -r -- '  exec "$ZI_TEST_REAL_GIT" clone --quiet --depth=1 --filter=blob:none --sparse --single-branch "$ZI_TEST_REMOTE" "$last_arg"'
+  builtin print -r -- 'fi'
+  builtin print -r -- 'if [ "$1" = ls-remote ]; then'
+  builtin print -r -- '  exec "$ZI_TEST_REAL_GIT" ls-remote --exit-code "$ZI_TEST_REMOTE" HEAD'
+  builtin print -r -- 'fi'
+  builtin print -r -- 'exec "$ZI_TEST_REAL_GIT" "$@"'
+} >| "$shim_dir/git" || fail "write Git shim"
+
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- 'if [ "${ZI_TEST_FAIL_ACTIVATION:-0}" = 1 ] && [ "$1" = -- ]; then'
+  builtin print -r -- '  case "$2" in */payload) exit 42 ;; esac'
+  builtin print -r -- 'fi'
+  builtin print -r -- 'exec "$ZI_TEST_REAL_MV" "$@"'
+} >| "$shim_dir/mv" || fail "write move shim"
+
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- 'printf "%s\n" "$*" >> "$ZI_TEST_SVN_LOG"'
+  builtin print -r -- 'if [ "$1" = checkout ]; then'
+  builtin print -r -- '  mkdir -p "$5/.svn"'
+  builtin print -r -- '  printf "%s\n" svn > "$5/from-svn.txt"'
+  builtin print -r -- 'fi'
+  builtin print -r -- 'exit 0'
+} >| "$shim_dir/svn" || fail "write Subversion shim"
+
+command chmod +x -- "$shim_dir/git" "$shim_dir/mv" "$shim_dir/svn" || fail "make command shims executable"
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gx ZI_TEST_REAL_GIT="$real_git"
+typeset -gx ZI_TEST_REAL_MV="$real_mv"
+typeset -gx ZI_TEST_REMOTE="file://$remote_repo"
+typeset -gx ZI_TEST_SVN_LOG="$svn_log"
+path=( "$shim_dir" "${path[@]}" )
+rehash
+
+typeset -gAH ZI OPTS
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || fail "source install library"
+
+typeset github_url=https://github.com/example/project/trunk/plugins/example
+
+mirror() {
+  builtin emulate -L zsh
+  (
+    builtin cd -q -- "$install_parent" || return 1
+    .zi-mirror-directory "$@"
+  )
+}
+
+# A fresh GitHub directory install contains only the selected subtree and
+# records enough metadata for later update and status checks.
+mirror "$github_url" "" installed || fail "install GitHub directory snippet"
+[[ $(<"$install_parent/installed/example.plugin.zsh") = v1 ]] || fail "install selected subtree content"
+[[ ! -e "$install_parent/installed/ignored.plugin.zsh" ]] || fail "exclude sibling subtree"
+[[ ! -e "$install_parent/installed/.git" ]] || fail "do not expose staging repository"
+[[ $(<"$install_parent/installed/._zi/mirror-backend") = git-sparse ]] || fail "record Git backend"
+typeset initial_revision="$(<"$install_parent/installed/._zi/mirror-revision")"
+[[ -n $initial_revision ]] || fail "record installed revision"
+pass "install selected GitHub directory"
+
+# Zi's object-path and status layers recognize the new metadata marker instead
+# of treating the copied snapshot as either a single file or an SVN checkout.
+typeset saved_snippets_dir=${ZI[SNIPPETS_DIR]}
+typeset status_output
+ZI[SNIPPETS_DIR]="$install_parent/object-paths"
+.zi-get-object-path snippet "$github_url" 2>/dev/null
+typeset object_local_dir=$reply[-3] object_dirname=$reply[-2]
+command mkdir -p -- "$object_local_dir" || fail "create integration object parent"
+(
+  builtin cd -q -- "$object_local_dir" || return 1
+  .zi-mirror-directory "$github_url" "" "$object_dirname"
+) || fail "install integration directory snippet"
+typeset -A stored_ice=( svn "" )
+.zi-store-ices "$object_local_dir/$object_dirname/._zi" stored_ice "" "" "$github_url" 1
+.zi-two-paths "$github_url" 2>/dev/null
+[[ $reply[-3] = ._zi/mirror-backend ]] || fail "recognize Git mirror object path"
+ICE=()
+status_output="$(.zi-update-or-status-snippet status "$github_url" 2>/dev/null)" || fail "run integrated status"
+[[ $status_output = *"Directory snapshot is up to date."* ]] || fail "report integrated Git mirror status"
+ZI[SNIPPETS_DIR]=$saved_snippets_dir
+pass "integrate object-path and status detection"
+
+if mirror "$github_url" -t installed; then
+  fail "unchanged directory reports an update"
+else
+  (( $? == 1 )) || fail "unchanged directory returns no-update status"
+fi
+status_output="$(mirror "$github_url" -s installed)" || fail "query Git directory status"
+[[ $status_output = *"Directory snapshot is up to date."* ]] || fail "report up-to-date status"
+pass "detect unchanged GitHub directory"
+
+# A remote change is detected, replaces the payload, removes stale payload
+# files, and preserves Zi-owned metadata.
+builtin print -r -- v2 >| "$source_repo/plugins/example/example.plugin.zsh"
+builtin print -r -- added >| "$source_repo/plugins/example/added.zsh"
+"$real_git" -C "$source_repo" add .
+"$real_git" -C "$source_repo" commit -qm "test: update directory snippet" || fail "commit updated fixture"
+"$real_git" -C "$source_repo" push -q "$remote_repo" main || fail "publish updated fixture"
+
+builtin print -r -- stale >| "$install_parent/installed/stale.zsh"
+builtin print -r -- keep >| "$install_parent/installed/._zi/custom-metadata"
+mirror "$github_url" -t installed || fail "detect remote update"
+mirror "$github_url" -u installed || fail "update GitHub directory snippet"
+[[ $(<"$install_parent/installed/example.plugin.zsh") = v2 ]] || fail "activate updated content"
+[[ -f "$install_parent/installed/added.zsh" ]] || fail "activate added content"
+[[ ! -e "$install_parent/installed/stale.zsh" ]] || fail "remove stale payload"
+[[ $(<"$install_parent/installed/._zi/custom-metadata") = keep ]] || fail "preserve Zi metadata"
+typeset updated_revision="$(<"$install_parent/installed/._zi/mirror-revision")"
+[[ $updated_revision != $initial_revision ]] || fail "advance installed revision"
+pass "update GitHub directory snapshot"
+
+# A staging failure leaves the previously activated directory untouched.
+builtin print -r -- v3 >| "$source_repo/plugins/example/example.plugin.zsh"
+"$real_git" -C "$source_repo" add .
+"$real_git" -C "$source_repo" commit -qm "test: publish failing update" || fail "commit failing-update fixture"
+"$real_git" -C "$source_repo" push -q "$remote_repo" main || fail "publish failing-update fixture"
+
+builtin print -r -- local >| "$install_parent/installed/local-sentinel"
+typeset -gx ZI_TEST_FAIL_ACTIVATION=1
+if mirror "$github_url" -u installed >/dev/null 2>&1; then
+  fail "failed activation reports success"
+fi
+unset ZI_TEST_FAIL_ACTIVATION
+[[ $(<"$install_parent/installed/example.plugin.zsh") = v2 ]] || fail "preserve old payload after failure"
+[[ -f "$install_parent/installed/local-sentinel" ]] || fail "preserve local file after failure"
+[[ $(<"$install_parent/installed/._zi/mirror-revision") = $updated_revision ]] || fail "preserve revision after failure"
+pass "roll back failed GitHub directory update"
+
+# An existing GitHub Subversion working copy migrates only after the Git
+# snapshot has staged successfully.
+command mkdir -p -- "$install_parent/legacy/.svn" "$install_parent/legacy/._zi" || fail "create migration fixture"
+builtin print -r -- legacy >| "$install_parent/legacy/old.zsh"
+builtin print -r -- keep >| "$install_parent/legacy/._zi/custom-metadata"
+mirror "$github_url" -u legacy || fail "migrate GitHub Subversion working copy"
+[[ $(<"$install_parent/legacy/example.plugin.zsh") = v3 ]] || fail "activate migrated content"
+[[ ! -e "$install_parent/legacy/.svn" ]] || fail "remove obsolete Subversion metadata"
+[[ $(<"$install_parent/legacy/._zi/custom-metadata") = keep ]] || fail "preserve migration metadata"
+[[ $(<"$install_parent/legacy/._zi/mirror-backend") = git-sparse ]] || fail "record migrated backend"
+pass "migrate existing GitHub Subversion directory"
+
+# GitHub URLs outside the supported legacy trunk shape fail closed instead of
+# falling through to Subversion, while other hosts retain Subversion behavior.
+if mirror https://github.com/example/project/tree/main/plugins/example "" unsupported >/dev/null 2>&1; then
+  fail "unsupported GitHub URL reports success"
+fi
+[[ ! -e $svn_log ]] || fail "unsupported GitHub URL falls through to Subversion"
+
+mirror https://svn.example.invalid/repository/path "" svn-target || fail "retain non-GitHub Subversion backend"
+[[ $(<"$install_parent/svn-target/from-svn.txt") = svn ]] || fail "install through Subversion backend"
+[[ $(<$svn_log) = checkout* ]] || fail "record Subversion checkout"
+pass "preserve non-GitHub Subversion boundary"
+
+# Path traversal in a legacy GitHub URL is rejected before any filesystem
+# activation occurs.
+if mirror https://github.com/example/project/trunk/plugins/../private "" traversal >/dev/null 2>&1; then
+  fail "path traversal URL reports success"
+fi
+[[ ! -e "$install_parent/traversal" ]] || fail "path traversal URL creates a target"
+pass "reject unsafe GitHub directory path"
+
+# Symlinked targets and metadata directories are rejected before staging so a
+# user-controlled link cannot redirect metadata writes or replacement.
+command ln -s -- installed "$install_parent/linked-target" || fail "create symlink target fixture"
+if mirror "$github_url" -u linked-target >/dev/null 2>&1; then
+  fail "symlinked target reports success"
+fi
+[[ -L "$install_parent/linked-target" ]] || fail "symlinked target was replaced"
+
+command mkdir -p -- "$install_parent/linked-metadata" "$temp_root/external-metadata" || fail "create metadata link fixture"
+command ln -s -- "$temp_root/external-metadata" "$install_parent/linked-metadata/._zi" || fail "create metadata symlink"
+if mirror "$github_url" -u linked-metadata >/dev/null 2>&1; then
+  fail "symlinked metadata directory reports success"
+fi
+[[ -L "$install_parent/linked-metadata/._zi" ]] || fail "metadata symlink was replaced"
+pass "reject symlinked activation targets"

--- a/zi.zsh
+++ b/zi.zsh
@@ -1377,7 +1377,7 @@ builtin setopt noaliases
     (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
   elif [[ -n ${opts[(r)--command]} || ${ICE[as]} = command ]]; then
     [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]] && ICE[pick]="${id_as:t}"
-    # Subversion - directory and multiple files possible.
+    # Directory snippet - a directory and multiple files are possible.
     if (( ${+ICE[svn]} )); then
       if [[ -n ${ICE[pick]} ]]; then
         list=( ${(M)~ICE[pick]##/*}(DN) $local_dir/$dirname/${~ICE[pick]}(DN) )


### PR DESCRIPTION
## Summary

- route legacy GitHub `/trunk/` directory snippets through shallow cone-mode Git sparse checkout
- preserve non-GitHub SVN compatibility and migrate existing GitHub `.svn` installs transactionally
- add status metadata, rollback, input and symlink hardening, and isolated regression coverage

## Test approach

Zi has no ZUnit harness, so this uses the repository's existing standalone isolated Zsh test pattern, as approved for #353.

## Verification

- `zsh -f tests/snippet-directory-mirror.zsh`
- full 28-file `zsh -n` and `zcompile` sweep
- existing version, self-update, archive, completion, and public-contract suites
- `actionlint .github/workflows/zsh-n.yml .github/workflows/promotion-readiness.yml`
- real GitHub smoke against `ohmyzsh/ohmyzsh/trunk/plugins/git`
- `git diff --check`

Trunk reported no lint findings locally, but five `git-diff-check` execution failures because its temporary sandbox lacked submodule Git metadata. Native `git diff --check` passed.

Closes #353