### PR TITLE
refactor(zsh): normalize option spellings

### DIFF
--- a/lib/zsh/additional.zsh
+++ b/lib/zsh/additional.zsh
@@ -22,7 +22,7 @@
   local ___data="$(<$1)"
 
   () {
-    builtin emulate -LR zsh -o extendedglob -o interactivecomments ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin emulate -LR zsh -o extended_glob -o interactive_comments ${=${options[xtrace]:#off}:+-o xtrace}
     local ___subst ___tabspc=$'\t'
     for ___subst ( "${___substs[@]}" ) {
       ___ab=( "${(@)${(@)${(@s:->:)___subst}##[[:space:]]##}%%[[:space:]]##}" )
@@ -43,7 +43,7 @@
 # $3 - id - URL or plugin ID or alias name (from id-as'')
 .zi-service() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   local ___tpe="$1" ___mode="$2" ___id="$3" ___fle="${ZI[SERVICES_DIR]}/${ICE[service]}.lock" ___fd ___cmd ___tmp ___lckd ___strd=0
   { builtin print -n >! "$___fle"; } 2>/dev/null 1>&2
   [[ ! -e ${___fle:r}.fifo ]] && command mkfifo "${___fle:r}.fifo" 2>/dev/null 1>&2

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -32,7 +32,7 @@ ZI[EXTENDED_GLOB]=""
   local uspl2="$1"
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[FUNCTIONS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[FUNCTIONS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A func
   local i
@@ -61,7 +61,7 @@ ZI[EXTENDED_GLOB]=""
   local uspl2="$1"
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[OPTIONS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[OPTIONS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A opts_before opts_after opts
   opts_before=( "${(z)ZI[OPTIONS_BEFORE__$uspl2]}" )
@@ -90,7 +90,7 @@ ZI[EXTENDED_GLOB]=""
   typeset -a tmp
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[PATH_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[PATH_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   [[ "${ZI[FPATH_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[FPATH_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A path_state fpath_state
@@ -140,7 +140,7 @@ ZI[EXTENDED_GLOB]=""
   typeset -a tmp
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[PARAMETERS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[PARAMETERS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   # Un-concatenated parameters from moment of diff start and of diff end
   typeset -A params_before params_after
@@ -185,17 +185,17 @@ ZI[EXTENDED_GLOB]=""
   .zi-any-to-user-plugin "$1" "$2"
   [[ "${reply[-2]}" = "%" ]] && REPLY="${reply[-2]}${reply[-1]}" || REPLY="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]//---//}"
 } # ]]]
-# FUNCTION: .zi-save-set-extendedglob [[[
-# Enables extendedglob-option first saving if it was already
+# FUNCTION: .zi-save-set-extended_glob [[[
+# Enables extended_glob-option first saving if it was already
 # enabled, for restoration of this state later.
-.zi-save-set-extendedglob() {
-  [[ -o "extendedglob" ]] && ZI[EXTENDED_GLOB]="1" || ZI[EXTENDED_GLOB]="0"
-  builtin setopt extendedglob
+.zi-save-set-extended_glob() {
+  [[ -o "extended_glob" ]] && ZI[EXTENDED_GLOB]="1" || ZI[EXTENDED_GLOB]="0"
+  builtin setopt extended_glob
 } # ]]]
-# FUNCTION: .zi-restore-extendedglob [[[
-# Restores extendedglob-option from state saved earlier.
-.zi-restore-extendedglob() {
-  [[ "${ZI[EXTENDED_GLOB]}" = "0" ]] && builtin unsetopt extendedglob || builtin setopt extendedglob
+# FUNCTION: .zi-restore-extended_glob [[[
+# Restores extended_glob-option from state saved earlier.
+.zi-restore-extended_glob() {
+  [[ "${ZI[EXTENDED_GLOB]}" = "0" ]] && builtin unsetopt extended_glob || builtin setopt extended_glob
 } # ]]]
 # FUNCTION: .zi-prepare-readlink [[[
 # Prepares readlink command, used for establishing completion's owner.
@@ -322,9 +322,9 @@ ZI[EXTENDED_GLOB]=""
   REPLY=""
   # Paranoid, don't want bad key/value pair error
   integer empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[OPTIONS__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   (( empty )) && return 0
   typeset -A opts
   opts=( "${(z)ZI[OPTIONS__$uspl2]}" )
@@ -371,7 +371,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - user/plugin (i.e. uspl2 format of plugin-spec)
 .zi-format-parameter() {
   local uspl2="$1" infoc="${ZI[col-info]}" k
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   REPLY=""
   [[ "${ZI[PARAMETERS_PRE__$uspl2]}" != *[$'! \t']* || "${ZI[PARAMETERS_POST__$uspl2]}" != *[$'! \t']* ]] && return 0
   typeset -A elem_pre elem_post
@@ -419,7 +419,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - absolute path to completion file (in COMPLETIONS_DIR)
 # $2 - readlink command (":" or "readlink")
 .zi-get-completion-owner() {
-  builtin setopt localoptions extendedglob nokshglob noksharrays noshwordsplit
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays no_sh_word_split
 
   local cpath="$1"
   local readlink_cmd="$2"
@@ -464,7 +464,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-find-completions-of-plugin() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
   .zi-any-to-user-plugin "${1}" "${2}"
   local user="${reply[-2]}" plugin="${reply[-1]}" uspl
   [[ "$user" = "%" ]] && uspl="${user}${plugin}" || uspl="${reply[-2]}${reply[-2]:+---}${reply[-1]//\//---}"
@@ -799,7 +799,7 @@ ZI[EXTENDED_GLOB]=""
 # User-action entry point.
 .zi-show-registered-plugins() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   typeset -a filtered
   local keyword="$1"
   keyword="${keyword## ##}"
@@ -844,9 +844,9 @@ ZI[EXTENDED_GLOB]=""
   (( quiet )) || builtin print -r -- "${ZI[col-bar]}---${ZI[col-rst]} Unloading plugin: $REPLY ${ZI[col-bar]}---${ZI[col-rst]}"
   local ___dir
   [[ "$user" = "%" ]] && ___dir="$plugin" || ___dir="${ZI[PLUGINS_DIR]}/${user:+${user}---}${plugin//\//---}"
-  # KSH_ARRAYS immunity
+  # ksh_arrays immunity
   integer correct=0
-  [[ -o "KSH_ARRAYS" ]] && correct=1
+  [[ -o "ksh_arrays" ]] && correct=1
   # Allow unload for debug user
   if [[ "$uspl2" != "_dtrace/_dtrace" ]]; then
     .zi-exists-message "$1" "$2" || return 1
@@ -874,9 +874,9 @@ ZI[EXTENDED_GLOB]=""
   if [[ -n ${sice[ps-on-unload]} ]]; then
     (( quiet )) || builtin print -r "Running plugin's provided unload code: ${ZI[col-info]}${sice[ps-on-unload][1,50]}${sice[ps-on-unload][51]:+…}${ZI[col-rst]}"
     local ___oldcd="$PWD"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___dir"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___dir"; }
     eval "${sice[ps-on-unload]}"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }
   fi
 
   #
@@ -902,7 +902,7 @@ ZI[EXTENDED_GLOB]=""
     if [[ "$sw_arr4" = "-M" && "$sw_arr6" != "-R" ]]; then
       if [[ -n "$sw_arr3" ]]; then
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3 ${ZI[col-info]}in map ${ZI[col-rst]}$sw_arr5"
         }
         bindkey -M "$sw_arr5" "$sw_arr1" "$sw_arr3"
@@ -935,7 +935,7 @@ ZI[EXTENDED_GLOB]=""
     else
       if [[ -n "$sw_arr3" ]]; then
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3"
         }
         bindkey "$sw_arr1" "$sw_arr3"
@@ -973,9 +973,9 @@ ZI[EXTENDED_GLOB]=""
   # Paranoid, don't want bad key/value pair error
   .zi-diff-options-compute "$uspl2"
   integer empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[OPTIONS__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   if (( empty != 1 )); then
     typeset -A opts
     opts=( "${(z)ZI[OPTIONS__$uspl2]}" )
@@ -1053,7 +1053,7 @@ ZI[EXTENDED_GLOB]=""
   keys=( "${(@on)ZI[(I)TIME_<->_*]}" )
   integer keys_size=${#keys}
   () {
-    builtin setopt localoptions extendedglob noksharrays typesetsilent
+    builtin setopt local_options extended_glob no_ksh_arrays typeset_silent
     typeset -a restore_widgets skip_delete
     local wid
     restore_widgets=( "${(z)ZI[WIDGETS_SAVED__$uspl2]}" )
@@ -1228,9 +1228,9 @@ ZI[EXTENDED_GLOB]=""
 
   .zi-diff-parameter-compute "$uspl2"
   empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[PARAMETERS_POST__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   if (( empty != 1 )); then
     typeset -A elem_pre elem_post
     elem_pre=( "${(z)ZI[PARAMETERS_PRE__$uspl2]}" )
@@ -1304,7 +1304,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-show-report() {
-  builtin setopt localoptions extendedglob warncreateglobal typesetsilent noksharrays
+  builtin setopt local_options extended_glob warn_create_global typeset_silent no_ksh_arrays
   .zi-any-to-user-plugin "$1" "$2"
   local user="${reply[-2]}" plugin="${reply[-1]}" uspl2="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]}"
   # Allow debug report
@@ -1326,7 +1326,7 @@ ZI[EXTENDED_GLOB]=""
   )
   # Print report gathered via shadowing
   () {
-    builtin setopt localoptions extendedglob
+    builtin setopt local_options extended_glob
     builtin print -rl -- "${(@)${(f@)ZI_REPORTS[$uspl2]}/(#b)(#s)([^[:space:]]##)([[:space:]]##)/${map[${match[1]}]:-${ZI[col-keyword]}}${match[1]}${ZI[col-rst]}${match[2]}}"
   }
   # Print report gathered via $functions-diffing
@@ -1407,9 +1407,9 @@ ZI[EXTENDED_GLOB]=""
 # $2 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $3 - plugin (only when $1 - i.e. user - given)
 .zi-update-or-status() {
-  # Set the localtraps option.
+  # Set the local_traps option.
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob null_glob warn_create_global typeset_silent no_short_loops
   local -a arr
   ZI[first-plugin-mark]=${${ZI[first-plugin-mark]:#init}:-1}
   ZI[-r/--reset-opt-hook-has-been-run]=0
@@ -1722,7 +1722,7 @@ ZI[EXTENDED_GLOB]=""
 # $2 - snippet URL
 .zi-update-or-status-snippet() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
   local st="$1" URL="${2%/}" local_dir filename is_snippet
   (( ${#ICE[@]} > 0 )) && { ZI_SICE[$URL]=""; local nf="-nftid"; }
   local -A ICE2
@@ -1767,7 +1767,7 @@ ZI[EXTENDED_GLOB]=""
 # User-action entry point.
 .zi-update-or-status-all() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob null_glob warn_create_global typeset_silent no_short_loops
   local -F2 SECONDS=0
   integer retval
   if (( OPTS[opt_-p,--parallel] )) && [[ $1 = update ]] {
@@ -1846,7 +1846,7 @@ ZI[EXTENDED_GLOB]=""
 # FUNCTION: .zi-update-in-parallel [[[
 .zi-update-all-parallel() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops nomonitor nonotify
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops no_monitor no_notify
   local id_as repo snip uspl user plugin PUDIR="$(mktemp -d)"
   local -A PUAssocArray map
   map=( / --  "=" -EQ-  "?" -QM-  "&" -AMP-  : - )
@@ -1943,7 +1943,7 @@ ZI[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zi-show-zstatus() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   local infoc="${ZI[col-info2]}"
   +zi-message "{info}Directories set{ehi}:{rst} "
@@ -2073,9 +2073,9 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 .zi-list-bindkeys() {
   local uspl2 uspl2col sw first=1
   local -a string_widget
-  # KSH_ARRAYS immunity
+  # ksh_arrays immunity
   integer correct=0
-  [[ -o "KSH_ARRAYS" ]] && correct=1
+  [[ -o "ksh_arrays" ]] && correct=1
   for uspl2 in "${(@ko)ZI[(I)BINDKEYS__*]}"; do
     [[ -z "${ZI[$uspl2]}" ]] && continue
     (( !first )) && builtin print
@@ -2119,7 +2119,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-compiled() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
 
   typeset -a matches m
   matches=( ${ZI[PLUGINS_DIR]}/*/*.zwc(DN) )
@@ -2148,7 +2148,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-compile-uncompile-all() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
 
   local compile="$1"
   typeset -a plugins
@@ -2176,7 +2176,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-uncompile-plugin() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
   .zi-any-to-user-plugin "${1}" "${2}"
   local user="${reply[-2]}" plugin="${reply[-1]}" silent="$3"
   # There are plugins having ".plugin.zsh"
@@ -2209,7 +2209,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-show-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   local count="${1:-3}"
   typeset -a completions
@@ -2289,7 +2289,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-clear-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   typeset -a completions
   completions=( "${ZI[COMPLETIONS_DIR]}"/_[^_.]*~*.zwc "${ZI[COMPLETIONS_DIR]}"/[^_.]*~*.zwc )
@@ -2339,7 +2339,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-search-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   typeset -a plugin_paths
   plugin_paths=( "${ZI[PLUGINS_DIR]}"/*(DN) )
@@ -2478,7 +2478,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-cd() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent rc_quotes
 
   .zi-get-path "$1" "$2" && {
     if [[ -e $REPLY ]]; then
@@ -2523,7 +2523,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-delete() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local -a opts match mbegin mend
   local MATCH; integer MBEGIN MEND _retval
@@ -2688,7 +2688,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $1 - time spec, e.g. "1 week"
 .zi-recently() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt nullglob extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt null_glob extended_glob warn_create_global typeset_silent no_short_loops
   local IFS=.
   local gitout
   local timespec=${*// ##/.}
@@ -2720,7 +2720,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $2 - (optional) plugin (only when $1 - i.e. user - given)
 .zi-create() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt localoptions extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt local_options extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   .zi-any-to-user-plugin "$1" "$2"
   local user="${reply[-2]}" plugin="${reply[-1]}"
@@ -2933,7 +2933,7 @@ EOF
   )
   (
     builtin emulate -LR ksh ${=${options[xtrace]:#off}:+-o xtrace}
-    builtin unsetopt shglob kshglob
+    builtin unsetopt sh_glob ksh_glob
     for i in "${ZI_STRESS_TEST_OPTIONS[@]}"; do
       builtin setopt "$i"
       builtin print -n "Stress-testing ${fname:t} for option $i "
@@ -2963,7 +2963,7 @@ EOF
 # FUNCTION: .zi-ls [[[
 .zi-ls() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   if (( ${+commands[tree]} )); then
     ZI[TREE]="${commands[tree]} -L 3 -C --charset utf-8"
@@ -2998,7 +2998,7 @@ EOF
 # ("%" "/home/..." and also "%SNIPPETS/..." etc.), or a plugin nickname (i.e. id-as'' ice-mod), or a snippet nickname.
 .zi-get-path() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   [[ $1 == % ]] && local id_as=%$2 || local id_as=$1${1:+/}$2
   .zi-get-object-path snippet "$id_as" || .zi-get-object-path plugin "$id_as"
   return $(( 1 - reply[3] ))
@@ -3006,7 +3006,7 @@ EOF
 # FUNCTION: .zi-recall [[[
 .zi-recall() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
 
   local -A ice
   local el val cand1 cand2 local_dir filename is_snippet

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -10,7 +10,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # Retrievies the ice-list from given profile from the JSON of the package.json.
 .zi-parse-json() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local -A ___pos_to_level ___level_to_pos ___pair_map ___final_pairs ___Strings ___Counts
   local ___input=$1 ___workbuf=$1 ___key=$2 ___varname=$3 ___style ___quoting
@@ -284,7 +284,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - plugin
 .zi-setup-plugin-dir() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global no_short_loops rc_quotes
 
   local user=$1 plugin=$2 id_as=$3 remote_url_path=${1:+$1/}$2 local_path tpe=$4 update=$5 version=$6
 
@@ -357,7 +357,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       command mkdir -p "$local_path"
       [[ -d "$local_path" ]] || return 1
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_path"; } || return 1
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_path"; } || return 1
         integer count
 
         for REPLY ( $reply ) {
@@ -395,7 +395,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       command mkdir -p "$local_path/._zi"
       [[ -d "$local_path" ]] || return 1
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_path"; } || return 1
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_path"; } || return 1
         .zi-get-cygwin-package "$remote_url_path" || return 1
         builtin print -r -- $REPLY >! ._zi/is_release
         ziextract "$REPLY"
@@ -600,7 +600,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 .zi-download-file-stdout() {
   local url="$1" restart="$2" progress="${(M)3:#1}"
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt localtraps extendedglob
+  builtin setopt local_traps extended_glob
 
   if (( restart )) {
     (( ${path[(I)/usr/local/bin]} )) || {
@@ -651,7 +651,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local url="$1" IFS line header
   local -a cmd
 
-  builtin setopt localoptions localtraps
+  builtin setopt local_options local_traps
 
   (( !${path[(I)/usr/local/bin]} )) && {
     path+=( "/usr/local/bin" );
@@ -690,7 +690,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - URL in https://github.com/OWNER/REPOSITORY/trunk/PATH form
 .zi-parse-github-svn-url() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   local url=${1%/}
   [[ $url = http(|s)://github.com/* ]] || return 1
@@ -725,7 +725,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $3 - installed directory
 .zi-mirror-using-git() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   local url=$1 mode=$2 directory=$3
   (( ${+commands[git]} )) || {
@@ -860,7 +860,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $3 - subdirectory (not path) with working copy, needed for -t and -u
 .zi-mirror-using-svn() {
   builtin emulate -L zsh
-  builtin setopt extendedglob warncreateglobal
+  builtin setopt extended_glob warn_create_global
   local url="$1" update="$2" directory="$3"
 
   (( ${+commands[svn]} )) || {
@@ -869,7 +869,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   }
 
   if [[ "$update" = "-t" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$directory"; }
       local -a out1 out2
       out1=( "${(f@)"$(LANG=C svn info -r HEAD)"}" )
       out2=( "${(f@)"$(LANG=C svn info)"}" )
@@ -882,7 +882,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     return $?
   fi
   if [[ "$update" = "-u" && -d "$directory" && -d "$directory/.svn" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$directory"; }
     command svn update
     return $? )
   else
@@ -898,7 +898,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - completion function name, e.g. "_cp"; can also be "cp"
 .zi-forget-completion() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal
+  builtin setopt extended_glob typeset_silent warn_create_global
 
   local f="$1" quiet="$2"
 
@@ -926,7 +926,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-compile-plugin() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}} first plugin_dir filename is_snippet
   local -a list
@@ -964,7 +964,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message -n "Compiling{ehi}:{rst} {b}{file}$fname{rst}{…}"
     if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
       () {
-        builtin emulate -LR zsh -o extendedglob
+        builtin emulate -LR zsh -o extended_glob
         if { ! zcompile -U "$first" } {
           +zi-message "{error}Warning{ehi}:{rst} Compilation failed. Don't worry, the plugin will work also without compilation"
           +zi-message "{error}Warning{ehi}:{rst} Consider submitting an error report to ❮ Zi ❯ or to the plugin's author"
@@ -991,7 +991,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       integer retval
       for first in $list; do
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           zcompile -U "$first"; retval+=$?
         }
       done
@@ -1014,7 +1014,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # svn ice is active. This provides a layer of support for Oh-My-Zsh and Prezto.
 .zi-download-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local save_url=$1 url=$2 id_as=$3 local_dir=$4 dirname=$5 filename=$6 update=$7
 
@@ -1078,7 +1078,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     if [[ $url = (http|https|ftp|ftps|scp)://* ]] {
       # URL
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir"; } || return 4
         local mirror_name=Subversion
         [[ $url = http(|s)://github.com/* ]] && mirror_name="Git sparse checkout"
         (( !OPTS[opt_-q,--quiet] )) && \
@@ -1142,7 +1142,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             fi
             if [[ -e ${list[1]} && ${list[1]} != */dev/null && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && ${+ICE[nocompile]} -eq 0 ]] {
               () {
-                builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+                builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
                 zcompile -U "${list[1]}" &>/dev/null || \
                   +zi-message "{error}Warning{ehi}:{rst} Couldn't compile {apo}\`{file}${list[1]}{rst}'"
               }
@@ -1231,7 +1231,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         fi
         if [[ -e $file_path && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && $file_path != */dev/null && ${+ICE[nocompile]} -eq 0 ]] {
           () {
-            builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+            builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
             if ! zcompile -U "$file_path" 2>/dev/null; then
               builtin print -r "Couldn't compile \`${file_path:t}', it MIGHT be wrongly downloaded"
               builtin print -r "(snippet URL points to a directory instead of a file?"
@@ -1424,12 +1424,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # FUNCTION: .zi-update-snippet [[[
 .zi-update-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   local -a tmp opts
   local url=$1
   integer correct=0
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
   opts=( -u ) # for z-a-readurl
 
   # Create a local copy of OPTS,
@@ -1644,7 +1644,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - file
 ziextract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops # warncreateglobal
+  builtin setopt extended_glob typeset_silent no_short_loops # warn_create_global
 
   if (( $+commands[file] != 1 )) { +zi-message "{annex}ziextract{ehi}:{rst} {error}The {cmd}file{error} command is required for recognizing the type of data to be processed{rst}"
     return 1
@@ -1752,7 +1752,7 @@ ziextract() {
 
   .zi-archive-members-safe() {
     builtin emulate -LR zsh
-    builtin setopt extendedglob
+    builtin setopt extended_glob
 
     local member component
     for member in "${(@f)1}"; do
@@ -1769,7 +1769,7 @@ ziextract() {
 
   .zi-extraction-targets-safe() {
     builtin emulate -LR zsh
-    builtin setopt extendedglob
+    builtin setopt extended_glob
 
     local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved link_target
     local -a staged_files
@@ -2020,7 +2020,7 @@ ziextract() {
 # FUNCTION: .zi-extract() [[[
 .zi-extract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
   local tpe=$1 extract=$2 local_dir=$3
   (
     builtin cd -q "$local_dir" || {
@@ -2142,7 +2142,7 @@ ziextract() {
 # FUNCTION zicp [[[
 zicp() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
   local -a mbegin mend match
   local cmd=cp
   if [[ $1 = (-m|--mv) ]] { cmd=mv; shift; }
@@ -2298,13 +2298,13 @@ zimv() {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
       () {
-        builtin setopt localoptions noautopushd
+        builtin setopt local_options no_auto_pushd
         builtin cd -q "$dir"
       }
     }
     eval "$atclone"
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }
   }
   return "$rc"
 } # ]]]
@@ -2328,7 +2328,7 @@ zimv() {
   @zi-substitute from to
   local -a mv_args=("-f")
   local -a afr
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; } || return 1
       afr=( ${~from}(DN) )
       if (( ! ${#afr} )) {
         +zi-message "{warn}Warning{ehi}:{rst} {auto}mv ice didn't match any file{rst} [{error}$ICE[mv]{rst}]" \
@@ -2359,7 +2359,7 @@ zimv() {
   @zi-substitute from to
 
   local -a afr retval
-  ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+  ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; } || return 1
     afr=( ${~from}(DN) )
     if (( ${#afr} )); then
       if (( !OPTS[opt_-q,--quiet] )); then
@@ -2383,7 +2383,7 @@ zimv() {
     if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
       () {
         builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-        builtin setopt extendedglob warncreateglobal
+        builtin setopt extended_glob warn_create_global
         if [[ $tpe == snippet ]] {
           .zi-compile-plugin "%$dir" ""
         } else {
@@ -2405,11 +2405,11 @@ zimv() {
   .zi-countdown atpull && {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
-      () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; }
+      () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; }
     }
     .zi-at-eval "$atpull" "$ICE[atclone]"
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; };
   }
   return "$rc"
 } # ]]]
@@ -2425,11 +2425,11 @@ zimv() {
   .zi-countdown atpull && {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
-      () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; }
+      () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; }
     }
     .zi-at-eval "$atpull" $ICE[atclone]
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; };
   }
   return "$rc"
 } # ]]]

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -28,7 +28,7 @@
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-exists-physically-message() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
   if ! .zi-exists-physically "$1" "$2"; then
     .zi-any-to-user-plugin "$1" "$2"
     if [[ $reply[1] = % ]] {
@@ -77,7 +77,7 @@
     reply=( "$dname" "" )
     return 1
   fi
-  # Take first entry (ksharrays resilience)
+  # Take first entry (ksh_arrays resilience)
   reply=( "$dname" "${reply[-${#reply}]}" )
   return 0
 } # ]]]
@@ -116,7 +116,7 @@
 # returns 2 possible paths for further examination
 .zi-two-paths() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal noshortloops
+  builtin setopt extended_glob typeset_silent warn_create_global no_short_loops
 
   local url=$1 url1 url2 local_dirA dirnameA svn_dirA local_dirB dirnameB
   local -a fileB_there
@@ -157,7 +157,7 @@
 # $6 - name of output string parameter, to hold is-snippet 0/1-bool ("is_snippet")
 .zi-compute-ice() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal noshortloops
+  builtin setopt extended_glob typeset_silent warn_create_global no_short_loops
 
   local ___URL="${1%/}" ___pack="$2" ___is_snippet=0
   local ___var_name1="${3:-ZI_ICE}" ___var_name2="${4:-local_dir}" ___var_name3="${5:-filename}" ___var_name4="${6:-is_snippet}"
@@ -345,7 +345,7 @@
 # successfully reaches 0, or 1 if Ctrl-C will be pressed.
 .zi-countdown() {
   (( !${+ICE[countdown]} )) && return 0
-  builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   trap "+zi-message \"{ehi}ABORTING, the ice {ice}$ice{ehi} not ran{rst}\"; return 1" INT
   local count=5 tpe="$1" ice
   ice="${ICE[$tpe]}"

--- a/scripts/public-contract-impact.zsh
+++ b/scripts/public-contract-impact.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 emulate -LR zsh
-setopt errexit nounset pipefail extendedglob
+setopt err_exit no_unset pipe_fail extended_glob
 
 typeset repository="."
 typeset manifest_path="contracts/public-contract-v1.json"

--- a/tests/path-resolution.zsh
+++ b/tests/path-resolution.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit pipefail
+setopt err_exit pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset temp_root
@@ -61,7 +61,7 @@ assert_paths() {
 
 run_case() (
   builtin emulate -LR zsh
-  setopt errexit pipefail
+  setopt err_exit pipe_fail
 
   local label="$1" case_root="${temp_root}/$1"
   local source_path="$project_root/zi.zsh"

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 emulate -LR zsh
-setopt errexit nounset pipefail
+setopt err_exit no_unset pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset fixture_root="${project_root}/tests/fixtures/public-contract"

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit pipefail
+setopt err_exit pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset git_bin="${commands[git]}"

--- a/tests/version-reporting.zsh
+++ b/tests/version-reporting.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit nounset pipefail
+setopt err_exit no_unset pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset temp_root
@@ -35,7 +35,7 @@ run_case() {
     ZI_TEST_EXPECTED="$expected" \
     zsh -f <<'ZSH' || fail "$label"
 builtin emulate -LR zsh
-setopt pipefail
+setopt pipe_fail
 
 typeset -gAH ZI
 ZI[BIN_DIR]="$ZI_TEST_CHECKOUT"

--- a/zi.zsh
+++ b/zi.zsh
@@ -42,7 +42,7 @@ uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|mod
 [[ ! -e ${ZI[BIN_DIR]}/zi.zsh ]] && ZI[BIN_DIR]=
 ZI[ZERO]="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 
-[[ ! -o functionargzero || ${options[posixargzero]} = on || ${ZI[ZERO]} != */* ]] && ZI[ZERO]="${(%):-%N}"
+[[ ! -o function_argzero || ${options[posix_argzero]} = on || ${ZI[ZERO]} != */* ]] && ZI[ZERO]="${(%):-%N}"
 : ${ZI[BIN_DIR]:="${ZI[ZERO]:h}"}
 
 [[ ${ZI[BIN_DIR]} = \~* ]] && ZI[BIN_DIR]=${~ZI[BIN_DIR]}
@@ -313,7 +313,7 @@ ZI_ZLE_HOOKS_LIST=(
   paste-insert 1
 )
 
-builtin setopt noaliases
+builtin setopt no_aliases
 
 # ]]]
 
@@ -354,7 +354,7 @@ builtin setopt noaliases
 # run custom `autoload' function, that doesn't need FPATH.
 :zi-tmp-subst-autoload () {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent rc_quotes
 
   local -a opts opts2 custom reply
   local func
@@ -401,7 +401,7 @@ builtin setopt noaliases
     # Real autoload doesn't touch function if it already exists.
     # Author of the idea of FPATH-clean autoloading: Bart Schaefer.
     if (( ${+functions[$func]} != 1 )) {
-      builtin setopt noaliases
+      builtin setopt no_aliases
       if [[ $func == /* ]] && is-at-least 5.4; then
         builtin autoload ${opts[@]} $func
         return $?
@@ -434,7 +434,7 @@ builtin setopt noaliases
           } else {
             eval "function ${(q)${custom[++count*2]}:-$func} {
               local body=\"\$(<${(qqq)sel}/${(qqq)func})\" body2
-              () { builtin setopt localoptions extendedglob
+              () { builtin setopt local_options extended_glob
                 body2=\"\${body##[[:space:]]#${func}[[:blank:]]#\(\)[[:space:]]#\{}\"
                 [[ \$body2 != \$body ]] && body2=\"\${body2%\}[[:space:]]#([$nl]#([[:blank:]]#\#[^$nl]#((#e)|[$nl]))#)#}\"
               }
@@ -473,7 +473,7 @@ builtin setopt noaliases
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-bindkey() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
 
   is-at-least 5.3 && .zi-add-report "${ZI[CUR_USPL2]}" "Bindkey ${(j: :)${(q+)@}}" || .zi-add-report "${ZI[CUR_USPL2]}" "Bindkey ${(j: :)${(q)@}}"
 
@@ -564,7 +564,7 @@ builtin setopt noaliases
     [[ ${ZI[DTRACE]} = 1 ]] && ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
   else
     # bindkey -A newkeymap main?
-    # Negative indices for KSH_ARRAYS immunity.
+    # Negative indices for ksh_arrays immunity.
     if [[ ${#opts} -eq 1 && ${+opts[-A]} = 1 && ${#pos} = 3 && ${pos[-1]} = main && ${pos[-2]} != -A ]]; then
       # Save a copy of main keymap.
       (( ZI[BINDKEY_MAIN_IDX] = ${ZI[BINDKEY_MAIN_IDX]:-0} + 1 ))
@@ -602,7 +602,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-zstyle() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob nowarncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob no_warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Zstyle $*"
   # Remember in order to perform the actual zstyle call.
   typeset -a pos
@@ -633,7 +633,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-alias() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Alias $*"
   # Remember to perform the actual alias call.
   typeset -a pos
@@ -674,7 +674,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-zle() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Zle $*"
   # Remember to perform the actual zle call.
   typeset -a pos
@@ -727,7 +727,7 @@ builtin setopt noaliases
 # The hijacking is not only for reporting, but also to save compdef
 # calls so that `compinit' can be called after loading plugins.
 :zi-tmp-subst-compdef() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Saving \`compdef $*' for replay"
   ZI_COMPDEF_REPLAY+=( "${(j: :)${(q)@}}" )
 
@@ -792,7 +792,7 @@ builtin setopt noaliases
 # Turn off temporary substituting of functions completely for a given mode ("load", "light",
 # "light-b" (i.e. the `trackbinds' mode) or "compdef").
 .zi-tmp-subst-off() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset noaliases
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset no_aliases
   local mode="$1"
   # Disable temporary substituting of functions only once.
   # Disable temporary substituting of functions only the way it was enabled first.
@@ -934,7 +934,7 @@ builtin setopt noaliases
 #
 .zi-any-to-user-plugin() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+reply}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+reply}:#0}:+warn_create_global}
   # Two components given?
   # That's a pretty fast track to call this function this way.
   if [[ -n $2 ]]; then
@@ -968,7 +968,7 @@ builtin setopt noaliases
 # FUNCTION: .zi-any-to-pid. [[[
 .zi-any-to-pid() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+REPLY}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+REPLY}:#0}:+warn_create_global}
 
   1=${~1} 2=${~2}
 
@@ -997,7 +997,7 @@ builtin setopt noaliases
 # Replaces parts of path with %HOME, etc.
 .zi-util-shands-path() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+REPLY}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+REPLY}:#0}:+warn_create_global}
 
   local -A map
   map=( \~ %HOME $HOME %HOME $ZI[SNIPPETS_DIR] %SNIPPETS $ZI[PLUGINS_DIR] %PLUGINS
@@ -1091,7 +1091,7 @@ builtin setopt noaliases
 # FUNCTION: @zi-substitute. [[[
 @zi-substitute() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   local -A ___subst_map
   ___subst_map=(
     "%ID%"   "${id_as_clean:-$id_as}"
@@ -1136,7 +1136,7 @@ builtin setopt noaliases
   ZI_EXTS[seqno]=$(( ${ZI_EXTS[seqno]:-0} + 1 ))
   ZI_EXTS[$key${${(M)type#hook:}:+ ${ZI_EXTS[seqno]}}]="${ZI_EXTS[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} ${(q)helphandler} ${(q)icemods}"
   () {
-    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
     integer index="${type##[%a-zA-Z:_!-]##}"
     ZI_EXTS[ice-mods]="${ZI_EXTS[ice-mods]}${icemods:+|}${(j:|:)${(@)${(@s:|:)icemods}/(#b)(#s)(?)/$index-$match[1]}}"
   }
@@ -1145,7 +1145,7 @@ builtin setopt noaliases
 # Registers the z-annex inside Zi.
 @zi-register-hook() {
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-    builtin setopt extendedglob nobanghist noshortloops typesetsilent warncreateglobal
+    builtin setopt extended_glob no_bang_hist no_short_loops typeset_silent warn_create_global
   local name="$1" type="$2" handler="$3" icemods="$4" key="zi ${(q)2}"
   ZI_EXTS2[seqno]=$(( ${ZI_EXTS2[seqno]:-0} + 1 ))
   ZI_EXTS2[$key${${(M)type#hook:}:+ ${ZI_EXTS2[seqno]}}]="${ZI_EXTS2[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} '' ${(q)icemods}"
@@ -1252,12 +1252,12 @@ builtin setopt noaliases
 .zi-set-m-func() {
   if [[ $1 == set ]]; then
     ZI[___m_bkp]="${functions[m]}"
-    builtin setopt noaliases
+    builtin setopt no_aliases
     functions[m]="${functions[+zi-message]}"
     builtin setopt aliases
   elif [[ $1 == unset ]]; then
     if [[ -n ${ZI[___m_bkp]} ]]; then
-      builtin setopt noaliases
+      builtin setopt no_aliases
       functions[m]="${ZI[___m_bkp]}"
       builtin setopt aliases
     else
@@ -1281,14 +1281,14 @@ builtin setopt noaliases
   # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@" within scripts that we `source`.
   builtin set --
   integer correct retval exists
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
   [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
     local -a precm
     precm=(
       builtin emulate
       ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
       ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
-      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
+      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o no_sh_glob -o brace_expand -o ksh_glob}}
       ${(s: :):-${${:-${(@s: :):--o}" "${(s: :)^ICE[opts]}}:#-o }}
       -c
     )
@@ -1339,7 +1339,7 @@ builtin setopt noaliases
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
     "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" \!atinit || return $(( 10 - $? ))
   done
-  (( ${+ICE[atinit]} )) && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  (( ${+ICE[atinit]} )) && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atinit-<-> <->]} )
   for key in "${reply[@]}"; do
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
@@ -1385,7 +1385,7 @@ builtin setopt noaliases
       (( 0 == retval )) && [[ $url = PZT::* || $url = https://github.com/sorin-ionescu/prezto/* ]] && zstyle ":prezto:module:${${id_as%/init.zsh}:t}" loaded 'yes'
     } else { [[ ${+ICE[silent]} -eq 1 || ${+ICE[pick]} -eq 1 && -z ${ICE[pick]} || ${ICE[pick]} = /dev/null ]] || { +zi-message "Snippet not loaded ({url}${id_as}{rst})"; retval=1; } }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for key in "${reply[@]}"; do
@@ -1397,8 +1397,8 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$save_url" "" "$id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
-    (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
+    (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
   elif [[ -n ${opts[(r)--command]} || ${ICE[as]} = command ]]; then
     [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]] && ICE[pick]="${id_as:t}"
     # Directory snippet - a directory and multiple files are possible.
@@ -1433,7 +1433,7 @@ builtin setopt noaliases
       ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"
       (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }
     fi
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for key in "${reply[@]}"; do
@@ -1445,14 +1445,14 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$save_url" "" "$id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
   fi
-  (( ${+ICE[atload]} )) && [[ ${ICE[atload][1]} != "!" ]] && { ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  (( ${+ICE[atload]} )) && [[ ${ICE[atload][1]} != "!" ]] && { ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atload-<-> <->]} )
   for key in "${reply[@]}"; do
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
@@ -1537,7 +1537,7 @@ builtin setopt noaliases
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
     "${___arr[5]}" plugin "$___user" "$___plugin" "$___id_as" "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}" \!atinit || return $(( 10 - $? ))
   done
-  [[ ${+ICE[atinit]} = 1 && $ICE[atinit] != '!'*   ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  [[ ${+ICE[atinit]} = 1 && $ICE[atinit] != '!'*   ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atinit-<-> <->]} )
   for ___key in "${reply[@]}"; do
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
@@ -1566,14 +1566,14 @@ builtin setopt noaliases
   local ___pbase="${${___plugin:t}%(.plugin.zsh|.zsh|.git)}" ___key
   # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@" within scripts that we `source`.
   builtin set --
-  [[ -o ksharrays ]] && ___correct=1
+  [[ -o ksh_arrays ]] && ___correct=1
   [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
     local -a ___precm
     ___precm=(
       builtin emulate
       ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
       ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
-      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
+      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o no_sh_glob -o brace_expand -o ksh_glob}}
       ${(s: :):-${${:-${(@s: :):--o}" "${(s: :)^ICE[opts]}}:#-o }}
       -c
     )
@@ -1610,9 +1610,9 @@ builtin setopt noaliases
       fi
     }
     local ZERO
-    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit#!]}"; ((1)); } || eval "${ICE[atinit]#!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit#!]}"; ((1)); } || eval "${ICE[atinit]#!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$___pdir_orig/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local ___fname; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local ___fname; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for ___key in "${reply[@]}"; do
@@ -1624,9 +1624,9 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$___user" "$___plugin" "$___id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
@@ -1649,11 +1649,11 @@ builtin setopt noaliases
     # We need some state, but ___user wants his for his plugins.
     (( ${+ICE[blockf]} )) && { local -a fpath_bkp; fpath_bkp=( "${fpath[@]}" ); }
     local ZERO="$___pdir_path/$___fname"
-    (( ${+ICE[aliases]} )) || builtin setopt noaliases
-    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]#!}"; ((1)); } || eval "${ICE[atinit]#1}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    (( ${+ICE[aliases]} )) || builtin setopt no_aliases
+    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]#!}"; ((1)); } || eval "${ICE[atinit]#1}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$___pdir_orig/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); } done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); } done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for ___key in "${reply[@]}"; do
@@ -1665,13 +1665,13 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$___user" "$___plugin" "$___id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     (( ZI[ALIASES_OPT] )) && builtin setopt aliases
     (( ${+ICE[blockf]} )) && { fpath=( "${fpath_bkp[@]}" ); }
     .zi-tmp-subst-off "${___mode:-load}"
     [[ $___mode != light(|-b) ]] && .zi-diff "${ZI[CUR_USPL2]}" end
   fi
-  [[ ${+ICE[atload]} = 1 && ${ICE[atload][1]} != "!" ]] && { ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  [[ ${+ICE[atload]} = 1 && ${ICE[atload][1]} != "!" ]] && { ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atload-<-> <->]} )
   for ___key in "${reply[@]}"; do
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
@@ -1758,7 +1758,7 @@ builtin setopt noaliases
     (( ___nolast )) && { builtin print -r "$1" >! ${ZI[BIN_DIR]}/last-run-object.txt; }
     ZI[last-run-plugin]="$1"
     eval "${@[2-correct,-1]}"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldpwd"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldpwd"; }
   else
     +zi-message "{u-warn}Error{b-warn}:{rst} no such plugin or snippet."
   fi
@@ -1840,7 +1840,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: .zi-formatter-pid. [[[
 .zi-formatter-pid() {
-  builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   # Save whitespace location
   local pbz=${(M)1##(#s)[[:space:]]##}
   local kbz=${(M)1%%[[:space:]]##(#e)}
@@ -1875,7 +1875,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: .zi-formatter-url. [[[
 .zi-formatter-url() {
-  builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   #              1:proto        3:domain/5:start      6:end-of-it         7:no-dot-domain        9:file-path
   if [[ $1 = (#b)([^:]#)(://|::)((([[:alnum:]._+-]##).([[:alnum:]_+-]##))|([[:alnum:].+_-]##))(|/(*)) ]] {
     # The advanced coloring if recognized the format…
@@ -2007,7 +2007,7 @@ builtin setopt noaliases
 # Parses ICE specification, puts the result into ICE global hash. The ice-spec is valid for
 # next command only (i.e. it "melts"), but it can then stick to plugin and activate e.g. at update.
 .zi-ice() {
-  builtin setopt localoptions noksharrays extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt local_options no_ksh_arrays extended_glob warn_create_global typeset_silent no_short_loops
   integer retval
   local bit exts="${(j:|:)${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}}"
   for bit; do
@@ -2057,7 +2057,7 @@ return retval
 } # ]]]
 # FUNCTION: .zi-setup-params. [[[
 .zi-setup-params() {
-  builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   reply=( ${(@)${(@s.;.)ICE[param]}/(#m)*/${${MATCH%%(-\>|→|=\>)*}//((#s)[[:space:]]##|[[:space:]]##(#e))}${${(M)MATCH#*(-\>|→|=\>)}:+\=${${MATCH#*(-\>|→|=\>)}//((#s)[[:space:]]##|[[:space:]]##(#e))}}} )
   (( ${#reply} )) && return 0 || return 1
 } # ]]]
@@ -2182,7 +2182,7 @@ return retval
 @zi-scheduler() {
   integer ___ret="${${ZI[lro-data]%:*}##*:}"
   # lro stands for lastarg-retval-option.
-  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[printexitvalue]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
+  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
   [[ -n $1 && $1 != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
   [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
   ZI[START_TIME]="${ZI[START_TIME]:-$EPOCHREALTIME}"
@@ -2191,12 +2191,12 @@ return retval
   local -a match mbegin mend reply
   local MATCH REPLY AFD; integer MBEGIN MEND
 
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
 
   if [[ -n $1 ]] {
     if [[ ${#ZI_RUN} -le 1 || $1 = following ]]  {
       () {
-        builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+        builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
         # Example entry:
         # 1531252764+2+1 p 18 light z-shell/zsh-diff-so-fancy
         #
@@ -2237,13 +2237,13 @@ return retval
     add-zsh-hook -d -- precmd @zi-scheduler
     add-zsh-hook -- chpwd @zi-scheduler
     () {
-      builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+      builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
       # No "+" in this pattern, it will match only "1531252764" in "1531252764+2" and replace it with current time.
       ZI_TASKS=( ${ZI_TASKS[@]/(#b)([0-9]##)(*)/$(( ${match[1]} <= 1 ? ${match[1]} : ___t ))${match[2]}} )
     }
     # There's a bug in Zsh: first sched call would not be issued until a key-press,
     # if "sched +1 ..." would be called inside zle -F handler. So it's done here, in precmd-handle code.
-    sched +1 'ZI[lro-data]="$_:$?:${options[printexitvalue]}"; @zi-scheduler following ${ZI[lro-data]%:*:*}'
+    sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following ${ZI[lro-data]%:*:*}'
 
     AFD=13371337 # for older Zsh + noclobber option
     exec {AFD}< <(LANG=C command sleep 0.002; builtin print run;)
@@ -2299,7 +2299,7 @@ zi() {
     local -a reply; local REPLY
   }
 
-  [[ -o ksharrays ]] && ___correct=1
+  [[ -o ksh_arrays ]] && ___correct=1
 
   local -A ___opt_map OPTS
   ___opt_map=(
@@ -2381,7 +2381,7 @@ zi() {
       integer  ___is_snippet
       # Classic syntax -> simulate a call through the for-syntax.
       () {
-        builtin setopt localoptions extendedglob
+        builtin setopt local_options extended_glob
         : ${@[@]//(#b)([ $'\t']##|(#s))(-b|--command|-f|--force)([ $'\t']##|(#e))/${OPTS[${match[2]}]::=1}}
       } "$@"
       builtin set -- "${@[@]:#(-b|--command|-f|--force)}"
@@ -2446,7 +2446,7 @@ zi() {
           [[ ${ICE[id-as]} = (auto|) && ${+ICE[id-as]} == 1 ]] && ICE[id-as]="${___etid:t}"
           integer  ___is_snippet=${${(M)___is_snippet:#-1}:-0}
           () {
-            builtin setopt localoptions extendedglob
+            builtin setopt local_options extended_glob
             if [[ $___is_snippet -ge 0 && ( -n ${ICE[is-snippet]+1} || $___etid = ((#i)(http(s|)|ftp(s|)):/|(${(~kj.|.)ZI_1MAP}))* ) ]] {
               ___is_snippet=1
             }
@@ -2511,7 +2511,7 @@ zi() {
 
           if [[ ${reply[-1]} -eq 1 && -n ${ICE[trigger-load]} ]] {
             () {
-              builtin setopt localoptions extendedglob
+              builtin setopt local_options extended_glob
               local ___mode
               (( ___is_snippet > 0 )) && ___mode=snippet || ___mode="${${${ICE[light-mode]+light}}:-load}"
               for MATCH ( ${(s.;.)ICE[trigger-load]} ) {
@@ -2582,7 +2582,7 @@ zi() {
 
     if (( ___error )) {
       () {
-        builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+        builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
         +zi-message -n "{u-warn}Error{b-warn}:{rst} No plugin or snippet ID given"
         if [[ -n $___last_ice ]] {
           +zi-message -n " (the last recognized ice was: {ice}"\
@@ -2841,7 +2841,7 @@ zi() {
           .zi-ls "$@"
           ;;
         (srv)
-          () { builtin setopt localoptions extendedglob warncreateglobal
+          () { builtin setopt local_options extended_glob warn_create_global
           [[ ! -e ${ZI[SERVICES_DIR]}/"$2".fifo ]] && { builtin print "No such service: $2"; } ||
             { [[ $3 = (#i)(next|stop|quit|restart) ]] &&
               { builtin print "${(U)3}" >>! ${ZI[SERVICES_DIR]}/"$2".fifo || builtin print "Service $2 inactive"; ___retval=1; } ||


### PR DESCRIPTION
## Description

Normalize Zi's separator-free multiword Zsh option spellings to canonical underscore-separated names:

- update 428 occurrences across source, scripts, tests, and nearby comments;
- cover 31 equivalent option pairs, including `local_options`, `no_auto_pushd`, `extended_glob`, `warn_create_global`, `ksh_arrays`, `err_exit`, `no_unset`, and `pipe_fail`;
- update static `setopt`, `unsetopt`, `emulate -o`, `[[ -o ... ]]`, `$options[...]`, and generated option arguments; and
- preserve option names originating dynamically from captured runtime state or user input.

Future authoring guidance is owned by z-shell/.github#566. This PR intentionally adds no narrow repository CI guard.

## Related issues

Part of #449.
Part of z-shell/.github#565.

## Type of change

- [ ] `fix` - bug fix (non-breaking)
- [ ] `feat` - new feature (non-breaking)
- [ ] `feat!` / `fix!` - breaking change
- [ ] `perf` - performance improvement
- [x] `refactor` - code change with no functional impact
- [ ] `docs` - documentation only
- [ ] `test` - test addition or correction
- [ ] `build` - build system or dependency change
- [ ] `ci` - CI/workflow change
- [x] `style` - formatting with no behavior change
- [ ] `chore` - maintenance / dependency bump
- [ ] `revert` - revert of an earlier change

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] This is not a `next` to `main` promotion
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailer credits a bot, AI agent, or automation
- [x] I have read the contribution guidelines
- [x] Existing tests pass
- [x] Canonical organization guidance is provided by z-shell/.github#566

## Verification

- All 31 old/new spelling pairs resolved to the same Zsh option state.
- A scan against 197 canonical names from the official Zsh Options manual found no remaining compact multiword spellings.
- Native syntax and isolated `zcompile -U`: all 31 Zsh files passed. The pre-existing `lib/zsh/rpm2cpio.zsh:54` warning remains.
- Existing Zi integration suites: 61 scenarios passed.
- `git diff --check`: passed.
- Local commit hook: passed.

## Migration plan

Not required. Zsh accepts both spellings; this is a readability-only normalization with semantic equivalence verified.

## Agent handoff

- **Status:** Ready for review
- **Current state:** The option spelling cleanup is complete on `bug-449-option-spelling` and linked to its canonical organization guidance.
- **Blockers:** None. A rebase may be needed after #450 and #451 merge because all three isolated branches started from the same `next` revision.
- **Next steps:** Review after #450, #451, and z-shell/.github#566. Continue the other duplicate-helper and snippet-ID work in #449 separately.
- **Related tracker/issues:** #449, z-shell/.github#565, z-shell/.github#566
