### PR TITLE
fix(security): stage archive extraction and reject unsafe members

### DIFF
--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1738,10 +1738,73 @@ ziextract() {
     command mv -f *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) ._backup 2>/dev/null
   }
 
+  .zi-archive-members-safe() {
+    builtin emulate -LR zsh
+    builtin setopt extendedglob
+
+    local member component
+    for member in "${(@f)1}"; do
+      while [[ $member == ./* ]]; do
+        member=${member#./}
+      done
+      [[ -z $member || $member == . ]] && continue
+      [[ $member != /* && $member != [[:alpha:]]:[/\\]* && $member != *\\* ]] || return 1
+      for component in "${(@s:/:)member}"; do
+        [[ $component != .. ]] || return 1
+      done
+    done
+  }
+
+  .zi-extraction-targets-safe() {
+    builtin emulate -LR zsh
+    builtin setopt extendedglob
+
+    local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved
+    local -a staged_files
+    staged_files=( "$stage"/**/*(DN) )
+    for staged_file in "${staged_files[@]}"; do
+      relative=${staged_file#${stage}/}
+      if [[ -L $staged_file ]]; then
+        resolved=${staged_file:A}
+        [[ $resolved == ${stage:A} || $resolved == ${stage:A}/* ]] || return 1
+      fi
+      target_path=$target_dir
+      for target_component in "${(@s:/:)relative}"; do
+        target_path+="/$target_component"
+        [[ ! -L $target_path ]] || return 1
+      done
+    done
+  }
+
   .zi-extract-wrapper() {
-    local file="$1" fun="$2" retval
+    local file="$1" fun="$2" retval=0 original_file="$1" original_dir="$PWD"
+    local source_file="${1:A}" stage listing
     (( !OPTS[opt_-q,--quiet] )) && +zi-message "{annex}ziextract{ehi}:{rst} Unpacking the files from{ehi}:{rst} \`{file}$file{rst}'{…}{rst}"
-    $fun; retval=$?
+    file=$source_file
+    if [[ $(typeset -f + →zi-list) == "→zi-list" ]]; then
+      listing="$(→zi-list)" || retval=$?
+      (( retval )) || .zi-archive-members-safe "$listing" || retval=1
+    fi
+    if (( !retval && stage_extract )); then
+      stage="$(command mktemp -d "${TMPDIR:-/tmp}/zi-extract.XXXXXXXX")" || retval=1
+      if (( !retval )); then
+        builtin cd -q "$stage" || retval=1
+      fi
+      if (( !retval )); then
+        $fun || retval=$?
+      fi
+      builtin cd -q "$original_dir" || retval=1
+      if (( !retval )); then
+        .zi-extraction-targets-safe "$stage" "$original_dir" || retval=1
+      fi
+      if (( !retval )); then
+        command cp -a "$stage"/. "$original_dir"/ || retval=$?
+      fi
+      [[ -z $stage ]] || command rm -rf -- "$stage"
+    elif (( !retval )); then
+      $fun || retval=$?
+    fi
+    file=$original_file
     if (( retval == 0 )) {
       local -a files
       files=( *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) )
@@ -1751,27 +1814,42 @@ ziextract() {
   }
 
   →zi-check() { (( ${+commands[$1]} )) || +zi-message "{annex}ziextract{ehi}:{rst} {error}No command {cmd}$1{msg2},{error} it is required to unpack {file}$2{rst}"; }
+  integer stage_extract=0
 
   case "${${ext:+.$ext}:-$file}" in
     ((#i)*.zip)
+      stage_extract=1
+      →zi-list() { command unzip -Z1 "$file"; }
       →zi-extract() { →zi-check unzip "$file" || return 1; command unzip -o "$file"; }
       ;;
     ((#i)*.rar)
+      stage_extract=1
+      →zi-list() { command unrar lb "$file"; }
       →zi-extract() { →zi-check unrar "$file" || return 1; command unrar x "$file"; }
       ;;
     ((#i)*.tar.bz2|(#i)*.tbz|(#i)*.tbz2)
+      stage_extract=1
+      →zi-list() { command bzip2 -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check bzip2 "$file" || return 1; command bzip2 -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.gz|(#i)*.tgz)
+      stage_extract=1
+      →zi-list() { command gzip -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check gzip "$file" || return 1; command gzip -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.xz|(#i)*.txz)
+      stage_extract=1
+      →zi-list() { command xz -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check xz "$file" || return 1; command xz -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.7z|(#i)*.t7z)
+      stage_extract=1
+      →zi-list() { command 7z x -so "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check 7z "$file" || return 1; command 7z x -so "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar)
+      stage_extract=1
+      →zi-list() { command tar -tf "$file"; }
       →zi-extract() { →zi-check tar "$file" || return 1; command tar -xf "$file"; }
       ;;
     ((#i)*.gz|(#i)*.gzip)
@@ -1817,9 +1895,12 @@ ziextract() {
       }
       ;;
     ((#i)*.7z|(#i)*.7-zip)
+      stage_extract=1
+      →zi-list() { command 7z l -ba -slt "$file" | command sed -n 's/^Path = //p'; }
       →zi-extract() { →zi-check 7z "$file" || return 1; command 7z x "$file" >/dev/null;  }
       ;;
     ((#i)*.dmg)
+      stage_extract=1
       →zi-extract() {
         local prog
         for prog ( hdiutil cp ) { →zi-check $prog "$file" || return 1; }
@@ -1836,9 +1917,13 @@ ziextract() {
       }
       ;;
     ((#i)*.deb)
+      stage_extract=1
+      →zi-list() { command dpkg-deb --fsys-tarfile "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check dpkg-deb "$file" || return 1; command dpkg-deb -R "$file" .; }
       ;;
     ((#i)*.rpm)
+      stage_extract=1
+      →zi-list() { "$ZI[BIN_DIR]"/lib/zsh/rpm2cpio.zsh "$file" | command cpio -t; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check cpio "$file" || return 1; $ZI[BIN_DIR]/lib/zsh/rpm2cpio.zsh "$file" | command cpio -imd --no-absolute-filenames; }
       ;;
     ((#i)*.exe|(#i)*.pe32)
@@ -1859,14 +1944,15 @@ ziextract() {
         command mv ._backup/*(DN) . 2>/dev/null
       }
       +zi-message ".{rst}"
-      unfunction -- →zi-extract →zi-check 2>/dev/null
+      unfunction -- →zi-extract →zi-check →zi-list 2>/dev/null
+      unfunction -- .zi-archive-members-safe .zi-extraction-targets-safe 2>/dev/null
       return 1
     }
-    unfunction -- →zi-extract →zi-check
+    unfunction -- →zi-extract →zi-check →zi-list 2>/dev/null
   } else {
     integer warning=1
   }
-  unfunction -- .zi-extract-wrapper
+  unfunction -- .zi-extract-wrapper .zi-archive-members-safe .zi-extraction-targets-safe
 
   local -a execs
   execs=( **/*~(._zi(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1759,13 +1759,16 @@ ziextract() {
     builtin emulate -LR zsh
     builtin setopt extendedglob
 
-    local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved
+    local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved link_target
     local -a staged_files
     staged_files=( "$stage"/**/*(DN) )
     for staged_file in "${staged_files[@]}"; do
       relative=${staged_file#${stage}/}
       if [[ -L $staged_file ]]; then
-        resolved=${staged_file:A}
+        link_target="$(command readlink "$staged_file")" || return 1
+        [[ $link_target != /* && $link_target != [[:alpha:]]:[/\\]* && $link_target != *\\* ]] || return 1
+        resolved=${staged_file:h}/${link_target}
+        resolved=${resolved:A}
         [[ $resolved == ${stage:A} || $resolved == ${stage:A}/* ]] || return 1
       fi
       target_path=$target_dir

--- a/tests/archive-extraction.zsh
+++ b/tests/archive-extraction.zsh
@@ -35,6 +35,7 @@ prepare_unzip() {
   command mkdir -p -- "$shim_dir" || fail "create unzip shim directory"
   {
     print -r -- '#!/bin/sh'
+    print -r -- 'if [ "$1" = "-Z1" ]; then exec bsdtar -tf "$2"; fi'
     print -r -- 'exec bsdtar -xf "$2"'
   } >| "${shim_dir}/unzip" || fail "write unzip shim"
   command chmod +x -- "${shim_dir}/unzip" || fail "make unzip shim executable"
@@ -59,6 +60,8 @@ new_fixture() {
 
   print -r -- one >| "$REPLY/one/one.txt" || fail "write first payload"
   print -r -- two >| "$REPLY/two/two.txt" || fail "write second payload"
+  print -r -- one >| "$REPLY/one/order.txt" || fail "write first ordered payload"
+  print -r -- two >| "$REPLY/two/order.txt" || fail "write second ordered payload"
   command tar -cf "$REPLY/staging/one.tar" -C "$REPLY/one" . || fail "create first nested archive"
   command tar -cf "$REPLY/staging/two.tar" -C "$REPLY/two" . || fail "create second nested archive"
   (
@@ -93,6 +96,7 @@ prepare_unzip
   ziextract --auto >/dev/null || fail "extract nested archives"
   [[ -f one.txt ]] || fail "extract first nested payload"
   [[ -f two.txt ]] || fail "extract second nested payload"
+  [[ $(<order.txt) = two ]] || fail "extract nested archives in lexical order"
   [[ ! -e outer.bin ]] || fail "remove outer archive after success"
   [[ ! -e ._backup/two.tar ]] || fail "do not back up a nested sibling"
 ) || exit 1
@@ -107,7 +111,7 @@ pass "extract every nested archive"
   command mkdir -p -- "$shim_dir" || fail "create tar shim directory"
   {
     print -r -- '#!/bin/sh'
-    print -r -- 'if [ "$2" = "two.tar" ]; then exit 42; fi'
+    print -r -- 'case "$2" in two.tar|*/two.tar) [ "$1" = "-xf" ] && exit 42;; esac'
     print -r -- "exec ${(q)real_tar} \"\$@\""
   } >| "$shim_dir/tar" || fail "write tar shim"
   command chmod +x -- "$shim_dir/tar" || fail "make tar shim executable"
@@ -125,3 +129,80 @@ pass "extract every nested archive"
   [[ ! -e ._backup/two.tar ]] || fail "do not back up failed nested archive"
 ) || exit 1
 pass "preserve outer archive after nested failure"
+
+# Member paths are rejected before extraction when they can escape the target.
+(
+  new_fixture traversal
+  typeset fixture_root="$REPLY"
+  print -r -- escaped >| "$fixture_root/staging/payload" || fail "write traversal payload"
+  if (( ${+commands[bsdtar]} )); then
+    command bsdtar -cf "$fixture_root/work/traversal.tar" \
+      -s '|^payload$|../escaped.txt|' -C "$fixture_root/staging" payload || fail "create traversal archive"
+  else
+    command tar -cf "$fixture_root/work/traversal.tar" \
+      --transform='s|^payload$|../escaped.txt|' -C "$fixture_root/staging" payload || fail "create traversal archive"
+  fi
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter traversal fixture"
+
+  if ziextract traversal.tar --nobkp >/dev/null 2>&1; then
+    fail "traversal archive reports success"
+  fi
+  [[ -f traversal.tar ]] || fail "preserve rejected traversal archive"
+  [[ ! -e "$fixture_root/escaped.txt" ]] || fail "write traversal member outside target"
+) || exit 1
+pass "reject archive member traversal"
+
+# Promotion rejects an existing destination symlink instead of writing through it.
+(
+  new_fixture symlink-target
+  typeset fixture_root="$REPLY"
+  command mkdir -p -- "$fixture_root/staging/link" "$fixture_root/external" || fail "create symlink target fixture"
+  print -r -- unsafe >| "$fixture_root/staging/link/payload.txt" || fail "write symlink target payload"
+  command tar -cf "$fixture_root/work/target.tar" -C "$fixture_root/staging" link || fail "create symlink target archive"
+  command ln -s -- "$fixture_root/external" "$fixture_root/work/link" || fail "create destination symlink"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter symlink target fixture"
+
+  if ziextract target.tar --nobkp >/dev/null 2>&1; then
+    fail "unsafe destination target reports success"
+  fi
+  [[ -L link ]] || fail "replace destination symlink"
+  [[ ! -e "$fixture_root/external/payload.txt" ]] || fail "write through destination symlink"
+  [[ -f target.tar ]] || fail "preserve archive rejected for unsafe target"
+) || exit 1
+pass "reject unsafe destination symlinks"
+
+# Relative links that remain inside the extracted tree retain archive behavior.
+(
+  new_fixture safe-archive-link
+  typeset fixture_root="$REPLY"
+  print -r -- safe >| "$fixture_root/staging/payload.txt" || fail "write safe linked payload"
+  command ln -s -- payload.txt "$fixture_root/staging/linked.txt" || fail "create safe archive symlink"
+  command tar -cf "$fixture_root/work/safe-link.tar" -C "$fixture_root/staging" payload.txt linked.txt || \
+    fail "create safe archive link fixture"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter safe archive link fixture"
+
+  ziextract safe-link.tar --nobkp >/dev/null || fail "extract safe archive symlink"
+  [[ -L linked.txt && $(<linked.txt) = safe ]] || fail "preserve safe archive symlink"
+) || exit 1
+pass "preserve safe archive symlinks"
+
+# Links escaping the staged tree are rejected before any result is promoted.
+(
+  new_fixture unsafe-archive-link
+  typeset fixture_root="$REPLY"
+  command ln -s -- "$fixture_root/external" "$fixture_root/staging/linked" || fail "create unsafe archive symlink"
+  command tar -cf "$fixture_root/work/unsafe-link.tar" -C "$fixture_root/staging" linked || \
+    fail "create unsafe archive link fixture"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter unsafe archive link fixture"
+
+  if ziextract unsafe-link.tar --nobkp >/dev/null 2>&1; then
+    fail "escaping archive symlink reports success"
+  fi
+  [[ ! -e linked && ! -L linked ]] || fail "promote escaping archive symlink"
+  [[ -f unsafe-link.tar ]] || fail "preserve archive containing escaping symlink"
+) || exit 1
+pass "reject escaping archive symlinks"

--- a/tests/archive-extraction.zsh
+++ b/tests/archive-extraction.zsh
@@ -193,7 +193,7 @@ pass "preserve safe archive symlinks"
 (
   new_fixture unsafe-archive-link
   typeset fixture_root="$REPLY"
-  command ln -s -- "$fixture_root/external" "$fixture_root/staging/linked" || fail "create unsafe archive symlink"
+  command ln -s -- ../external "$fixture_root/staging/linked" || fail "create unsafe archive symlink"
   command tar -cf "$fixture_root/work/unsafe-link.tar" -C "$fixture_root/staging" linked || \
     fail "create unsafe archive link fixture"
   load_zi "$fixture_root"


### PR DESCRIPTION
## Summary

Closes #440.

`ziextract` unpacked archives directly into the destination directory, so an archive could write outside the intended target in two ways:

- **Member path traversal** — member names containing `..` components, absolute paths, or Windows-style drive/backslash paths were passed straight to the extractor.
- **Writing through an existing destination symlink** — if a destination path component already existed as a symlink, extraction followed it.

Because extraction happened in place, a rejected archive could also leave a partially-written tree behind.

## Change

- **Validate before extracting.** `.zi-archive-members-safe` rejects members with `..` components, absolute paths, or drive/backslash forms. Backed by new `→zi-list` hooks for each staged format (zip, rar, tar and its compressed variants, 7z, deb, rpm).
- **Stage, then promote.** Staged formats extract into a `mktemp -d` directory and are copied to the destination only after validation, so a rejection leaves the destination untouched rather than half-written.
- **Validate promotion targets.** `.zi-extraction-targets-safe` refuses promotion when any destination path component is an existing symlink, or when a staged link escapes the staging root.
- **Resolve link targets without following them.** `${file:A}` resolves *through* a link, validating its fully-resolved destination rather than the path it literally names. The raw target is read with `readlink`; absolute and drive/backslash targets are rejected outright, and a relative target is resolved against the link's own directory before confirming it stays inside the staging root.

Formats without a reliable listing hook keep the previous in-place path, so behavior is unchanged where the new guarantees cannot be enforced.

## Test plan

`tests/archive-extraction.zsh`, 6/6 pass:

```
ok - extract every nested archive
ok - preserve outer archive after nested failure
ok - reject archive member traversal
ok - reject unsafe destination symlinks
ok - preserve safe archive symlinks
ok - reject escaping archive symlinks
```

New cases:

- **`reject archive member traversal`** — member rewritten to `../escaped.txt`; asserts failure, archive preserved, nothing written outside the target.
- **`reject unsafe destination symlinks`** — pre-existing destination symlink pointing outside the tree; asserts failure, link not replaced, nothing written through it.
- **`preserve safe archive symlinks`** — a link staying inside the tree still extracts, so the guard is not over-broad.
- **`reject escaping archive symlinks`** — a *relative* link escaping the staging root; this is the case the original `:A` resolution handled incorrectly.

Also extends the nested-archive fixture with an `order.txt` assertion pinning lexical extraction order.

Verified no regression elsewhere:

- `zsh -f tests/snippet-directory-mirror.zsh` — 12/12 pass
- `zsh -n lib/zsh/install.zsh` — clean

## Note

Targets `next` per ADR-0019. Independent of #439 (directory-snippet symlinks) — that PR touches the snippet mirror path, this one touches `ziextract`. Both branch from `next` and neither contains the other's commit; they can land in either order.
