### PR TITLE
fix(ci): retain promotion test guards

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -48,16 +48,20 @@ jobs:
       - name: Test version reporting
         run: zsh tests/version-reporting.zsh
 
-      - name: Test self-update reload
+      - name: Test self-update reload when present
+        if: ${{ hashFiles('tests/self-update-reload.zsh') != '' }}
         run: zsh -f tests/self-update-reload.zsh
 
-      - name: Test archive extraction
+      - name: Test archive extraction when present
+        if: ${{ hashFiles('tests/archive-extraction.zsh') != '' }}
         run: zsh tests/archive-extraction.zsh
 
-      - name: Test completion refresh
+      - name: Test completion refresh when present
+        if: ${{ hashFiles('tests/completion-refresh.zsh') != '' }}
         run: zsh tests/completion-refresh.zsh
 
-      - name: Test snippet directory mirror
+      - name: Test snippet directory mirror when present
+        if: ${{ hashFiles('tests/snippet-directory-mirror.zsh') != '' }}
         run: zsh -f tests/snippet-directory-mirror.zsh
 
   zd:


### PR DESCRIPTION
## Summary

- retain the main-bootstrap `hashFiles()` guards on the `next` promotion workflow
- keep every current candidate test enabled when its file is present
- avoid a divergent workflow edit when `next` is promoted to `main`

## Verification

- `actionlint .github/workflows/promotion-readiness.yml`
- Ruby YAML parse
- `git diff --check`
- confirmed the resulting workflow matches the guarded bootstrap merged by #418

Related: #353