### PR TITLE
fix(security): reject symlinks in GitHub directory snippets

### DIFF
--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -772,6 +772,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message "{error}Error{ehi}:{rst} Refusing to replace a symlinked GitHub directory snippet or metadata directory"
     return 4
   }
+  local -a metadata_symlinks
+  metadata_symlinks=( "$directory/._zi"/**/*(@DN) )
+  (( !${#metadata_symlinks} )) || {
+    +zi-message "{error}Error{ehi}:{rst} Refusing GitHub directory snippet metadata containing symlinks"
+    return 4
+  }
 
   local temp_root
   temp_root=$(command mktemp -d ".zi-git-mirror.XXXXXXXX") || return 4
@@ -785,6 +791,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     command git -C "$repository_dir" sparse-checkout set --cone -- "$subpath" || return 4
     source_dir=$repository_dir/$subpath
     [[ -d $source_dir ]] || return 4
+    local -a source_symlinks
+    source_symlinks=( "$source_dir"/**/*(@DN) )
+    (( !${#source_symlinks} )) || {
+      +zi-message "{error}Error{ehi}:{rst} Refusing a GitHub directory snippet containing symlinks"
+      return 4
+    }
 
     remote_revision=$(command git -C "$repository_dir" rev-parse HEAD) || return 4
     command mkdir -p -- "$payload_dir" || return 4

--- a/tests/snippet-directory-mirror.zsh
+++ b/tests/snippet-directory-mirror.zsh
@@ -239,6 +239,38 @@ mirror "$github_url" -u legacy || fail "migrate GitHub Subversion working copy"
 [[ $(<"$install_parent/legacy/._zi/mirror-backend") = git-sparse ]] || fail "record migrated backend"
 pass "migrate existing GitHub Subversion directory"
 
+# Nested metadata symlinks are rejected before staging so metadata copying
+# cannot preserve a user-controlled link into a newly activated snapshot.
+command mkdir -p -- "$temp_root/external-metadata" || fail "create nested metadata symlink target"
+command ln -s -- "$temp_root/external-metadata" "$install_parent/installed/._zi/linked-entry" || \
+  fail "create nested metadata symlink fixture"
+if mirror "$github_url" -u installed >/dev/null 2>&1; then
+  fail "nested metadata symlink reports success"
+fi
+[[ -L "$install_parent/installed/._zi/linked-entry" ]] || fail "nested metadata symlink was replaced"
+[[ $(<"$install_parent/installed/example.plugin.zsh") = v2 ]] || fail "replace payload with unsafe metadata"
+command rm -f -- "$install_parent/installed/._zi/linked-entry" || fail "remove nested metadata symlink fixture"
+pass "reject nested metadata symlinks"
+
+# Repository-controlled symlinks are rejected before activation because a
+# sourced or executed link could escape the selected directory snapshot.
+command ln -s -- ../../modules/utility/init.zsh "$source_repo/plugins/example/unsafe-link" || \
+  fail "create source symlink fixture"
+"$real_git" -C "$source_repo" add plugins/example/unsafe-link
+"$real_git" -C "$source_repo" commit -qm "test: add unsafe directory symlink" || fail "commit source symlink fixture"
+"$real_git" -C "$source_repo" push -q "$remote_repo" main || fail "publish source symlink fixture"
+
+typeset migration_revision="$(<"$install_parent/legacy/._zi/mirror-revision")"
+if mirror "$github_url" -u legacy >/dev/null 2>&1; then
+  fail "source symlink reports success"
+fi
+[[ $(<"$install_parent/legacy/example.plugin.zsh") = v3 ]] || fail "preserve payload after source symlink rejection"
+[[ ! -e "$install_parent/legacy/unsafe-link" && ! -L "$install_parent/legacy/unsafe-link" ]] || \
+  fail "activate repository-controlled symlink"
+[[ $(<"$install_parent/legacy/._zi/mirror-revision") = $migration_revision ]] || \
+  fail "preserve revision after source symlink rejection"
+pass "reject repository-controlled symlinks"
+
 # GitHub URLs outside the supported legacy trunk shape fail closed instead of
 # falling through to Subversion, while other hosts retain Subversion behavior.
 if mirror https://github.com/example/project/tree/main/plugins/example "" unsupported >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Closes #438.

A directory snippet could carry symlinks in two places that survived into an activated snapshot:

- **Repository-controlled links inside the selected subpath**, where a sourced or executed link could escape the snapshot; and
- **Nested links under an existing `._zi` metadata directory**, which metadata copying would preserve into the newly activated tree.

The previous guard only refused a symlinked *activation target*; it did not inspect the contents of either tree.

## Change

Refuse both cases before staging, so activation fails closed and leaves the previous payload, revision, and metadata untouched.

Both checks use `(@DN)` glob qualifiers to find links at any depth, including dotfiles, and return `4` consistent with the surrounding failure paths.

## Test plan

Adds two cases to `tests/snippet-directory-mirror.zsh`:

- **`reject nested metadata symlinks`** — plants a link under `._zi/`, asserts the mirror reports failure, the link is *not* replaced, and the payload still updates from the clean path.
- **`reject repository-controlled symlinks`** — commits and pushes a link inside the snippet directory upstream, asserts the mirror reports failure, the link is never activated, and the recorded `mirror-revision` is preserved.

Both assert the failure is closed rather than partial — the previous payload and revision survive intact.

```
$ zsh -f tests/snippet-directory-mirror.zsh
ok - load PZTM directory snippet through Git sparse checkout
ok - install selected GitHub directory
ok - integrate object-path and status detection
ok - detect unchanged GitHub directory
ok - update GitHub directory snapshot
ok - roll back failed GitHub directory update
ok - migrate existing GitHub Subversion directory
ok - reject nested metadata symlinks
ok - reject repository-controlled symlinks
ok - preserve non-GitHub Subversion boundary
ok - reject unsafe GitHub directory path
ok - reject symlinked activation targets
```

12/12 pass, including the two new cases.

## Note

Targets `next` per ADR-0019 (`zi` keeps a persistent integration branch).
