### PR TITLE
chore(branching): promote XDG path defaults

### DIFF
--- a/.github/workflows/promotion-readiness.yml
+++ b/.github/workflows/promotion-readiness.yml
@@ -52,6 +52,10 @@ jobs:
         if: ${{ hashFiles('tests/self-update-reload.zsh') != '' }}
         run: zsh -f tests/self-update-reload.zsh
 
+      - name: Test path resolution when present
+        if: ${{ hashFiles('tests/path-resolution.zsh') != '' }}
+        run: zsh -f tests/path-resolution.zsh
+
       - name: Test archive extraction when present
         if: ${{ hashFiles('tests/archive-extraction.zsh') != '' }}
         run: zsh tests/archive-extraction.zsh
@@ -158,6 +162,9 @@ jobs:
             exit 1
           (( ${+functions[zi]} )) || exit 1
           .zi-prepare-home || exit 1
+          [[ ${ZI[HOME_DIR]} = ${XDG_DATA_HOME}/zi ]] || exit 1
+          [[ ${ZI[CACHE_DIR]} = ${XDG_CACHE_HOME}/zi ]] || exit 1
+          [[ ${ZI[CONFIG_DIR]} = ${XDG_CONFIG_HOME}/zi ]] || exit 1
           [[ -d ${ZI[HOME_DIR]} ]] || exit 1
           ZSH
 

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -11,6 +11,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/path-resolution.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -20,6 +21,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/path-resolution.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -80,6 +82,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test version reporting
         run: zsh tests/version-reporting.zsh
+
+  path-resolution:
+    name: Path resolution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test path resolution
+        run: zsh -f tests/path-resolution.zsh
 
   self-update-reload:
     name: Self-update reload

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1955,6 +1955,11 @@ ZI[EXTENDED_GLOB]=""
   +zi-message "{msg}Modules{ehi}:{rst} {tab}{tab}{tab}{tab}{dir}${ZI[ZMODULES_DIR]}{rst}"
   +zi-message "{msg}User-land{ehi}:{rst} {tab}{tab}{dir}${ZPFX}{rst}"
   +zi-message "{msg}Completions{ehi}:{rst}{tab}{dir}${ZI[COMPLETIONS_DIR]}{rst}"
+  if [[ ${ZI[HOME_LAYOUT]} == legacy ]]; then
+    +zi-message "{info3}Legacy Zi home retained{ehi}:{rst} {dir}${ZI[HOME_DIR]}{rst}. Set {var}ZI[HOME_DIR]{rst} before sourcing Zi to opt in to a different root; no data was moved."
+  elif [[ ${ZI[HOME_LAYOUT]} == ambiguous-* ]]; then
+    +zi-message "{info3}Both legacy and XDG Zi homes were detected{ehi}.{rst} Zi selected {dir}${ZI[HOME_DIR]}{rst}. Set {var}ZI[HOME_DIR]{rst} before sourcing Zi to resolve the ambiguity; no data was moved."
+  fi
   # Without _zlocal/zi
   +zi-message "{info}Loaded plugins{ehi}:{rst} {num}$(( ${#ZI_REGISTERED_PLUGINS[@]} - 1 )){rst}"
   # Count light-loaded plugins

--- a/tests/path-resolution.zsh
+++ b/tests/path-resolution.zsh
@@ -1,0 +1,262 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+setopt errexit pipefail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-path-resolution.XXXXXXXX")"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+zmodload zsh/stat
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin print -r -- "ok - $1"
+}
+
+assert_equal() {
+  [[ $1 == "$2" ]] || fail "$3: expected ${(qqq)2}, got ${(qqq)1}"
+}
+
+assert_private() {
+  local -A path_stat
+  zstat -H path_stat +mode -- "$1" || fail "$2: stat failed"
+  (( (path_stat[mode] & 8#77) == 0 )) || fail "$2: group or other permissions are set"
+}
+
+assert_mode() {
+  local -A path_stat
+  zstat -H path_stat +mode -- "$1" || fail "$2: stat failed"
+  (( (path_stat[mode] & 8#777) == $3 )) || fail "$2: mode changed"
+}
+
+assert_paths() {
+  local label="$1" expected_home="$2" expected_cache="$3" expected_config="$4"
+  local expected_layout="$5" expected_log="${6:-${expected_cache}/log}"
+  local expected_zcompdump="${7:-${expected_cache}/.zcompdump}"
+  local expected_zpfx="${8:-${expected_home}/polaris}"
+
+  assert_equal "${ZI[HOME_DIR]}" "$expected_home" "$label home"
+  assert_equal "${ZI[CACHE_DIR]}" "$expected_cache" "$label cache"
+  assert_equal "${ZI[CONFIG_DIR]}" "$expected_config" "$label config"
+  assert_equal "${ZI[LOG_DIR]}" "$expected_log" "$label log"
+  assert_equal "${ZI[ZCOMPDUMP_PATH]}" "$expected_zcompdump" "$label zcompdump"
+  assert_equal "$ZPFX" "$expected_zpfx" "$label ZPFX"
+  assert_equal "${ZI[PLUGINS_DIR]}" "${expected_home}/plugins" "$label plugins"
+  assert_equal "${ZI[SNIPPETS_DIR]}" "${expected_home}/snippets" "$label snippets"
+  assert_equal "${ZI[COMPLETIONS_DIR]}" "${expected_home}/completions" "$label completions"
+  assert_equal "${ZI[ZMODULES_DIR]}" "${expected_home}/zmodules" "$label zmodules"
+  assert_equal "$XDG_ZI_HOME" "$expected_home" "$label XDG_ZI_HOME output"
+  assert_equal "$XDG_ZI_CACHE" "$expected_cache" "$label XDG_ZI_CACHE output"
+  assert_equal "$XDG_ZI_CONFIG" "$expected_config" "$label XDG_ZI_CONFIG output"
+  assert_equal "${ZI[HOME_LAYOUT]}" "$expected_layout" "$label layout"
+}
+
+run_case() (
+  builtin emulate -LR zsh
+  setopt errexit pipefail
+
+  local label="$1" case_root="${temp_root}/$1"
+  local source_path="$project_root/zi.zsh"
+  local expected_home expected_cache expected_config expected_layout
+  local expected_log expected_zcompdump expected_zpfx status_output
+
+  command mkdir -p -- "$case_root/home" "$case_root/zdotdir" "$case_root/tmp"
+  builtin cd -q -- "$case_root"
+
+  typeset -gx HOME="$case_root/home"
+  typeset -gx ZDOTDIR="$case_root/zdotdir"
+  typeset -gx TMPDIR="$case_root/tmp"
+  unset XDG_DATA_HOME XDG_CACHE_HOME XDG_CONFIG_HOME
+  unset ZPFX XDG_ZI_HOME XDG_ZI_CACHE XDG_ZI_CONFIG
+  typeset -gAH ZI
+  ZI=()
+  ZI[BIN_DIR]="$project_root"
+
+  case "$label" in
+    explicit)
+      typeset -gx XDG_DATA_HOME="$case_root/xdg-data"
+      typeset -gx XDG_CACHE_HOME="$case_root/xdg-cache"
+      typeset -gx XDG_CONFIG_HOME="$case_root/xdg-config"
+      typeset -gx XDG_ZI_HOME="$case_root/ignored-input"
+      ZI[HOME_DIR]="$case_root/explicit data"
+      ZI[CACHE_DIR]="$case_root/explicit cache"
+      ZI[CONFIG_DIR]="$case_root/explicit config"
+      ZI[LOG_DIR]="$case_root/explicit log"
+      ZI[ZCOMPDUMP_PATH]="$case_root/explicit cache/custom-zcompdump"
+      typeset -gx ZPFX="$case_root/explicit prefix"
+      expected_home="${ZI[HOME_DIR]}"
+      expected_cache="${ZI[CACHE_DIR]}"
+      expected_config="${ZI[CONFIG_DIR]}"
+      expected_layout=explicit
+      expected_log="${ZI[LOG_DIR]}"
+      expected_zcompdump="${ZI[ZCOMPDUMP_PATH]}"
+      expected_zpfx="$ZPFX"
+      ;;
+    xdg-absolute)
+      typeset -gx XDG_DATA_HOME="$case_root/data with spaces"
+      typeset -gx XDG_CACHE_HOME="$case_root/cache with spaces"
+      typeset -gx XDG_CONFIG_HOME="$case_root/config with spaces"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_cache="$XDG_CACHE_HOME/zi"
+      expected_config="$XDG_CONFIG_HOME/zi"
+      expected_layout=xdg
+      ;;
+    xdg-existing-bases)
+      typeset -gx XDG_DATA_HOME="$case_root/existing data"
+      typeset -gx XDG_CACHE_HOME="$case_root/existing cache"
+      typeset -gx XDG_CONFIG_HOME="$case_root/existing config"
+      command mkdir -p -- "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
+      command chmod 755 -- "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_cache="$XDG_CACHE_HOME/zi"
+      expected_config="$XDG_CONFIG_HOME/zi"
+      expected_layout=xdg
+      ;;
+    xdg-unset)
+      command mkdir -p -- "$ZDOTDIR/.zi/plugins"
+      expected_home="$HOME/.local/share/zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=xdg
+      ;;
+    xdg-empty)
+      typeset -gx XDG_DATA_HOME=''
+      typeset -gx XDG_CACHE_HOME=''
+      typeset -gx XDG_CONFIG_HOME=''
+      expected_home="$HOME/.local/share/zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=xdg
+      ;;
+    xdg-relative)
+      typeset -gx XDG_DATA_HOME='relative data'
+      typeset -gx XDG_CACHE_HOME='relative cache'
+      typeset -gx XDG_CONFIG_HOME='relative config'
+      expected_home="$HOME/.local/share/zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=xdg
+      ;;
+    legacy-only)
+      command mkdir -p -- "$HOME/.zi/plugins"
+      command chmod 755 -- "$HOME/.zi"
+      expected_home="$HOME/.zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=legacy
+      ;;
+    xdg-only)
+      typeset -gx XDG_DATA_HOME="$case_root/data"
+      command mkdir -p -- "$XDG_DATA_HOME/zi/plugins"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=xdg
+      ;;
+    both-external)
+      typeset -gx XDG_DATA_HOME="$case_root/data"
+      command mkdir -p -- "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/plugins"
+      expected_home="$HOME/.zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=ambiguous-legacy
+      ;;
+    both-legacy-source)
+      typeset -gx XDG_DATA_HOME="$case_root/data"
+      command mkdir -p -- "$HOME/.zi/bin" "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/plugins"
+      command ln -s -- "$project_root/zi.zsh" "$HOME/.zi/bin/zi.zsh"
+      command ln -s -- "$project_root/lib" "$HOME/.zi/bin/lib"
+      ZI[BIN_DIR]="$HOME/.zi/bin"
+      source_path="$HOME/.zi/bin/zi.zsh"
+      expected_home="$HOME/.zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=ambiguous-legacy
+      ;;
+    both-xdg-source)
+      typeset -gx XDG_DATA_HOME="$case_root/data"
+      command mkdir -p -- "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/bin" "$XDG_DATA_HOME/zi/plugins"
+      command ln -s -- "$project_root/zi.zsh" "$XDG_DATA_HOME/zi/bin/zi.zsh"
+      command ln -s -- "$project_root/lib" "$XDG_DATA_HOME/zi/bin/lib"
+      ZI[BIN_DIR]="$XDG_DATA_HOME/zi/bin"
+      source_path="$XDG_DATA_HOME/zi/bin/zi.zsh"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_cache="$HOME/.cache/zi"
+      expected_config="$HOME/.config/zi"
+      expected_layout=ambiguous-xdg
+      ;;
+    *)
+      fail "unknown case: $label"
+      ;;
+  esac
+
+  builtin source "$source_path" >/dev/null || fail "$label source"
+  assert_paths "$label" "$expected_home" "$expected_cache" "$expected_config" \
+    "$expected_layout" "$expected_log" "$expected_zcompdump" "$expected_zpfx"
+
+  if [[ $label == xdg-absolute ]]; then
+    builtin source "$source_path" >/dev/null || fail "$label reload"
+    assert_paths "$label reload" "$expected_home" "$expected_cache" "$expected_config" \
+      "$expected_layout" "$expected_log" "$expected_zcompdump" "$expected_zpfx"
+  fi
+
+  case "$label" in
+    explicit|xdg-absolute|xdg-unset|xdg-empty|xdg-relative)
+      assert_private "$expected_home" "$label home permissions"
+      assert_private "$expected_cache" "$label cache permissions"
+      assert_private "$expected_config" "$label config permissions"
+      assert_private "${expected_log:-${expected_cache}/log}" "$label log permissions"
+      ;;
+    xdg-existing-bases)
+      assert_private "$expected_home" "$label home permissions"
+      assert_private "$expected_cache" "$label cache permissions"
+      assert_private "$expected_config" "$label config permissions"
+      assert_private "${expected_log:-${expected_cache}/log}" "$label log permissions"
+      assert_mode "$XDG_DATA_HOME" "$label data base" 8#755
+      assert_mode "$XDG_CACHE_HOME" "$label cache base" 8#755
+      assert_mode "$XDG_CONFIG_HOME" "$label config base" 8#755
+      ;;
+    legacy-only)
+      assert_mode "$expected_home" "$label pre-existing legacy home" 8#755
+      builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "$label autoload"
+      status_output="$(.zi-show-zstatus)" || fail "$label zstatus"
+      [[ $status_output == *'Legacy Zi home retained'* ]] || fail "$label migration hint"
+      ;;
+    both-*)
+      builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null || fail "$label autoload"
+      status_output="$(.zi-show-zstatus)" || fail "$label zstatus"
+      [[ $status_output == *'Both legacy and XDG Zi homes were detected'* ]] || fail "$label ambiguity report"
+      ;;
+  esac
+
+  if [[ $label == xdg-relative ]]; then
+    [[ ! -e "$case_root/relative data" ]] || fail "$label created relative data root"
+    [[ ! -e "$case_root/relative cache" ]] || fail "$label created relative cache root"
+    [[ ! -e "$case_root/relative config" ]] || fail "$label created relative config root"
+  fi
+)
+
+typeset case_name
+for case_name in \
+  explicit \
+  xdg-absolute \
+  xdg-existing-bases \
+  xdg-unset \
+  xdg-empty \
+  xdg-relative \
+  legacy-only \
+  xdg-only \
+  both-external \
+  both-legacy-source \
+  both-xdg-source; do
+  run_case "$case_name"
+  pass "$case_name path resolution"
+done

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -65,10 +65,11 @@ load_zi() {
   ZI[BIN_DIR]="$1"
   builtin source "${ZI[BIN_DIR]}/zi.zsh" >/dev/null || fail "source Zi fixture"
   builtin source "${ZI[BIN_DIR]}/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload fixture"
-  [[ ${ZI[HOME_DIR]} == "${HOME}/.zi" ]] || fail "Zi fixture uses isolated home"
+  [[ ${ZI[HOME_DIR]} == "${XDG_DATA_HOME}/zi" ]] || fail "Zi fixture uses isolated home"
   [[ ${ZI[CACHE_DIR]} == "${XDG_CACHE_HOME}/zi" ]] || fail "Zi fixture uses isolated cache"
   [[ ${ZI[CONFIG_DIR]} == "${XDG_CONFIG_HOME}/zi" ]] || fail "Zi fixture uses isolated config"
   [[ -d ${ZI[HOME_DIR]} ]] || fail "Zi fixture prepares isolated home"
+  [[ ${ZI[HOME_LAYOUT]} == xdg ]] || fail "Zi fixture preserves resolved layout"
 }
 
 # A current checkout is a true no-op: it neither compiles nor changes the
@@ -103,6 +104,8 @@ pass "no-op reload"
   "$git_bin" -C "$publisher" config commit.gpgsign false
 
   load_zi "$checkout"
+  typeset resolved_home="${ZI[HOME_DIR]}"
+  typeset resolved_layout="${ZI[HOME_LAYOUT]}"
   print -r -- '# current-shell revision' >> "${publisher}/lib/zsh/additional.zsh"
   "$git_bin" -C "$publisher" add lib/zsh/additional.zsh
   "$git_bin" -C "$publisher" commit -qm "test: publish self-update fixture"
@@ -115,6 +118,8 @@ pass "no-op reload"
   [[ -z $output ]] || fail "current-shell quiet update emits no progress output"
   [[ $("$git_bin" -C "$checkout" rev-parse HEAD) == "$published_revision" ]] || fail "self-update fast-forwards checkout"
   [[ ${ZI[LOADED_REVISION]} == "$published_revision" ]] || fail "self-update loads merged revision"
+  [[ ${ZI[HOME_DIR]} == "$resolved_home" ]] || fail "self-update reload preserves resolved home"
+  [[ ${ZI[HOME_LAYOUT]} == "$resolved_layout" ]] || fail "self-update reload preserves resolved layout"
 )
 pass "current-shell self-update"
 

--- a/zi.zsh
+++ b/zi.zsh
@@ -67,46 +67,73 @@ else
   [[ -n ${ZI[LOADED_REVISION]} ]] || ZI[LOADED_REVISION]="unknown"
 fi
 
-# Zi home path for creating working directories.
-if [[ -z $ZI[HOME_DIR] ]]; then
-  if [[ -d $HOME ]]; then
-    ZI[HOME_DIR]="${HOME}/.zi"
-  elif [[ -d $ZDOTDIR ]]; then
-    ZI[HOME_DIR]="${ZDOTDIR}/.zi"
-  elif [[ -d $XDG_DATA_HOME ]]; then
-    ZI[HOME_DIR]="${XDG_DATA_HOME}/.zi"
-  else
-    ZI[HOME_DIR]="${HOME}/.zi"
-  fi
-fi
+# Resolve Zi application roots without depending on caller options or creating
+# directories. Explicit ZI values win. A recognized legacy home is retained;
+# otherwise fresh installs use valid absolute XDG bases and specification
+# fallbacks. When both homes exist, the sourced installation identity wins,
+# with the legacy home as the conservative fallback for an external checkout.
+# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+() {
+  builtin emulate -L zsh
 
-# Directory for Zi cache files.
-if [[ -z $ZI[CACHE_DIR] ]]; then
-  if [[ -d ${HOME}/.cache ]]; then
-    ZI[CACHE_DIR]="${HOME}/.cache/zi"
-  elif [[ -d $XDG_CACHE_HOME ]]; then
-    ZI[CACHE_DIR]="${XDG_CACHE_HOME}/zi"
-  elif [[ -d ${ZDOTDIR}/.cache ]]; then
-    ZI[CACHE_DIR]="${ZDOTDIR}/.cache/zi"
-  elif [[ -d ${XDG_DATA_HOME}/.cache ]]; then
-    ZI[CACHE_DIR]="${XDG_DATA_HOME}/.cache/zi"
-  else
-    ZI[CACHE_DIR]="${HOME}/.cache/zi"
-  fi
-fi
+  local data_base cache_base config_base legacy_home xdg_home marker
+  integer legacy_present=0 xdg_present=0
 
-# Directory for Zi configuration files.
-if [[ -z $ZI[CONFIG_DIR] ]]; then
-  if [[ -d ${HOME}/.config ]]; then
-    ZI[CONFIG_DIR]="${HOME}/.config/zi"
-  elif [[ -d $XDG_CONFIG_HOME ]]; then
-    ZI[CONFIG_DIR]="${XDG_CONFIG_HOME}/zi"
-  elif [[ -d ${XDG_DATA_HOME}/.config ]]; then
-    ZI[CONFIG_DIR]="${XDG_DATA_HOME}/.config/zi"
+  if [[ -n $XDG_DATA_HOME && $XDG_DATA_HOME == /* ]]; then
+    data_base="$XDG_DATA_HOME"
   else
-    ZI[CONFIG_DIR]="${HOME}/.config/zi"
+    data_base="${HOME}/.local/share"
   fi
-fi
+  if [[ -n $XDG_CACHE_HOME && $XDG_CACHE_HOME == /* ]]; then
+    cache_base="$XDG_CACHE_HOME"
+  else
+    cache_base="${HOME}/.cache"
+  fi
+  if [[ -n $XDG_CONFIG_HOME && $XDG_CONFIG_HOME == /* ]]; then
+    config_base="$XDG_CONFIG_HOME"
+  else
+    config_base="${HOME}/.config"
+  fi
+
+  legacy_home="${HOME}/.zi"
+  xdg_home="${data_base}/zi"
+
+  if [[ -z ${ZI[HOME_DIR]} ]]; then
+    for marker in bin/zi.zsh plugins snippets completions zmodules; do
+      if [[ -e "${legacy_home}/${marker}" ]]; then
+        legacy_present=1
+        break
+      fi
+    done
+    for marker in bin/zi.zsh plugins snippets completions zmodules; do
+      if [[ -e "${xdg_home}/${marker}" ]]; then
+        xdg_present=1
+        break
+      fi
+    done
+
+    if (( legacy_present && xdg_present )); then
+      if [[ ${ZI[BIN_DIR]} == "${xdg_home}/bin" || ${ZI[BIN_DIR]} == "${xdg_home}/bin/"* ]]; then
+        ZI[HOME_DIR]="$xdg_home"
+        ZI[HOME_LAYOUT]=ambiguous-xdg
+      else
+        ZI[HOME_DIR]="$legacy_home"
+        ZI[HOME_LAYOUT]=ambiguous-legacy
+      fi
+    elif (( legacy_present )); then
+      ZI[HOME_DIR]="$legacy_home"
+      ZI[HOME_LAYOUT]=legacy
+    else
+      ZI[HOME_DIR]="$xdg_home"
+      ZI[HOME_LAYOUT]=xdg
+    fi
+  elif [[ -z ${ZI[HOME_LAYOUT]} ]]; then
+    ZI[HOME_LAYOUT]=explicit
+  fi
+
+  [[ -n ${ZI[CACHE_DIR]} ]] || ZI[CACHE_DIR]="${cache_base}/zi"
+  [[ -n ${ZI[CONFIG_DIR]} ]] || ZI[CONFIG_DIR]="${config_base}/zi"
+}
 
 # Base Directories
 # https://wiki.zshell.dev/docs/guides/customization#customizing-paths
@@ -127,11 +154,8 @@ fi
 : ${ZI[ZCOMPDUMP_PATH]:=${ZI[CACHE_DIR]}/.zcompdump}
 : ${ZI[COMPLETIONS_DIR]:=${ZI[HOME_DIR]}/completions}
 
-# Base Directory Specification (XDG)
-# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-: ${XDG_ZI_HOME:=${ZI[HOME_DIR]}}
-: ${XDG_ZI_CACHE:=${ZI[CACHE_DIR]}}
-: ${XDG_ZI_CONFIG:=${ZI[CONFIG_DIR]}}
+# XDG_ZI_* are exported, derived compatibility outputs. Configure paths with
+# ZI[HOME_DIR], ZI[CACHE_DIR], and ZI[CONFIG_DIR] before sourcing Zi.
 
 # Disable aliases.
 : ${ZI[ALIASES_OPT]:=${${options[aliases]:#off}:+1}}
@@ -1150,7 +1174,7 @@ builtin setopt noaliases
   ZI[HOME_READY]=1
   if [[ ! -d ${ZI[HOME_DIR]} ]]; then
     command mkdir -p "${ZI[HOME_DIR]}"
-    command chmod go-w "${ZI[HOME_DIR]}"
+    command chmod 700 "${ZI[HOME_DIR]}"
   fi
   # Set up $ZPFX
   if [[ ! -d ${ZPFX}/bin ]]; then
@@ -1170,15 +1194,15 @@ builtin setopt noaliases
   fi
   if [[ ! -d ${ZI[CACHE_DIR]} ]]; then
     command mkdir -p "${ZI[CACHE_DIR]}"
-    command chmod go-w "${ZI[CACHE_DIR]}"
+    command chmod 700 "${ZI[CACHE_DIR]}"
   fi
   if [[ ! -d ${ZI[CONFIG_DIR]} ]]; then
     command mkdir -p "${ZI[CONFIG_DIR]}"
-    command chmod go-w "${ZI[CONFIG_DIR]}"
+    command chmod 700 "${ZI[CONFIG_DIR]}"
   fi
   if [[ ! -d ${ZI[LOG_DIR]} ]]; then
     command mkdir -p "${ZI[LOG_DIR]}"
-    command chmod go-w "${ZI[LOG_DIR]}"
+    command chmod 700 "${ZI[LOG_DIR]}"
   fi
   if [[ ! -d ${ZI[ZMODULES_DIR]} ]]; then
     command mkdir -p "${ZI[ZMODULES_DIR]}"


### PR DESCRIPTION
Closes #428.

Parent: https://github.com/z-shell/.github/issues/553
Project: https://github.com/orgs/z-shell/projects/28

## Summary

- promote the reviewed XDG-first, legacy-safe resolver from persistent `next` to stable `main`
- preserve complete persistent-branch ancestry with a merge commit
- make the stable core contract available before dependent installer and current-state documentation merges

## Candidate identity

- Prior `main` SHA: `1e41c12dbe055f500e1dcbee00d242022b370e44`
- Candidate `next` SHA: `9a4fa5174ee2d897dc983acfdaa0d01813bbc096`
- Candidate tree SHA: `114ea67bb2f22f6e5430b277403a8f44bd750d69`
- Complete compare: https://github.com/z-shell/zi/compare/1e41c12dbe055f500e1dcbee00d242022b370e44...9a4fa5174ee2d897dc983acfdaa0d01813bbc096

- [x] Prior `main` is an ancestor of candidate `next`.
- [x] The candidate tree equals the recorded tree SHA.
- [x] Zi #434 supplied the reviewed file changes and full green feature CI.
- [x] Zi #435 preserved stable ancestry without changing the candidate tree.

## Required validation

The promotion workflow must validate the exact candidate and aggregate its required Zsh, ZD, Trunk, CodeQL, clean-install, and branch-source jobs before merge.

## Unresolved issues

- #429 remains the separately designed, opt-in, recoverable migration workflow. This promotion never moves or deletes user data.
- #430 remains the separate durable-state, log, cache, and temporary-artifact classification. This promotion retains the current `ZI[LOG_DIR]` compatibility behavior.

## User-facing and migration notes

Fresh installs use valid absolute XDG data, cache, and config bases with specification fallbacks. Recognized legacy `$HOME/.zi` installations remain active. Both-present roots are resolved deterministically and reported by `zi zstatus`. No automatic migration, merge, overwrite, or deletion occurs.

## Public-contract follow-ups

- z-shell/src#194 reconciles the loader and POSIX installer.
- z-shell/wiki#887 publishes the canonical precedence and migration boundary.
- z-shell/zpmod#107 aligns module installation and compatibility CI.
- z-shell/zi#429 and #430 retain the deferred migration and state-classification work.

## Merge contract

Use **Create a merge commit**. Never squash or rebase persistent `next` into `main`. Immediately before merge, re-fetch and confirm both branch tips and the candidate tree still equal the values above.

## Rollback readiness

- Rollback owner: `@ss-o`
- Observable rollback criteria: clean installation or startup selects an incorrect root, an explicit override is ignored, or a recognized legacy installation is split.
- Rollback uses a reviewed same-repository `hotfix-*` revert PR. Neither persistent branch is force-pushed.

This promotion updates stable `main`; it creates no semantic tag or GitHub release.
