### PR TITLE
fix(callbacks): persist Plugin Standard callbacks by effective ID

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -12,6 +12,8 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/plugin-standard-callbacks.zsh"
+      - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -22,6 +24,8 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/plugin-standard-callbacks.zsh"
+      - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -93,6 +97,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test path resolution
         run: zsh -f tests/path-resolution.zsh
+
+  plugin-standard-callbacks:
+    name: Plugin Standard Callbacks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test plugin standard callbacks
+        run: zsh -f tests/plugin-standard-callbacks.zsh
 
   self-update-reload:
     name: Self-update reload

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -821,7 +821,7 @@ ZI[EXTENDED_GLOB]=""
 } # ]]]
 # FUNCTION: .zi-unload [[[
 # 0. Call the Zsh Plugin's Standard *_plugin_unload function
-# 0. Call the code provided by the Zsh Plugin's Standard @zsh-plugin-run-at-update
+# 0. Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload
 # 1. Delete bindkeys (...)
 # 2. Delete zstyles
 # 3. Restore options
@@ -840,6 +840,7 @@ ZI[EXTENDED_GLOB]=""
   .zi-any-to-user-plugin "$1" "$2"
   local uspl2="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]}" user="${reply[-2]}" plugin="${reply[-1]}" quiet="${${3:+1}:-0}"
   local k
+  integer callback_rc=0
   .zi-any-colorify-as-uspl2 "$uspl2"
   (( quiet )) || builtin print -r -- "${ZI[col-bar]}---${ZI[col-rst]} Unloading plugin: $REPLY ${ZI[col-bar]}---${ZI[col-rst]}"
   local ___dir
@@ -864,7 +865,7 @@ ZI[EXTENDED_GLOB]=""
   (( ${+functions[${plugin}_plugin_unload]} )) && ${plugin}_plugin_unload
 
   #
-  # Call the code provided by the Zsh Plugin's Standard @zsh-plugin-run-at-update
+  # Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload
   #
 
   local -a tmp
@@ -873,10 +874,8 @@ ZI[EXTENDED_GLOB]=""
   (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )) && sice=( "${(Q)tmp[@]}" ) || sice=()
   if [[ -n ${sice[ps-on-unload]} ]]; then
     (( quiet )) || builtin print -r "Running plugin's provided unload code: ${ZI[col-info]}${sice[ps-on-unload][1,50]}${sice[ps-on-unload][51]:+…}${ZI[col-rst]}"
-    local ___oldcd="$PWD"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___dir"; }
-    eval "${sice[ps-on-unload]}"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
+    .zi-run-plugin-standard-unload-callback "${sice[ps-on-unload]}" "$___dir" "$@"
+    callback_rc=$?
   fi
 
   #
@@ -1295,6 +1294,7 @@ ZI[EXTENDED_GLOB]=""
     .zi-clear-report-for "$user" "$plugin"
     (( quiet )) || +zi-message "Plugin's report saved to {var}\$LASTREPORT{rst}"
   fi
+  return "$callback_rc"
 } # ]]]
 # FUNCTION: .zi-show-report [[[
 # Displays report of the plugin given.

--- a/tests/fixtures/plugin-standard-callbacks/plugin.plugin.zsh
+++ b/tests/fixtures/plugin-standard-callbacks/plugin.plugin.zsh
@@ -1,0 +1,9 @@
+@zsh-plugin-run-on-unload \
+  'builtin print -r -- "plugin-unload:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "plugin-unload:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_UNLOAD_RETURN:-0}'
+
+@zsh-plugin-run-on-update \
+  'builtin print -r -- "plugin-update:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "plugin-update:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_RETURN:-0}'

--- a/tests/fixtures/plugin-standard-callbacks/snippet.zsh
+++ b/tests/fixtures/plugin-standard-callbacks/snippet.zsh
@@ -1,0 +1,9 @@
+@zsh-plugin-run-on-unload \
+  'builtin print -r -- "snippet-unload:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "snippet-unload:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_UNLOAD_RETURN:-0}'
+
+@zsh-plugin-run-on-update \
+  'builtin print -r -- "snippet-update:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "snippet-update:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_RETURN:-0}'

--- a/tests/plugin-standard-callbacks.zsh
+++ b/tests/plugin-standard-callbacks.zsh
@@ -1,0 +1,173 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset fixture_root="$project_root/tests/fixtures/plugin-standard-callbacks"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-plugin-callback-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+assert_lines() {
+  builtin emulate -L zsh
+  local file="$1" label="$2"
+  shift 2
+  local -a actual=( "${(@f)$(<$file)}" )
+  local -a expected=( "$@" )
+  [[ "${(j:\n:)actual}" == "${(j:\n:)expected}" ]] ||
+    fail "$label: expected ${(qqq)${(j:\n:)expected}}, got ${(qqq)${(j:\n:)actual}}"
+}
+
+load_stored_ice() {
+  builtin emulate -L zsh
+  local object_id="$1"
+  local -a packed=( "${(z@)ZI_SICE[$object_id]}" )
+  (( ${#packed} > 1 && ${#packed} % 2 == 0 )) ||
+    fail "invalid packed ICE for $object_id"
+  ICE=( "${(Q)packed[@]}" )
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" \
+  "$temp_root/tmp" || fail "create isolated environment"
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gx TMPDIR="$temp_root/tmp"
+typeset -gx ZI_CALLBACK_LOG="$temp_root/callbacks.log"
+typeset -gx ZI_CALLBACK_RETURN=0
+typeset -gx ZI_CALLBACK_UNLOAD_RETURN=0
+typeset -gAH ZI OPTS ICE ZI_SICE
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload library"
+builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || fail "source install library"
+unsetopt warn_create_global
+OPTS[opt_-q,--quiet]=1
+
+[[ $PMSPEC == *U* && $PMSPEC == *p* ]] ||
+  fail "PMSPEC does not advertise the implemented unload and update callbacks"
+pass "PMSPEC advertises both callback capabilities"
+
+# Registration outside an active load must fail even if a stale dynamic name exists.
+typeset -g id_as=stale/object
+ZI[CUR_USPL2]=
+ICE=()
+@zsh-plugin-run-on-unload ':' >/dev/null 2>&1
+integer unload_registration_rc=$?
+@zsh-plugin-run-on-update ':' >/dev/null 2>&1
+integer update_registration_rc=$?
+(( unload_registration_rc != 0 && update_registration_rc != 0 )) ||
+  fail "callback registration succeeded without an active object"
+(( ! ${+ICE[ps-on-unload]} && ! ${+ICE[ps-on-update]} )) ||
+  fail "rejected callback registration mutated ICE"
+[[ -z ${ZI_SICE[stale/object]} ]] || fail "rejected callback used a stale dynamic identity"
+pass "callback registration rejects missing active-load identity"
+
+# Load a regular plugin and verify exact persistence plus update execution.
+typeset plugin_id=owner/plugin
+typeset plugin_dir="${ZI[PLUGINS_DIR]}/owner---plugin"
+command mkdir -p -- "$plugin_dir" || fail "create regular plugin directory"
+command cp -- "$fixture_root/plugin.plugin.zsh" "$plugin_dir/plugin.plugin.zsh" ||
+  fail "copy regular plugin fixture"
+ICE=()
+.zi-load owner plugin light >/dev/null || fail "load regular plugin fixture"
+[[ -n ${ZI_SICE[$plugin_id]} && -z ${ZI_SICE[stale/object]} ]] ||
+  fail "regular plugin callbacks were not stored under $plugin_id"
+load_stored_ice "$plugin_id"
+[[ ${ICE[ps-on-unload]} == *plugin-unload:first*\;\ *plugin-unload:second*\;\ *ZI_CALLBACK_UNLOAD_RETURN* ]] ||
+  fail "regular plugin unload callback order was not preserved"
+[[ ${ICE[ps-on-update]} == *plugin-update:first*\;\ *plugin-update:second*\;\ *ZI_CALLBACK_RETURN* ]] ||
+  fail "regular plugin update callback order was not preserved"
+pass "regular plugin callbacks persist under the effective ID"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=23
+typeset original_pwd="$PWD"
+∞zi-ps-on-update-hook plugin owner plugin "$plugin_id" "$plugin_dir" atpull-post update:1 >/dev/null
+integer plugin_update_rc=$?
+(( plugin_update_rc == 23 )) || fail "regular plugin update callback returned $plugin_update_rc instead of 23"
+[[ $PWD == "$original_pwd" ]] || fail "regular plugin update callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "regular plugin update callback" \
+  "plugin-update:first:$plugin_dir:7:plugin,owner,plugin,$plugin_id,$plugin_dir,atpull-post,update:1" \
+  "plugin-update:second:$plugin_dir:7:plugin,owner,plugin,$plugin_id,$plugin_dir,atpull-post,update:1"
+pass "regular plugin update callback preserves order, cwd, arguments, and status"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=0
+ZI_CALLBACK_UNLOAD_RETURN=31
+unsetopt warn_create_global
+.zi-unload owner plugin -q >/dev/null
+integer plugin_unload_rc=$?
+(( plugin_unload_rc == 31 )) || fail "regular plugin unload callback returned $plugin_unload_rc instead of 31"
+[[ $PWD == "$original_pwd" ]] || fail "regular plugin unload callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "regular plugin unload callback" \
+  "plugin-unload:first:$plugin_dir:3:owner,plugin,-q" \
+  "plugin-unload:second:$plugin_dir:3:owner,plugin,-q"
+[[ -z ${ZI_REGISTERED_PLUGINS[(r)$plugin_id]} ]] || fail "regular plugin remained registered after unload"
+pass "regular plugin unload callback preserves order, cwd, and arguments"
+
+# Load a snippet, then exercise its persisted callbacks with the same manager
+# callback frames used by snippet update and unload execution.
+typeset snippet_id=snippet/effective
+typeset snippet_source="$fixture_root/snippet.zsh"
+ICE=()
+ICE[id-as]="$snippet_id"
+unsetopt warn_create_global
+.zi-load-snippet "$snippet_source" >/dev/null || fail "load snippet fixture"
+[[ -n ${ZI_SICE[$snippet_id]} && -z ${ZI_SICE[stale/object]} ]] ||
+  fail "snippet callbacks were not stored under $snippet_id"
+load_stored_ice "$snippet_id"
+[[ ${ICE[ps-on-unload]} == *snippet-unload:first*\;\ *snippet-unload:second*\;\ *ZI_CALLBACK_UNLOAD_RETURN* ]] ||
+  fail "snippet unload callback order was not preserved"
+[[ ${ICE[ps-on-update]} == *snippet-update:first*\;\ *snippet-update:second*\;\ *ZI_CALLBACK_RETURN* ]] ||
+  fail "snippet update callback order was not preserved"
+pass "snippet callbacks persist under the effective ID"
+
+.zi-get-object-path snippet "$snippet_id" >/dev/null || fail "resolve loaded snippet directory"
+typeset snippet_dir="$REPLY"
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=29
+∞zi-ps-on-update-hook snippet "$snippet_source" "$snippet_id" "$snippet_dir" atpull-post update:1 >/dev/null
+integer snippet_update_rc=$?
+(( snippet_update_rc == 29 )) || fail "snippet update callback returned $snippet_update_rc instead of 29"
+[[ $PWD == "$original_pwd" ]] || fail "snippet update callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "snippet update callback" \
+  "snippet-update:first:$snippet_dir:6:snippet,$snippet_source,$snippet_id,$snippet_dir,atpull-post,update:1" \
+  "snippet-update:second:$snippet_dir:6:snippet,$snippet_source,$snippet_id,$snippet_dir,atpull-post,update:1"
+pass "snippet update callback preserves order, cwd, arguments, and status"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_UNLOAD_RETURN=37
+.zi-run-plugin-standard-unload-callback "${ICE[ps-on-unload]}" "$snippet_dir" \
+  snippet "$snippet_source" "$snippet_id" "$snippet_dir" unload
+integer snippet_unload_rc=$?
+(( snippet_unload_rc == 37 )) || fail "snippet unload callback returned $snippet_unload_rc instead of 37"
+[[ $PWD == "$original_pwd" ]] || fail "snippet unload callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "snippet unload callback" \
+  "snippet-unload:first:$snippet_dir:5:snippet,$snippet_source,$snippet_id,$snippet_dir,unload" \
+  "snippet-unload:second:$snippet_dir:5:snippet,$snippet_source,$snippet_id,$snippet_dir,unload"
+pass "snippet unload callback preserves order, cwd, arguments, and status"
+
+builtin unset id_as

--- a/zi.zsh
+++ b/zi.zsh
@@ -1151,18 +1151,43 @@ builtin setopt noaliases
   ZI_EXTS2[$key${${(M)type#hook:}:+ ${ZI_EXTS2[seqno]}}]="${ZI_EXTS2[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} '' ${(q)icemods}"
   ZI_EXTS2[ice-mods]="${ZI_EXTS2[ice-mods]}${icemods:+|}$icemods"
 } # ]]]
-# FUNCTION: @zsh-plugin-run-on-update. [[[
+# FUNCTION: .zi-run-plugin-standard-unload-callback. [[[
+# Runs a persisted Plugin Standard unload callback in the current shell while
+# containing `return` to the callback frame and restoring the caller's cwd.
+.zi-run-plugin-standard-unload-callback() {
+  local callback="$1" callback_dir="$2" callback_oldcd="$PWD"
+  integer callback_rc
+  shift 2
+  () { builtin setopt local_options no_auto_pushd; builtin cd -q "$callback_dir"; } || return 1
+  () { eval "$callback"; } "$@"
+  callback_rc=$?
+  () { builtin setopt local_options no_auto_pushd; builtin cd -q "$callback_oldcd"; }
+  return "$callback_rc"
+} # ]]]
+# FUNCTION: @zsh-plugin-run-on-unload. [[[
 # The Plugin Standard required mechanism, see:
 # https://wiki.zshell.dev/community/zsh_plugin_standard
 @zsh-plugin-run-on-unload() {
+  builtin emulate -L zsh
+  local current_id="${ZI[CUR_USPL2]}"
+  if [[ -z $current_id ]]; then
+    builtin print -u2 -r -- "@zsh-plugin-run-on-unload: no plugin or snippet load is active"
+    return 1
+  fi
   ICE[ps-on-unload]="${(j.; .)@}"
-  .zi-pack-ice "$id_as" ""
+  .zi-pack-ice "$current_id" ""
 } # ]]]
 # FUNCTION: @zsh-plugin-run-on-update. [[[
 # The Plugin Standard required mechanism
 @zsh-plugin-run-on-update() {
+  builtin emulate -L zsh
+  local current_id="${ZI[CUR_USPL2]}"
+  if [[ -z $current_id ]]; then
+    builtin print -u2 -r -- "@zsh-plugin-run-on-update: no plugin or snippet load is active"
+    return 1
+  fi
   ICE[ps-on-update]="${(j.; .)@}"
-  .zi-pack-ice "$id_as" ""
+  .zi-pack-ice "$current_id" ""
 } # ]]]
 
 # Remaining functions.


### PR DESCRIPTION
## Description

Persist Zsh Plugin Standard lifecycle callbacks under Zi's effective active object identity and execute unload callbacks with reliable context:

- resolve registrations through `ZI[CUR_USPL2]` for plugins and snippets;
- reject registration when no load is active before mutating ICE;
- preserve callback order, arguments, working directory, and status;
- contain callback `return` in its own frame while retaining current-shell effects; and
- restore the caller's working directory before Zi finishes unloading.

Real plugin and snippet fixtures cover callback persistence and execution behavior. Newly added option literals use canonical underscore spellings.

## Related issues

Closes #444

## Type of change

- [x] `fix` - bug fix (non-breaking)
- [ ] `feat` - new feature (non-breaking)
- [ ] `feat!` / `fix!` - breaking change
- [ ] `perf` - performance improvement
- [ ] `refactor` - code change with no functional impact
- [ ] `docs` - documentation only
- [x] `test` - test addition or correction
- [ ] `build` - build system or dependency change
- [x] `ci` - CI/workflow change
- [ ] `style` - formatting with no behavior change
- [ ] `chore` - maintenance / dependency bump
- [ ] `revert` - revert of an earlier change

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] This is not a `next` to `main` promotion
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailer credits a bot, AI agent, or automation
- [x] I have read the contribution guidelines
- [x] Existing tests pass
- [x] No separate user documentation change is required; behavior follows the existing Plugin Standard contract

## Verification

- `zsh -f tests/plugin-standard-callbacks.zsh`: 8 scenarios passed.
- Existing Zi integration suites: 61 scenarios passed.
- Native syntax and isolated `zcompile -U`: all 31 Zsh files passed. The pre-existing `lib/zsh/rpm2cpio.zsh:54` warning remains.
- `actionlint .github/workflows/zsh-n.yml`: passed.
- `git diff --check`: passed.
- Local commit hook: passed.

## Migration plan

Not required. The change repairs the advertised callback contract without removing a public surface.

## Agent handoff

- **Status:** Ready for review
- **Current state:** The implementation, real fixtures, and focused CI coverage are complete on `bug-444-plugin-standard-callbacks`.
- **Blockers:** None in the implementation. Project 28 status mutation was previously rate-limited.
- **Next steps:** Review and run required repository checks.
- **Related tracker/issues:** #444
