### PR TITLE
fix(update): make parallel updater deterministic

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -12,6 +12,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/parallel-update.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -22,6 +23,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/parallel-update.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -93,6 +95,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test path resolution
         run: zsh -f tests/path-resolution.zsh
+
+  parallel-update:
+    name: Parallel Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test parallel update
+        run: zsh -f tests/parallel-update.zsh
 
   self-update-reload:
     name: Self-update reload

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1846,91 +1846,113 @@ ZI[EXTENDED_GLOB]=""
 # FUNCTION: .zi-update-in-parallel [[[
 .zi-update-all-parallel() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops nomonitor nonotify
-  local id_as repo snip uspl user plugin PUDIR="$(mktemp -d)"
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops no_monitor no_notify
+  local id_as repo snip uspl user plugin pid PUDIR
+  PUDIR="$(command mktemp -d "${TMPDIR:-/tmp}/zi-update.XXXXXXXX")" || return 1
+  local MATCH
+  integer MBEGIN MEND
   local -A PUAssocArray map
   map=( / --  "=" -EQ-  "?" -QM-  "&" -AMP-  : - )
   local -a files
-  integer main_counter counter PUPDATE=1
-  files=( ${ZI[SNIPPETS_DIR]}/**/(._zi|._zinit|._zplugin)/mode(ND) )
-  main_counter=${#files}
-  if (( OPTS[opt_-s,--snippets] || !OPTS[opt_-l,--plugins] )) {
-    for snip ( "${files[@]}" ) {
-      main_counter=main_counter-1
-      # The continue may cause the tail of processes to
-      # fall-through to the following plugins-specific `wait'
-      # Should happen only in a very special conditions
-      # TODO #114 handle this
-      [[ ! -f ${snip:h}/url ]] && continue
-      [[ -f ${snip:h}/id-as ]] && id_as="$(<${snip:h}/id-as)" || id_as=
-      counter+=1
-      local ef_id="${id_as:-$(<${snip:h}/url)}"
-      local PUFILEMAIN=${${ef_id#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
-      local PUFILE=$PUDIR/${counter}_$PUFILEMAIN.out
-      .zi-update-or-status-snippet "$st" "$ef_id" &>! $PUFILE &
-      PUAssocArray[$!]=$PUFILE
-      .zi-wait-for-update-jobs snippets
+  integer counter=0 PUPDATE=1 retval=0
+  builtin trap 'retval=130; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 130' INT
+  builtin trap 'retval=129; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 129' HUP
+  builtin trap 'retval=143; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 143' TERM
+  {
+    files=( ${ZI[SNIPPETS_DIR]}/**/(._zi|._zinit|._zplugin)/mode(ND) )
+    if (( OPTS[opt_-s,--snippets] || !OPTS[opt_-l,--plugins] )) {
+      for snip ( "${files[@]}" ) {
+        [[ ! -f ${snip:h}/url ]] && continue
+        [[ -f ${snip:h}/id-as ]] && id_as="$(<${snip:h}/id-as)" || id_as=
+        (( ++counter ))
+        local ef_id="${id_as:-$(<${snip:h}/url)}"
+        local PUFILEMAIN=${${ef_id#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
+        local PUFILE=$PUDIR/${(l:8::0:)counter}_$PUFILEMAIN.out
+        .zi-update-or-status-snippet "$st" "$ef_id" &>! "$PUFILE" &
+        PUAssocArray[$!]=$PUFILE
+        .zi-wait-for-update-jobs snippets
+      }
+      .zi-wait-for-update-jobs snippets flush
     }
-  }
 
-  counter=0
-  PUAssocArray=()
-  if (( OPTS[opt_-l,--plugins] || !OPTS[opt_-s,--snippets] )) {
-    local -a files2
-    files=( ${ZI[PLUGINS_DIR]}/*(ND/) )
-    # Pre-process plugins
-    for repo ( $files ) {
-      uspl=${repo:t}
-      # Two special cases
-      [[ $uspl = custom || $uspl = _local---zi ]] && continue
-      # Check if repository has a remote set
-      if [[ -f $repo/.git/config ]] {
-        local -a config
-        config=( ${(f)"$(<$repo/.git/config)"} )
-        if [[ ${#${(M)config[@]:#\[remote[[:blank:]]*\]}} -eq 0 ]] {
+    counter=0
+    PUAssocArray=()
+    if (( OPTS[opt_-l,--plugins] || !OPTS[opt_-s,--snippets] )) {
+      local -a files2
+      files=( ${ZI[PLUGINS_DIR]}/*(ND/) )
+      # Pre-process plugins
+      for repo ( $files ) {
+        uspl=${repo:t}
+        # Two special cases
+        [[ $uspl = custom || $uspl = _local---zi ]] && continue
+        # Check if repository has a remote set
+        if [[ -f $repo/.git/config ]] {
+          local -a config
+          config=( ${(f)"$(<$repo/.git/config)"} )
+          if [[ ${#${(M)config[@]:#\[remote[[:blank:]]*\]}} -eq 0 ]] {
+            continue
+          }
+        }
+        .zi-any-to-user-plugin "$uspl"
+        local user=${reply[-2]} plugin=${reply[-1]}
+        # Must be a git repository or a binary release
+        if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]] {
           continue
         }
+        files2+=( $repo )
       }
-      .zi-any-to-user-plugin "$uspl"
-      local user=${reply[-2]} plugin=${reply[-1]}
-      # Must be a git repository or a binary release
-      if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]] {
-        continue
+      for repo ( "${files2[@]}" ) {
+        uspl=${repo:t}
+        id_as=${uspl//---//}
+        (( ++counter ))
+        local PUFILEMAIN=${${id_as#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
+        local PUFILE=$PUDIR/${(l:8::0:)counter}_$PUFILEMAIN.out
+        .zi-any-colorify-as-uspl2 "$uspl"
+        +zi-message "Updating{ehi}:{rst} $REPLY{rst}" >! "$PUFILE"
+        .zi-any-to-user-plugin "$uspl"
+        local user=${reply[-2]} plugin=${reply[-1]}
+        .zi-update-or-status update "$user" "$plugin" &>>! "$PUFILE" &
+        PUAssocArray[$!]=$PUFILE
+        .zi-wait-for-update-jobs plugins
       }
-      files2+=( $repo )
+      .zi-wait-for-update-jobs plugins flush
     }
-    main_counter=${#files2}
-    for repo ( "${files2[@]}" ) {
-      main_counter=main_counter-1
-      uspl=${repo:t}
-      id_as=${uspl//---//}
-      counter+=1
-      local PUFILEMAIN=${${id_as#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
-      local PUFILE=$PUDIR/${counter}_$PUFILEMAIN.out
-      .zi-any-colorify-as-uspl2 "$uspl"
-      +zi-message "Updating{ehi}:{rst} $REPLY{rst}" >! $PUFILE
-      .zi-any-to-user-plugin "$uspl"
-      local user=${reply[-2]} plugin=${reply[-1]}
-      .zi-update-or-status update "$user" "$plugin" &>>! $PUFILE &
-      PUAssocArray[$!]=$PUFILE
-      .zi-wait-for-update-jobs plugins
-    }
+  } always {
+    # Reap every child before removing its output directory, including when an
+    # error or signal interrupts a phase between normal flushes.
+    (( ${#PUAssocArray} )) && .zi-wait-for-update-jobs cleanup flush
+    [[ -n $PUDIR && -d $PUDIR ]] && command rm -rf -- "$PUDIR"
   }
-  # Shouldn't happen
-  # (( ${#PUAssocArray} > 0 )) && wait ${(k)PUAssocArray}
+  return "$retval"
 }
 # ]]]
 # FUNCTION: .zi-wait-for-update-jobs [[[
 .zi-wait-for-update-jobs() {
-  local tpe=$1
-  if (( counter > OPTS[value] || main_counter == 0 )) {
-    wait ${(k)PUAssocArray}
-    local ind_file
-    for ind_file ( ${^${(von)PUAssocArray}}.ind(DN.) ) {
-      command cat ${ind_file:r}
-      (( !OPTS[opt_-d,--debug] && !ZI[DEBUG_MODE] )) && command rm -f $ind_file
-    }
-    (( !OPTS[opt_-d,--debug] && !ZI[DEBUG_MODE] )) && command rm -f ${(v)PUAssocArray}
+  local tpe="$1"
+  integer force_flush=0 max_jobs=${OPTS[value]:-1}
+  [[ $2 == flush ]] && force_flush=1
+  (( max_jobs > 0 )) || max_jobs=1
+  if (( ${#PUAssocArray} && ( counter >= max_jobs || force_flush ) )) {
+    local pid output_file
+    integer wait_rc output_rc
+    local -A failed_files
+    for pid in ${(on)${(k)PUAssocArray}}; do
+      wait "$pid"
+      wait_rc=$?
+      if (( wait_rc != 0 )); then
+        (( retval == 0 )) && retval=$wait_rc
+        failed_files[${PUAssocArray[$pid]}]=$wait_rc
+      fi
+    done
+    for output_file in ${(on)${(v)PUAssocArray}}; do
+      if [[ -f $output_file.ind || -n ${failed_files[$output_file]} ]] ||
+        (( OPTS[opt_-d,--debug] || ZI[DEBUG_MODE] )); then
+        command cat -- "$output_file"
+        output_rc=$?
+        (( output_rc != 0 && retval == 0 )) && retval=$output_rc
+      fi
+      command rm -f -- "$output_file.ind" "$output_file"
+    done
     counter=0
     PUAssocArray=()
   } elif (( counter == 1 && !OPTS[opt_-q,--quiet] )) {

--- a/tests/parallel-update.zsh
+++ b/tests/parallel-update.zsh
@@ -1,0 +1,221 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-parallel-update-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" || fail "create isolated environment"
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gAH ZI OPTS
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload library"
+
+new_case() {
+  builtin emulate -L zsh
+  local label="$1"
+  REPLY="$temp_root/$label"
+  command mkdir -p -- "$REPLY/snippets" "$REPLY/plugins" "$REPLY/tmp" ||
+    fail "create $label fixture"
+  ZI[SNIPPETS_DIR]="$REPLY/snippets"
+  ZI[PLUGINS_DIR]="$REPLY/plugins"
+  ZI[DEBUG_MODE]=0
+  OPTS=()
+  OPTS[value]=2
+  OPTS[opt_-q,--quiet]=1
+  OPTS[opt_-d,--debug]=0
+  OPTS[opt_-s,--snippets]=1
+  OPTS[opt_-l,--plugins]=0
+  typeset -gx TMPDIR="$REPLY/tmp"
+}
+
+add_snippet() {
+  builtin emulate -L zsh
+  local case_root="$1" name="$2" url="$3"
+  local metadata="$case_root/snippets/$name/._zi"
+  command mkdir -p -- "$metadata" || fail "create $name snippet metadata"
+  builtin print -r -- single >| "$metadata/mode" || fail "write $name mode"
+  builtin print -r -- "$url" >| "$metadata/url" || fail "write $name URL"
+}
+
+add_invalid_snippet() {
+  builtin emulate -L zsh
+  local case_root="$1" name="$2"
+  local metadata="$case_root/snippets/$name/._zi"
+  command mkdir -p -- "$metadata" || fail "create invalid $name metadata"
+  builtin print -r -- single >| "$metadata/mode" || fail "write invalid $name mode"
+}
+
+assert_temp_clean() {
+  builtin emulate -L zsh
+  local case_root="$1" label="$2"
+  local -a remaining=( "$case_root/tmp"/*(ND) )
+  (( ${#remaining} == 0 )) || fail "$label left temporary output behind"
+}
+
+run_parallel() {
+  builtin emulate -L zsh
+  local st=update
+  .zi-update-all-parallel
+}
+
+# A valid job followed by malformed metadata must still be reaped.
+(
+  new_case trailing-invalid
+  local case_root="$REPLY" completed="$REPLY/completed"
+  add_snippet "$case_root" a-valid https://example.invalid/valid
+  add_invalid_snippet "$case_root" z-invalid
+  .zi-update-or-status-snippet() {
+    command sleep 0.15
+    builtin print -r -- "$2" >> "$completed"
+  }
+  run_parallel >/dev/null || fail "trailing invalid metadata returned failure"
+  [[ -f $completed && "$(<$completed)" == https://example.invalid/valid ]] ||
+    fail "trailing invalid metadata allowed a live job to escape"
+  assert_temp_clean "$case_root" "trailing invalid metadata"
+) || exit 1
+pass "trailing invalid metadata does not skip the final wait"
+
+# A child failure must become the aggregate updater status and remain visible.
+(
+  new_case child-failure
+  local case_root="$REPLY"
+  add_snippet "$case_root" failing https://example.invalid/failing
+  .zi-update-or-status-snippet() {
+    builtin print -r -- "simulated update failure"
+    return 7
+  }
+  run_parallel >/dev/null
+  local update_rc=$?
+  (( update_rc == 7 )) || fail "child status 7 became $update_rc"
+  assert_temp_clean "$case_root" "child failure"
+) || exit 1
+pass "child failures propagate from the parallel updater"
+
+# The configured bound is an upper limit, not a threshold exceeded by one.
+(
+  new_case concurrency
+  local case_root="$REPLY" event_log="$REPLY/events"
+  local index
+  for index in {1..5}; do
+    add_snippet "$case_root" "$index" "https://example.invalid/$index"
+  done
+  .zi-update-or-status-snippet() {
+    builtin print -r -- start >> "$event_log"
+    command sleep 0.12
+    builtin print -r -- end >> "$event_log"
+  }
+  run_parallel >/dev/null || fail "bounded parallel update failed"
+  integer active=0 peak=0
+  local event
+  while IFS= builtin read -r event; do
+    if [[ $event == start ]]; then
+      (( ++active ))
+      (( active > peak )) && peak=$active
+    else
+      (( --active ))
+    fi
+  done < "$event_log"
+  (( peak == 2 && active == 0 )) ||
+    fail "parallel limit 2 observed peak $peak with $active unfinished: ${(j: :)${(@f)$(<$event_log)}}"
+  assert_temp_clean "$case_root" "bounded parallel update"
+) || exit 1
+pass "parallel updates honor the configured concurrency limit"
+
+# Snippet and plugin phases own separate complete job batches.
+(
+  new_case both-phases
+  local case_root="$REPLY" phase_log="$REPLY/phases"
+  OPTS[opt_-s,--snippets]=0
+  OPTS[opt_-l,--plugins]=0
+  add_snippet "$case_root" snippet https://example.invalid/snippet
+  command mkdir -p -- "$case_root/plugins/owner---plugin/._zi" || fail "create plugin fixture"
+  builtin print -r -- 1 >| "$case_root/plugins/owner---plugin/._zi/is_release" ||
+    fail "mark plugin fixture as a release"
+  .zi-update-or-status-snippet() {
+    builtin print -r -- snippet >> "$phase_log"
+  }
+  .zi-update-or-status() {
+    builtin print -r -- plugin >> "$phase_log"
+  }
+  run_parallel >/dev/null || fail "combined phases failed"
+  local -a phases=( "${(@f)$(<$phase_log)}" )
+  [[ "${(j: :)phases}" == "snippet plugin" ]] ||
+    fail "combined phases ran ${(j: :)phases}"
+  assert_temp_clean "$case_root" "combined phases"
+) || exit 1
+pass "snippet and plugin phases flush independently"
+
+# Output follows discovery order even when jobs complete out of order.
+(
+  new_case output-order
+  local case_root="$REPLY" output
+  add_snippet "$case_root" first https://example.invalid/first
+  add_snippet "$case_root" second https://example.invalid/second
+  .zi-update-or-status-snippet() {
+    [[ $2 == */first ]] && command sleep 0.12 || command sleep 0.01
+    builtin print -r -- "${2:t}"
+    builtin print -r -- 1 >| "$PUFILE.ind"
+  }
+  output="$(run_parallel)" || fail "ordered output update failed"
+  [[ $output == $'first\nsecond' ]] || fail "parallel output order was ${(qqq)output}"
+  assert_temp_clean "$case_root" "ordered output"
+) || exit 1
+pass "parallel output is deterministic"
+
+# Pattern captures are scoped and the temporary directory is removed on TERM.
+(
+  new_case interruption
+  local case_root="$REPLY" started="$REPLY/started" result="$REPLY/result"
+  add_snippet "$case_root" interrupted https://example.invalid/interrupted
+  builtin unset MATCH MBEGIN MEND
+  .zi-update-or-status-snippet() {
+    builtin print -r -- started >| "$started"
+    command sleep 10
+  }
+  (
+    run_parallel >/dev/null
+    builtin print -r -- $? >| "$result"
+  ) &
+  local updater_pid=$!
+  integer attempt=0
+  while [[ ! -f $started && attempt -lt 100 ]]; do
+    command sleep 0.02
+    (( ++attempt ))
+  done
+  [[ -f $started ]] || fail "interrupted child did not start"
+  builtin kill -TERM "$updater_pid" || fail "signal parallel updater"
+  wait "$updater_pid" || fail "interrupted updater wrapper failed"
+  [[ -f $result && "$(<$result)" == 143 ]] || fail "TERM status was not preserved"
+  (( ! ${+parameters[MATCH]} && ! ${+parameters[MBEGIN]} && ! ${+parameters[MEND]} )) ||
+    fail "pattern capture parameters leaked globally"
+  assert_temp_clean "$case_root" "interrupted update"
+) || exit 1
+pass "parallel updater scopes captures and cleans up after interruption"


### PR DESCRIPTION
## Description

Make Zi's parallel updater deterministic and failure-aware:

- retain every child PID until it is reaped;
- enforce the configured concurrency limit exactly;
- flush snippet and plugin phases independently;
- emit captured output in launch order;
- propagate child and output failures; and
- reap children and remove temporary output after normal completion or handled interruption.

The focused regression suite covers the original trailing-job failure, concurrency, phase isolation, deterministic output, failure propagation, and signal cleanup.

## Related issues

Closes #114

## Type of change

- [x] `fix` - bug fix (non-breaking)
- [ ] `feat` - new feature (non-breaking)
- [ ] `feat!` / `fix!` - breaking change
- [ ] `perf` - performance improvement
- [ ] `refactor` - code change with no functional impact
- [ ] `docs` - documentation only
- [x] `test` - test addition or correction
- [ ] `build` - build system or dependency change
- [x] `ci` - CI/workflow change
- [ ] `style` - formatting with no behavior change
- [ ] `chore` - maintenance / dependency bump
- [ ] `revert` - revert of an earlier change

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] This is not a `next` to `main` promotion
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailer credits a bot, AI agent, or automation
- [x] I have read the contribution guidelines
- [x] Existing tests pass
- [x] No documentation change is required for this internal bug fix

## Verification

- `zsh -f tests/parallel-update.zsh`: 6 scenarios passed.
- Existing Zi integration suites: 61 scenarios passed.
- Native syntax and isolated `zcompile -U`: all 29 Zsh files passed. The pre-existing `lib/zsh/rpm2cpio.zsh:54` warning remains.
- `actionlint .github/workflows/zsh-n.yml`: passed.
- `git diff --check`: passed.
- Local commit hook: passed.

## Migration plan

Not required. No destructive public-contract impact is expected.

## Agent handoff

- **Status:** Ready for review
- **Current state:** The implementation and focused CI coverage are complete on `bug-114-parallel-update`.
- **Blockers:** None.
- **Next steps:** Review and run required repository checks.
- **Related tracker/issues:** #114
