### PR TITLE
ci(promotion): bootstrap candidate test suite

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install Zsh
-        run: sudo apt-get update && sudo apt-get install -yq zsh
+      - name: Install Zsh and archive tools
+        run: sudo apt-get update && sudo apt-get install -yq zsh zip unzip
 
       - name: Check and compile Zsh sources
         shell: bash
@@ -47,6 +47,22 @@ jobs:
 
       - name: Test version reporting
         run: zsh tests/version-reporting.zsh
+
+      - name: Test self-update reload when present
+        if: ${{ hashFiles('tests/self-update-reload.zsh') != '' }}
+        run: zsh -f tests/self-update-reload.zsh
+
+      - name: Test archive extraction when present
+        if: ${{ hashFiles('tests/archive-extraction.zsh') != '' }}
+        run: zsh tests/archive-extraction.zsh
+
+      - name: Test completion refresh when present
+        if: ${{ hashFiles('tests/completion-refresh.zsh') != '' }}
+        run: zsh tests/completion-refresh.zsh
+
+      - name: Test snippet directory mirror when present
+        if: ${{ hashFiles('tests/snippet-directory-mirror.zsh') != '' }}
+        run: zsh -f tests/snippet-directory-mirror.zsh
 
   zd:
     name: ZD integration


### PR DESCRIPTION
## Summary

- bootstrap the current `next` candidate test suite into the `main` promotion workflow
- guard each test with `hashFiles()` so the main-based bootstrap candidate skips files it does not yet contain
- install the archive tools required when the future candidate includes the archive extraction test

## Why this targets main

GitHub evaluates `pull_request` workflow definitions from the base branch. Without this bootstrap, the first `next` to `main` promotion containing #417 would use the older workflow from `main` and would not run the newer candidate tests.

The guards return false on current `main`, where these test files are absent. They evaluate true for the current `next` candidate, where all four files exist. A scoped follow-up on `next` will retain the same guards, avoiding a workflow merge conflict while preserving full candidate coverage.

## Verification

- `actionlint .github/workflows/promotion-readiness.yml`
- `git diff --check`
- confirmed all guarded test paths are absent from current `main`
- confirmed all guarded test paths are present on current `next`
- confirmed `hashFiles()` is supported in step `if` expressions and returns an empty string when no files match
- all GitHub checks passed, including the promotion gate

No Zi runtime behavior, semantic tag, release, or promotion is included.

Related: #353