### PR TITLE
chore(contract): refresh consumer evidence and detect stale pins

### DIFF
--- a/.github/workflows/public-contract-evidence.yml
+++ b/.github/workflows/public-contract-evidence.yml
@@ -1,0 +1,40 @@
+---
+name: Public Contract Evidence
+
+# Consumer evidence pins in contracts/public-contract-v1.json cite a fixed
+# commit. Nothing detects when the consumer file moves on, so a pin can
+# silently describe a version that no longer exists. This scheduled report
+# surfaces those pins for maintainer review; it never edits the manifest.
+
+on:
+  schedule:
+    # Weekly, Monday, offset off the hour to avoid the scheduler peak.
+    - cron: "23 7 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-contract-evidence
+  cancel-in-progress: false
+
+jobs:
+  evidence:
+    name: Consumer evidence freshness
+    if: github.repository == 'z-shell/zi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -yq jq zsh
+
+      - name: Report stale consumer evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zsh scripts/public-contract-evidence.zsh

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_version": 1,
-  "evidence_reviewed": "2026-08-24",
+  "evidence_reviewed": "2026-08-28",
   "renames": [],
   "surfaces": [
     {
@@ -99,13 +99,13 @@
       "repository": "z-shell/src",
       "path": "public/sh/install.sh",
       "surfaces": ["installer-git-output"],
-      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/sh/install.sh"
+      "evidence": "https://github.com/z-shell/src/blob/5ac79863d55baf056796e5e3afce5970506b8871/public/sh/install.sh"
     },
     {
       "repository": "z-shell/src",
       "path": "public/zsh/init.zsh",
       "surfaces": ["installer-git-output"],
-      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/zsh/init.zsh"
+      "evidence": "https://github.com/z-shell/src/blob/5ac79863d55baf056796e5e3afce5970506b8871/public/zsh/init.zsh"
     },
     {
       "repository": "z-shell/zd",

--- a/scripts/public-contract-evidence.zsh
+++ b/scripts/public-contract-evidence.zsh
@@ -1,0 +1,128 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# public-contract-evidence.zsh -- report stale consumer evidence pins.
+#
+# Every entry in contracts/public-contract-v1.json cites a consumer file at a
+# fixed commit. Nothing detects when that consumer file moves on, so an
+# evidence URL can silently describe a version that no longer exists. This
+# script compares the Git blob object of each pinned path against the blob
+# currently on the consumer repository's default branch.
+#
+# A stale pin is a review signal, not automatically a contract break: the
+# consumer may have changed lines unrelated to the surfaces it claims. Re-read
+# the consumer, then bump the pin when the claim still holds.
+#
+# Usage:
+#   zsh scripts/public-contract-evidence.zsh [--manifest PATH] [--quiet]
+#
+# Exit codes:
+#   0  every pin resolves and matches the consumer default branch
+#   1  at least one pin is stale or unresolvable
+#   2  usage or dependency error
+
+emulate -LR zsh
+setopt errexit nounset pipefail
+
+typeset manifest_path="contracts/public-contract-v1.json"
+integer quiet=0
+
+usage() {
+  print "usage: ${0:t} [--manifest PATH] [--quiet]"
+}
+
+while (( $# )); do
+  case "$1" in
+    --manifest)
+      manifest_path="${2-}"
+      shift 2
+      ;;
+    --quiet)
+      quiet=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      print -u2 "public-contract-evidence: unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for command_name in gh jq; do
+  (( $+commands[$command_name] )) || {
+    print -u2 "public-contract-evidence: required command not found: ${command_name}"
+    exit 2
+  }
+done
+
+[[ -r $manifest_path ]] || {
+  print -u2 "public-contract-evidence: cannot read manifest: ${manifest_path}"
+  exit 2
+}
+
+# Resolve a path's blob object id. With a ref, read that exact commit;
+# without one, read the repository default branch.
+blob_at() {
+  local repository="$1" file_path="$2" ref="${3-}" endpoint
+  endpoint="repos/${repository}/contents/${file_path}"
+  [[ -n $ref ]] && endpoint+="?ref=${ref}"
+  command gh api "$endpoint" --jq '.sha' 2>/dev/null
+}
+
+typeset -a stale=() unresolved=()
+typeset line repository file_path evidence commit pinned_blob head_blob
+integer checked=0
+
+while IFS=$'\t' read -r repository file_path evidence; do
+  [[ -n $repository ]] || continue
+  (( checked += 1 ))
+  commit="${${evidence#*/blob/}%%/*}"
+
+  pinned_blob="$(blob_at "$repository" "$file_path" "$commit")" || pinned_blob=""
+  head_blob="$(blob_at "$repository" "$file_path")" || head_blob=""
+
+  if [[ -z $pinned_blob || -z $head_blob ]]; then
+    unresolved+=( "${repository}/${file_path}" )
+    continue
+  fi
+  if [[ $pinned_blob != $head_blob ]]; then
+    stale+=( "${repository}/${file_path}"$'\t'"${commit}"$'\t'"${pinned_blob}"$'\t'"${head_blob}" )
+    continue
+  fi
+  (( quiet )) || print -r -- "current   ${repository}/${file_path}"
+done < <(jq -r '.consumers[] | [.repository, .path, .evidence] | @tsv' "$manifest_path")
+
+if (( ${#unresolved} )); then
+  print -u2 -r -- ""
+  print -u2 -r -- "Unresolvable evidence (moved, renamed, or private):"
+  for line in "${unresolved[@]}"; do
+    print -u2 -r -- "  ${line}"
+  done
+fi
+
+if (( ${#stale} )); then
+  print -u2 -r -- ""
+  print -u2 -r -- "Stale evidence pins (consumer file changed since the pinned commit):"
+  for line in "${stale[@]}"; do
+    print -u2 -r -- "  ${${(s:	:)line}[1]}"
+    print -u2 -r -- "    pinned commit : ${${(s:	:)line}[2]}"
+    print -u2 -r -- "    pinned blob   : ${${(s:	:)line}[3]}"
+    print -u2 -r -- "    current blob  : ${${(s:	:)line}[4]}"
+  done
+  print -u2 -r -- ""
+  print -u2 -r -- "Re-read each consumer, confirm the claimed surfaces still apply,"
+  print -u2 -r -- "then bump its evidence commit and evidence_reviewed."
+fi
+
+if (( ${#stale} || ${#unresolved} )); then
+  exit 1
+fi
+
+(( quiet )) || print -r -- ""
+print -r -- "public-contract-evidence: ${checked} consumer pins current"


### PR DESCRIPTION
Closes #431.

## What this changes

Every consumer entry in `contracts/public-contract-v1.json` cites a file at a fixed commit, but nothing detected when that file moved on. The two `z-shell/src` entries still pointed at `5e301f2`, superseded by `5ac7986`, and the `init.zsh` blob had changed underneath the pin:

```console
$ gh api "repos/z-shell/src/contents/public/zsh/init.zsh?ref=5e301f2b..." -q .sha
74544ef108ab09fd5103802b8fc4c1309ce2f481
$ gh api "repos/z-shell/src/contents/public/zsh/init.zsh" -q .sha
c72db2050a9d39511dd86a1fcc9b1a73ec30c9a4
```

The intervening commit did not touch the claimed `installer-git-output` surface, so this is evidence drift rather than a contract break.

## Changes

- Repin both `z-shell/src` consumers to `5ac7986` and refresh `evidence_reviewed`.
- Add `scripts/public-contract-evidence.zsh`, comparing each pinned path's Git blob object against the blob on the consumer's default branch. Blob identity is the right test here: it ignores unrelated commits in the same repository and reports only consumers whose cited file actually changed.
- Run it weekly via `public-contract-evidence.yml`, which reports for maintainer review and never edits the manifest.

## Deliberately not fixed here

The new check reports three further stale pins. Each needs its consumer re-read before the surface claim can be reaffirmed, which is judgment work rather than a mechanical repin:

| Consumer | Path |
| --- | --- |
| `z-shell/docs` | `code/zsdoc/asciidoc/zi.zsh.adoc` |
| `z-shell/zd` | `tests/helpers.zsh` |
| `z-shell/z-a-meta-plugins` | `z-a-meta-plugins.plugin.zsh` |

The workflow will keep surfacing them until they are reviewed.

## Note on scope

The checker reports rather than gates. A stale pin is a review signal, not automatically a break, and making it a required check would fail PRs for changes in other repositories that the PR author cannot fix.

## Verification

- `zsh -n scripts/public-contract-evidence.zsh` clean; script exercised against all 20 consumers.
- `zsh tests/public-contract-impact.zsh` passes (17 assertions).
- `zsh scripts/public-contract-impact.zsh --base origin/next --head HEAD` reports no public-contract change.
