### PR TITLE
docs: align co-author policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,7 +45,8 @@
 
 - [ ] Ordinary work targets `next`; only same-repository hotfixes target `main`
 - [ ] Commit messages follow Conventional Commits format
-- [ ] No `Co-authored-by` trailers in commit messages
+- [ ] Any `Co-authored-by` trailer credits a real human, never a bot, AI agent,
+      or automation
 - [ ] I have read the [contribution guidelines](https://github.com/z-shell/.github/blob/main/.github/CONTRIBUTING.md)
 - [ ] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
 - [ ] Documentation updated if needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,4 +19,6 @@ annexes, plugins, documentation, installers, and test environments.
 - Write Zsh-first code and avoid Bash-only syntax.
 - Run the existing Zsh syntax, integration, and focused tests for changed paths.
 - Keep user-facing documentation in the canonical wiki when practical.
-- Follow the organization commit policy and never add `Co-authored-by` trailers.
+- Follow the organization commit policy. A `Co-authored-by` trailer may credit a
+  real human, including the pull-request author; never credit a bot, AI agent,
+  or automation as a co-author.


### PR DESCRIPTION
## Summary

- align repository guidance with the organization policy for human
  `Co-authored-by` credit
- retain the prohibition on bot, agent, and automation co-author trailers

## Verification

- cross-repository instruction contract: 88 tests passed
- `git diff --check origin/next...HEAD`
