### PR TITLE
feat!: rebuild message output with safe auto formatting

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -11,6 +11,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -21,6 +22,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -126,6 +128,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
+
+  message-formatting:
+    name: Message formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test message formatting
+        run: zsh -f tests/message-formatting.zsh
 
   snippet-directory-mirror:
     name: Snippet directory mirror

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -35,6 +35,22 @@
       "description": "Hook registration API positional signature"
     },
     {
+      "id": "message-output",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "+zi-message",
+      "declaration_marker": "# FUNCTION: +zi-message. [[[",
+      "description": "Byte-preserving semantic message renderer and emitter"
+    },
+    {
+      "id": "message-progress",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "+zi-progress",
+      "declaration_marker": "# FUNCTION: +zi-progress. [[[",
+      "description": "Carriage-return progress emitter sharing the message renderer"
+    },
+    {
       "id": "compatibility-functions",
       "kind": "function-region",
       "file": "zi.zsh",
@@ -75,6 +91,18 @@
     }
   ],
   "consumers": [
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/guides/04_messages.mdx",
+      "surfaces": ["message-output", "message-progress"],
+      "evidence": "https://github.com/z-shell/wiki/blob/32a2d7c33f4575df0876de600d8718d7446b4b4c/docs/guides/04_messages.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/getting_started/02_overview.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/958209c2998023b387688a9e738a692dfe032ef1/docs/getting_started/02_overview.mdx"
+    },
     {
       "repository": "z-shell/wiki",
       "path": "ecosystem/annexes/0_overview.mdx",

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1570,7 +1570,7 @@ ZI[EXTENDED_GLOB]=""
               } || +zi-message "{nl}Updating{ehi}:{rst} $REPLY{rst}"
             }
           }
-          +zi-message "$line" | command tee .zi_lastupd | .zi-pager &
+          +zi-message --literal -- "$line" | command tee .zi_lastupd | .zi-pager &
           integer pager_pid=$!
           { sleep 20 && kill -9 $pager_pid 2>/dev/null 1>&2; } &!
           { wait $pager_pid; } > /dev/null 2>&1
@@ -1822,7 +1822,7 @@ ZI[EXTENDED_GLOB]=""
     local user=${reply[-2]} plugin=${reply[-1]}
     # Must be a git repository or a binary release
     if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]]; then
-      (( OPTS[opt_-q,--quiet] )) || +zi-message "$REPLY: not a git repository"
+      (( OPTS[opt_-q,--quiet] )) || +zi-message -- "$REPLY: not a git repository"
       continue
     fi
     if [[ $st = status ]]; then
@@ -2064,7 +2064,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     elif [[ ( ${sice[pick]} = /dev/null || ${sice[as]} = null ) && ${+sice[make]} = 1 ]]; then
       line="$line {mdsh} {faint} ({dir}/dev/null{rst} {cmd}make{rst} {p}plugin{rst}{faint}){rst}"
     fi
-    +zi-message "$line"
+    +zi-message -- "$line"
     (( sum += ZI[$entry] ))
   done
   +zi-message "{mmdsh}{rst} {b}Total{ehi}:{rst} {auto}${sum}s"
@@ -2137,10 +2137,10 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     if [[ "$cur_plugin" != "$uspl1" ]]; then
       [[ -n "$cur_plugin" ]] && builtin print # newline
       .zi-any-colorify-as-uspl2 "$user" "$plugin"
-      +zi-message "$REPLY:"
+      +zi-message -- "$REPLY:"
       cur_plugin="$uspl1"
     fi
-    +zi-message "$file"
+    +zi-message --literal -- "$file"
   done
 } # ]]]
 # FUNCTION: .zi-compile-uncompile-all [[[
@@ -2190,7 +2190,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
       +zi-message "not compiled"
     else
       .zi-any-colorify-as-uspl2 "$user" "$plugin"
-      +zi-message "$REPLY not compiled"
+      +zi-message -- "$REPLY not compiled"
     fi
     return 1
   fi
@@ -2324,7 +2324,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     fi
     if (( unknown == 1 || stray == 1 )); then
       +zi-message -n "Removing completion{ehi}:{rst} ${(r:longest+1:: :)c} $REPLY"
-      (( disabled )) && +zi-message -n " {error}[disabled]{col-rst]}"
+      (( disabled )) && +zi-message -n " {error}[disabled]{rst}"
       (( unknown )) && +zi-message -n " {error}[unknown file]{rst}"
       (( stray )) && +zi-message -n " {error}[stray]{rst}"
       builtin print
@@ -3335,5 +3335,5 @@ sleep 0.04 && +zi-message "❯ loaded|lists      {p}[keyword]{rst} {mdsh}{rst} {
   +zi-message "{mmdsh}{info} Registered ice-modifiers{ehi}:{rst}"
   local -a ice_order
   ice_order=( ${${(As:|:)ZI[ice-list]}:#teleid} ${(@)${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}:#(.*|dynamic-unscope)} )
-  +zi-message "${ice_order[*]}"
+  +zi-message -- "${ice_order[*]}"
 } # ]]]

--- a/tests/fixtures/public-contract/addition/zi.zsh
+++ b/tests/fixtures/public-contract/addition/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update|doctor"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/base/zi.zsh
+++ b/tests/fixtures/public-contract/base/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|load|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/breaking/zi.zsh
+++ b/tests/fixtures/public-contract/breaking/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|fetch|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/conditional/zi.zsh
+++ b/tests/fixtures/public-contract/conditional/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (
   pmodload() {

--- a/tests/fixtures/public-contract/dead-alias/zi.zsh
+++ b/tests/fixtures/public-contract/dead-alias/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|load|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/foreach/zi.zsh
+++ b/tests/fixtures/public-contract/foreach/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 foreach item (one)
   pmodload() {

--- a/tests/fixtures/public-contract/guards/zi.zsh
+++ b/tests/fixtures/public-contract/guards/zi.zsh
@@ -13,6 +13,20 @@ true || @zi-register-hook() {
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
+false && {
+  +zi-message() {
+    print -r -- "$@"
+  }
+}
+
+# FUNCTION: +zi-progress. [[[
+false && {
+  +zi-progress() {
+    print -r -- "$@"
+  }
+}
+
 # FUNCTION: pmodload. [[[
 true || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/multiple-renames/zi.zsh
+++ b/tests/fixtures/public-contract/multiple-renames/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|fetch|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/nested/zi.zsh
+++ b/tests/fixtures/public-contract/nested/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 outer_runtime() {
   helper_runtime() {

--- a/tests/fixtures/public-contract/one-line-functions/zi.zsh
+++ b/tests/fixtures/public-contract/one-line-functions/zi.zsh
@@ -7,6 +7,12 @@ ZI[cmd-list]="help|load|update"
 # FUNCTION: @zi-register-hook. [[[
 @zi-register-hook() { local name="$1" type="$2" handler="$3" icemods="$4"; }
 
+# FUNCTION: +zi-message. [[[
++zi-message() { print -r -- "$@"; }
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() { print -r -- "$@"; }
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() { print -r -- "$@"; }
 

--- a/tests/fixtures/public-contract/refactor/zi.zsh
+++ b/tests/fixtures/public-contract/refactor/zi.zsh
@@ -20,6 +20,16 @@ ZI[cmd-list]="update|help|\
   local icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message () {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress () {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload () {
   print -r -- "$@"

--- a/tests/message-formatting.zsh
+++ b/tests/message-formatting.zsh
@@ -1,0 +1,317 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+builtin setopt err_exit pipe_fail extended_glob
+
+typeset project_root=${0:A:h:h}
+typeset temp_root
+temp_root=$(command mktemp -d "${TMPDIR:-/tmp}/zi-message-formatting.XXXXXXXX")
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+typeset -gx HOME=$temp_root/home
+typeset -gx ZDOTDIR=$temp_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$temp_root/cache
+typeset -gx XDG_CONFIG_HOME=$temp_root/config
+typeset -gx XDG_DATA_HOME=$temp_root/data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+
+typeset -gAH ZI
+ZI[BIN_DIR]=$project_root
+builtin source "$project_root/zi.zsh" >/dev/null
+builtin setopt err_exit pipe_fail extended_glob
+
+fail() {
+  builtin print -ru2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin print -r -- "ok - $1"
+}
+
+assert_equal() {
+  [[ $1 == "$2" ]] || fail "$3: expected ${(qqq)2}, got ${(qqq)1}"
+}
+
+assert_contains() {
+  [[ $1 == *"$2"* ]] || fail "$3: ${(qqq)1} does not contain ${(qqq)2}"
+}
+
+assert_not_contains() {
+  [[ $1 != *"$2"* ]] || fail "$3: ${(qqq)1} unexpectedly contains ${(qqq)2}"
+}
+
+strip_ansi() {
+  REPLY=${1//$'\e'\[[0-9\;]#m/}
+}
+
+typeset sample output expected stdout_file stderr_file selected_file
+integer command_status output_fd
+stdout_file=$temp_root/stdout
+stderr_file=$temp_root/stderr
+selected_file=$temp_root/selected
+
+sample=$'tabs\tremain  doubled\nnew line {unknown} 100% -leading Unicode: λ sentinel: ←→ control: \e[31m'
+output=$(+zi-message -n --color=never -- "$sample")
+assert_equal "$output" "$sample" 'safe auto preserves unstyled bytes'
+pass 'safe auto preserves unstyled bytes'
+
+output=$(+zi-message -n --color=never --literal -- '{error}literal{rst} {auto}load')
+assert_equal "$output" '{error}literal{rst} {auto}load' 'literal mode bypasses markup and auto'
+pass 'literal mode bypasses markup and auto'
+
+output=$(+zi-message -n --color=never -- 'before {unknown} after')
+assert_equal "$output" 'before {unknown} after' 'unknown tags remain literal'
+pass 'unknown tags remain literal'
+
+output=$(+zi-message -n --color=never -- $'{profile}I have been loaded{nl}{auto}`Zi Rocks ♥`')
+assert_equal "$output" $'I have been loaded\n`Zi Rocks ♥`' 'existing wiki markup example'
+pass 'existing documented markup remains compatible'
+
+expected='See https://example.com/a-b?x=1#frag and ssh://user@example.com/repo; load --wait=1 in 1.5s with 42 and `two words`.'
+output=$(+zi-message -n --color=always -- "$expected")
+strip_ansi "$output"
+assert_equal "$REPLY" "$expected" 'safe auto preserves recognized text'
+assert_contains "$output" "${ZI[col-url]}https://example.com/a-b?x=1#frag${ZI[col-rst]}" 'HTTP URL style'
+assert_contains "$output" "${ZI[col-url]}ssh://user@example.com/repo${ZI[col-rst]}" 'SSH URL style'
+assert_contains "$output" "${ZI[col-cmd]}load${ZI[col-rst]}" 'Zi command style'
+assert_contains "$output" "${ZI[col-ice]}--wait=1${ZI[col-rst]}" 'ice style'
+assert_contains "$output" "${ZI[col-time]}1.5s${ZI[col-rst]}" 'duration style'
+assert_contains "$output" "${ZI[col-num]}42${ZI[col-rst]}" 'number style'
+assert_contains "$output" "${ZI[col-quo]}\`two words\`${ZI[col-rst]}" 'balanced quote style'
+assert_not_contains "$output" "${ZI[col-rst]}${ZI[col-rst]}" 'redundant trailing reset'
+pass 'safe auto recognizes deterministic forms'
+
+expected='ambiguous owner/repo usr/bin 1..2 ... are plain'
+output=$(+zi-message -n --color=always -- "$expected")
+assert_equal "$output" "$expected" 'safe auto rejects ambiguous forms'
+pass 'safe auto rejects ambiguous forms'
+
+zi_message_test_function() { :; }
+@zi-register-annex message-test subcommand:annexcmd message-test-handler '' annexice
+command mkdir -p -- "${ZI[PLUGINS_DIR]}/owner---repo" "$temp_root/existing-path"
+output=$(builtin cd -q -- "$temp_root" && +zi-message -n --color=always --auto=contextual -- 'print zi_message_test_function annexcmd --annexice=value owner/repo existing-path')
+assert_contains "$output" "${ZI[col-bcmd]}print${ZI[col-rst]}" 'contextual command style'
+assert_contains "$output" "${ZI[col-func]}zi_message_test_function${ZI[col-rst]}" 'contextual function style'
+assert_contains "$output" "${ZI[col-cmd]}annexcmd${ZI[col-rst]}" 'contextual annex command style'
+assert_contains "$output" "${ZI[col-ice]}--annexice=value${ZI[col-rst]}" 'contextual annex ice style'
+assert_contains "$output" "${ZI[col-pname]}owner/repo${ZI[col-rst]}" 'contextual plugin style'
+assert_contains "$output" "${ZI[col-file]}existing-path${ZI[col-rst]}" 'contextual path style'
+pass 'contextual auto recognizes shell and filesystem forms'
+
+output=$(+zi-message -n --color=always -- '{error}load{rst}')
+assert_contains "$output" "${ZI[col-error]}load" 'explicit tag style'
+assert_not_contains "$output" "${ZI[col-cmd]}load" 'explicit tag precedence'
+output=$(+zi-message -n --color=always -- '{error}load{rst} update')
+assert_contains "$output" "${ZI[col-cmd]}update${ZI[col-rst]}" 'reset resumes safe auto'
+output=$(+zi-message -n --color=always -- '{no-auto}load {auto}update')
+assert_not_contains "$output" "${ZI[col-cmd]}load${ZI[col-rst]}" 'inline no-auto mode'
+assert_contains "$output" "${ZI[col-cmd]}update${ZI[col-rst]}" 'inline safe auto mode'
+pass 'explicit tags take precedence over auto'
+
+output=$(+zi-message -n --color=always --auto=off --level=error -- 'level message')
+strip_ansi "$output"
+assert_equal "$REPLY" 'level message' 'semantic level text'
+assert_contains "$output" "$ZI[col-error]" 'semantic level style'
+pass 'semantic levels preserve text and apply style'
+
+typeset level level_style
+typeset -A expected_level_styles=(
+  debug dbg
+  info info
+  warn warn
+  error error
+  success happy
+)
+for level level_style in ${(kv)expected_level_styles}; do
+  output=$(+zi-message -n --color=always --auto=off --level="$level" -- message)
+  assert_contains "$output" "$ZI[col-$level_style]" "$level level style"
+  strip_ansi "$output"
+  assert_equal "$REPLY" message "$level level text"
+done
+output=$(+zi-message -n --color=always --auto=off --level=plain -- message)
+assert_equal "$output" message 'plain level does not add a style'
+pass 'all semantic levels have stable mappings'
+
+zstyle ':zi:message' auto off
+output=$(+zi-message -n --color=always -- load)
+assert_equal "$output" load 'zstyle disables auto'
+zstyle -d ':zi:message' auto
+pass 'zstyle configures default auto mode'
+
+zstyle ':zi:message' color never
+output=$(+zi-message -n -- load)
+assert_equal "$output" load 'zstyle disables color'
+zstyle -d ':zi:message' color
+pass 'zstyle configures default color mode'
+
+zstyle ':zi:message' auto invalid
+unsetopt err_exit
++zi-message message >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid zstyle auto mode did not return status 2'
+zstyle -d ':zi:message' auto
+zstyle ':zi:message' color invalid
+unsetopt err_exit
++zi-message message >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid zstyle color mode did not return status 2'
+zstyle -d ':zi:message' color
+pass 'invalid zstyle modes fail explicitly'
+
+typeset -gx NO_COLOR=1
+output=$(+zi-message -n --color=auto -- load)
+assert_equal "$output" load 'NO_COLOR disables automatic color'
+output=$(+zi-message -n --color=always -- load)
+assert_contains "$output" "$ZI[col-cmd]" 'explicit color overrides NO_COLOR'
+unset NO_COLOR
+pass 'color policy honors NO_COLOR and explicit override'
+
+typeset saved_term=$TERM
+typeset -gx TERM=dumb
+output=$(+zi-message -n --color=auto -- load)
+assert_equal "$output" load 'TERM dumb disables automatic color'
+typeset -gx TERM=$saved_term
+pass 'color policy honors TERM dumb'
+
+output=$(
+  TERM=xterm-color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/eight-home ZDOTDIR=$ZI_TEST_ROOT/eight-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/eight-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/eight-config XDG_DATA_HOME=$ZI_TEST_ROOT/eight-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+typeset key
+for key in ${(k)ZI}; do
+  [[ $key == col-* && ${ZI[$key]} == *'38;5'* ]] && builtin print -r -- "$key=${ZI[$key]}"
+done
+builtin true
+ZSH
+)
+assert_equal "$output" '' 'eight-color palette has no 256-color sequences'
+output=$(
+  TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/full-home ZDOTDIR=$ZI_TEST_ROOT/full-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/full-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/full-config XDG_DATA_HOME=$ZI_TEST_ROOT/full-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -rn -- "$ZI[col-url]"
+ZSH
+)
+assert_contains "$output" '38;5' '256-color palette'
+pass 'palette follows terminal color capability'
+
+output=$(
+  TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/custom-home ZDOTDIR=$ZI_TEST_ROOT/custom-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/custom-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/custom-config XDG_DATA_HOME=$ZI_TEST_ROOT/custom-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+ZI[col-url]='custom-url-color'
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -r -- "$ZI[col-url]"
+builtin print -r -- "$ZI[col-error]"
+ZSH
+)
+assert_equal "${${(f)output}[1]}" 'custom-url-color' 'partial palette customization'
+assert_contains "${${(f)output}[2]}" $'\e[' 'missing palette entries initialized'
+pass 'partial palette customization is preserved and completed'
+
+typeset saved_url_color=$ZI[col-url]
+ZI[col-url]='custom-url-color'
+builtin source "$project_root/zi.zsh" >/dev/null
+assert_equal "$ZI[col-url]" 'custom-url-color' 'reload preserves customized palette'
+ZI[col-url]=$saved_url_color
+builtin setopt err_exit pipe_fail extended_glob
+pass 'reload preserves customized palette'
+
+exec {output_fd}>| "$selected_file"
++zi-message -u "$output_fd" --color=never -- 'selected descriptor' >| "$stdout_file" 2>| "$stderr_file"
+exec {output_fd}>&-
+assert_equal "$(<"$selected_file")" 'selected descriptor' 'selected descriptor content'
+[[ ! -s $stdout_file ]] || fail 'selected descriptor leaked to stdout'
+[[ ! -s $stderr_file ]] || fail 'selected descriptor wrote to stderr'
+pass 'output and newline use only the selected descriptor'
+
+unsetopt err_exit
++zi-message -u 999 --color=never -- invalid >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status != 0 )) || fail 'invalid descriptor returned success'
+[[ ! -s $stdout_file ]] || fail 'invalid descriptor wrote to stdout'
+pass 'invalid descriptors return failure'
+
+unset zi_message_option_target
+unsetopt err_exit
++zi-message -vzi_message_option_target value >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid option did not return status 2'
+(( ! ${+parameters[zi_message_option_target]} )) || fail 'invalid option created a parameter'
+pass 'strict option parsing prevents print option injection'
+
+output=$(+zi-message -n --color=never -- 'literal %F{red} percent')
+assert_equal "$output" 'literal %F{red} percent' 'percent text remains literal'
+output=$(+zi-message -n --color=never -- -leading)
+assert_equal "$output" -leading 'option boundary preserves leading hyphen'
+pass 'literal output does not perform prompt expansion'
+
++zi-message --color=never -- message >| "$stdout_file"
+assert_equal "$(command od -An -tx1 -v "$stdout_file" | tr -d ' \n')" 6d6573736167650a 'ordinary message terminator'
++zi-progress --color=never -- message >| "$stdout_file"
+assert_equal "$(command od -An -tx1 -v "$stdout_file" | tr -d ' \n')" 6d6573736167650d 'progress terminator'
+pass 'message and progress terminators are separated'
+
+typeset saved_columns=$COLUMNS
+integer COLUMNS=1
+output=$(+zi-message -n --color=always --auto=off -- '{bar}X')
+assert_contains "$output" "${ZI[col-bar]}${ZI[col-rst]}X" 'zero-width bar resets before following text'
+strip_ansi "$output"
+assert_equal "$REPLY" X 'zero-width bar text'
+integer COLUMNS=$saved_columns
+pass 'structural tags remain structural with empty output'
+
+output=$(+zi-message -n -l --color=never -- one two three)
+assert_equal "$output" $'one\ntwo\nthree' 'line mode'
+pass 'line mode preserves argument boundaries'
+
+typeset before_directory=$PWD
+typeset -g REPLY='caller reply'
+typeset -g MATCH='caller match'
+typeset -ga match=( 'caller match array' )
+unset 'ZI[__last-formatter-code]'
+() {
+  builtin emulate -L zsh
+  setopt ksh_arrays sh_word_split no_rc_quotes
+  typeset hostile_options=${(j:,:)${(ok)options}}
+  +zi-message -n --color=never -- 'caller state' >| "$stdout_file"
+  assert_equal "${(j:,:)${(ok)options}}" "$hostile_options" 'hostile options restored'
+  assert_equal "$PWD" "$before_directory" 'working directory restored'
+  assert_equal "$REPLY" 'caller reply' 'caller REPLY restored'
+  assert_equal "$MATCH" 'caller match' 'caller MATCH restored'
+  assert_equal "${(j: :)match}" 'caller match array' 'caller match array restored'
+  (( ! ${+ZI[__last-formatter-code]} )) || fail 'global formatter scratch was created'
+}
+pass 'caller state is preserved'
+
+if [[ ${ZI_MESSAGE_BENCHMARK:-0} == 1 ]]; then
+  zmodload zsh/datetime
+  typeset payload='Zi update --wait=1 from https://example.com/a-b?x=1#frag in 1.5s, then load `tree`.'
+  integer iterations=1000 index
+  float started=$EPOCHREALTIME elapsed microseconds_per_call
+  for (( index = 1; index <= iterations; ++index )); do
+    +zi-message -n --color=always -- "$payload" >/dev/null
+  done
+  elapsed=$(( EPOCHREALTIME - started ))
+  microseconds_per_call=$(( elapsed * 1000000.0 / iterations ))
+  (( microseconds_per_call < 1000.0 )) || fail "safe auto benchmark exceeded 1 ms: $microseconds_per_call us"
+  builtin printf 'ok - safe auto benchmark: %.1f us per call\n' $microseconds_per_call
+fi

--- a/tests/message-formatting.zsh
+++ b/tests/message-formatting.zsh
@@ -209,6 +209,22 @@ assert_contains "$output" '38;5' '256-color palette'
 pass 'palette follows terminal color capability'
 
 output=$(
+  SOURCED=1 TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/sourced-home ZDOTDIR=$ZI_TEST_ROOT/sourced-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/sourced-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/sourced-config XDG_DATA_HOME=$ZI_TEST_ROOT/sourced-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -r -- "legacy=${ZI[col-url]-}"
++zi-message -n --color=always --auto=off -- '{url}https://example.com{rst}'
+ZSH
+)
+assert_equal "${${(f)output}[1]}" 'legacy=' 'SOURCED suppresses the legacy public palette'
+assert_contains "${${(f)output}[2]}" $'\e[' 'explicit color uses the private message palette'
+pass 'SOURCED compatibility does not weaken explicit message color'
+
+output=$(
   TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
 typeset -gx HOME=$ZI_TEST_ROOT/custom-home ZDOTDIR=$ZI_TEST_ROOT/custom-zdotdir
 typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/custom-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/custom-config XDG_DATA_HOME=$ZI_TEST_ROOT/custom-data

--- a/tests/message-formatting.zsh
+++ b/tests/message-formatting.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-builtin setopt err_exit pipe_fail extended_glob
+builtin setopt pipe_fail extended_glob
 
 typeset project_root=${0:A:h:h}
 typeset temp_root
@@ -15,6 +15,7 @@ typeset -gx ZDOTDIR=$temp_root/zdotdir
 typeset -gx XDG_CACHE_HOME=$temp_root/cache
 typeset -gx XDG_CONFIG_HOME=$temp_root/config
 typeset -gx XDG_DATA_HOME=$temp_root/data
+typeset -gx TERM=xterm-256color
 command mkdir -p -- "$HOME" "$ZDOTDIR"
 
 typeset -gAH ZI

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -122,6 +122,8 @@ assert_contains "$output" '`zpcompinit` was removed'
 assert_contains "$output" '`pmodload` was removed'
 assert_contains "$output" '`@zi-register-annex` was removed'
 assert_contains "$output" '`@zi-register-hook` was removed'
+assert_contains "$output" '`+zi-message` was removed'
+assert_contains "$output" '`+zi-progress` was removed'
 assert_contains "$output" '`extraction-policy`'
 print "ok - only manifested declaration guards are accepted"
 

--- a/zi.zsh
+++ b/zi.zsh
@@ -258,12 +258,14 @@ ZI_2MAP=(
 # Initiate. [[[
 zmodload zsh/zutil || { builtin print -P "%F{196}zsh/zutil module is required, aborting ❮ Zi ❯ set up.%f"; return 1; }
 zmodload zsh/parameter || { builtin print -P "%F{196}zsh/parameter module is required, aborting ❮ Zi ❯ set up.%f"; return 1; }
-zmodload zsh/terminfo 2>/dev/null
-zmodload zsh/termcap 2>/dev/null
+zmodload zsh/terminfo 2>/dev/null || builtin true
+zmodload zsh/termcap 2>/dev/null || builtin true
 
-# Terminal color codes. The palette is always available so an explicit
+# Terminal color codes. Keep a complete private palette so an explicit
 # --color=always request works even when Zi was sourced from a non-terminal.
-# Automatic color is decided later for the selected output descriptor.
+# The public ZI palette retains the legacy SOURCED suppression used by direct
+# consumers; +zi-message overlays missing entries only for its dynamic scope.
+typeset -gAH ZI_MESSAGE_PALETTE
 if [[ ${ZI[term-colors]} != <-> ]]; then
   ZI[term-colors]=0
   [[ ${terminfo[colors]} == <-> ]] && ZI[term-colors]=${terminfo[colors]}
@@ -333,9 +335,12 @@ fi
     col-↔       ${${${(M)LANG:#*UTF-8*}:+$'\e[32m↔\e[0m'}:-$'\e[32m«-»\e[0m'}
     )
   fi
-  for key in ${(k)palette}; do
-    (( ${+ZI[$key]} )) || ZI[$key]=${palette[$key]}
-  done
+  ZI_MESSAGE_PALETTE=( "${(@kv)palette}" )
+  if [[ -z $SOURCED ]]; then
+    for key in ${(k)palette}; do
+      (( ${+ZI[$key]} )) || ZI[$key]=${palette[$key]}
+    done
+  fi
 }
 
 # List of hooks.
@@ -2112,6 +2117,15 @@ builtin setopt no_aliases
   local message_kind=$1 auto_mode=default color_mode=default level=plain message REPLY
   integer output_fd=1 newline=1 line_mode=0 literal_mode=0 color_enabled=0 render_status
   shift
+
+  if [[ -n $SOURCED ]]; then
+    local -A message_zi=( "${(@kv)ZI}" )
+    local -A ZI=( "${(@kv)message_zi}" )
+    local palette_key
+    for palette_key in ${(k)ZI_MESSAGE_PALETTE}; do
+      (( ${+ZI[$palette_key]} )) || ZI[$palette_key]=${ZI_MESSAGE_PALETTE[$palette_key]}
+    done
+  fi
 
   while (( $# )); do
     case $1 in

--- a/zi.zsh
+++ b/zi.zsh
@@ -261,15 +261,26 @@ zmodload zsh/parameter || { builtin print -P "%F{196}zsh/parameter module is req
 zmodload zsh/terminfo 2>/dev/null
 zmodload zsh/termcap 2>/dev/null
 
-# Terminal color codes.
-if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+termcap} -eq 1 && -n ${termcap[Co]} ) ]] {
-  ZI+=(
+# Terminal color codes. The palette is always available so an explicit
+# --color=always request works even when Zi was sourced from a non-terminal.
+# Automatic color is decided later for the selected output descriptor.
+if [[ ${ZI[term-colors]} != <-> ]]; then
+  ZI[term-colors]=0
+  [[ ${terminfo[colors]} == <-> ]] && ZI[term-colors]=${terminfo[colors]}
+  [[ ${termcap[Co]} == <-> && ${termcap[Co]} -gt ${ZI[term-colors]} ]] && ZI[term-colors]=${termcap[Co]}
+fi
+() {
+  builtin emulate -L zsh
+  local key
+  local -A palette
+
+  palette=(
   col-annex   $'\e[38;5;165m'      col-info    $'\e[38;5;82m'       col-p       $'\e[38;5;81m'
   col-apo     $'\e[1;38;5;220m'    col-info2   $'\e[38;5;220m'      col-pkg     $'\e[1;3;38;5;27m'
   col-b       $'\e[1m'             col-info3   $'\e[1m\e[38;5;220m' col-pname   $'\e[1;4m\e[32m'
   col-aps     $'\e[38;5;117m'      col-baps    $'\e[1;38;5;82m'     col-pre     $'\e[38;5;93m'
   col-bar     $'\e[38;5;82m'       col-bcmd    $'\e[38;5;220m'      col-profile $'\e[38;5;201m'
-  col-bspc    $'\b'                col-bapo    $'\e[1;39;5;220m'    col-keyword $'\e[32m'
+  col-bspc    $'\b'                col-bapo    $'\e[1;38;5;220m'    col-keyword $'\e[32m'
   col-b-lhi   $'\e[1m\e[38;5;27m'  col-lhi     $'\e[38;5;33m'       col-slight  $'\e[38;5;230m'
   col-b-warn  $'\e[1;38;5;214m'    col-msg     $'\e[0m'             col-st      $'\e[9m'
   col-cmd     $'\e[38;5;82m'       col-msg2    $'\e[38;5;172m'      col-tab     $' \t '
@@ -295,9 +306,36 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
   col-…     "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
   col--…    "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
   )
-  if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 ) ]] {
-    ZI+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
-  }
+  if (( ${ZI[term-colors]} < 256 )); then
+    palette+=(
+    col-annex   $'\e[35m'      col-info    $'\e[32m'      col-p       $'\e[36m'
+    col-apo     $'\e[1;33m'    col-info2   $'\e[33m'      col-pkg     $'\e[1;3;34m'
+    col-aps     $'\e[36m'      col-bapo    $'\e[1;33m'    col-baps    $'\e[1;32m'
+    col-bar     $'\e[32m'      col-bcmd    $'\e[33m'      col-info3   $'\e[1;33m'
+    col-msg2    $'\e[33m'      col-msg3    $'\e[90m'      col-pre     $'\e[35m'
+    col-profile $'\e[35m'      col-term    $'\e[33m'
+    col-b-lhi   $'\e[1;34m'    col-lhi     $'\e[34m'      col-slight  $'\e[37m'
+    col-b-warn  $'\e[1;33m'    col-cmd     $'\e[32m'      col-data    $'\e[32m'
+    col-data2   $'\e[36m'      col-meta    $'\e[36m'      col-th-bar  $'\e[32m'
+    col-dir     $'\e[3;35m'    col-meta2   $'\e[35m'      col-txt     $'\e[37m'
+    col-ehi     $'\e[1;31m'    col-error   $'\e[1;31m'    col-failure $'\e[31m'
+    col-faint   $'\e[90m'      col-note    $'\e[33m'      col-url     $'\e[34m'
+    col-file    $'\e[3;36m'    col-u-warn  $'\e[4;33m'    col-func    $'\e[35m'
+    col-uname   $'\e[1;4;35m'  col-uninst  $'\e[32m'      col-var     $'\e[36m'
+    col-flag    $'\e[1;3;32m'  col-quo     $'\e[1;34m'    col-glob    $'\e[33m'
+    col-num     $'\e[3;32m'    col-version $'\e[3;32m'    col-happy   $'\e[1;32m'
+    col-obj     $'\e[36m'      col-hi      $'\e[1;35m'    col-obj2    $'\e[32m'
+    col-warn    $'\e[33m'      col-ice     $'\e[36m'      col-ok      $'\e[33m'
+    col-id-as   $'\e[4;33m'    col-opt     $'\e[32m'      col-time    $'\e[33m'
+    col-quos    $'\e[1;31m'    col-pname   $'\e[1;4;36m'
+    col-mdsh    $'\e[1;33m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh   $'\e[1;33m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+    col-↔       ${${${(M)LANG:#*UTF-8*}:+$'\e[32m↔\e[0m'}:-$'\e[32m«-»\e[0m'}
+    )
+  fi
+  for key in ${(k)palette}; do
+    (( ${+ZI[$key]} )) || ZI[$key]=${palette[$key]}
+  done
 }
 
 # List of hooks.
@@ -1782,174 +1820,350 @@ builtin setopt noaliases
   command true # workaround a Zsh bug, see: http://www.zsh.org/mla/workers/2018/msg00966.html
   builtin zle -F "$THEFD" +zi-deploy-message
 } # ]]]
-# FUNCTION: .zi-formatter-auto[[[
-# The automatic message formatting tool automatically detects,
-# formats, and colorizes the following pieces of text:
-# [URLs], [plugin IDs (user/repo) if exists on the disk], [numbers], [time], [single-word id-as plugins],
-# [single word commands], [single word functions], [zi commands], [ice modifiers (e.g: mv'a -> b')],
-# [single-char bits and quoted strings (`...`, ,'...', "...")].
-.zi-formatter-auto() {
+# FUNCTION: .zi-message-auto-format. [[[
+# Applies byte-preserving automatic formatting to one unstyled message span.
+# Safe mode recognizes only deterministic Zi and lexical forms. Contextual mode
+# additionally consults the current shell and filesystem.
+.zi-message-auto-format() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+  builtin setopt extended_glob no_short_loops
 
-  local MATCH in=$1 out rwmsg spaces rest; integer MBEGIN MEND
-  local -a match mbegin mend ice_order ecmds
+  local rest=$1 mode=${2:-safe} resume=$3 output chunk core prefix suffix style quote ice_name
+  local MATCH
+  local -a match mbegin mend command_names ice_names extension_commands extension_ices
+  integer MBEGIN MEND color_enabled=${4:-1} index quote_end styled=0
 
-  ice_order=( ${(As:|:)ZI[ice-list]} ${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/} )
-  ecmds=( ${ZI_EXTS[(I)z-annex subcommand:*]#z-annex subcommand:} )
-  in=${(j: :)${${(Z+Cn+)in}//[$'\t ']/$'\u00a0'}}
-  rwmsg=$in
-
-  while [[ $in == (#b)([[:space:]]#)([^[:space:]]##)(*) ]]; do
-    spaces=$match[1]
-    rest=$match[3]
-    rwmsg=${match[2]//---//}
-    REPLY=$rwmsg
-    if [[ $rwmsg == ([[:space:]]##|(#s))[0-9.]##([[:space:]]##|(#e)) && \
-      $rest == ([[:space:]]#|(#s))[sm]([[:space:]]##*|(#e)) || $rwmsg == ([[:space:]]##|(#s))[0-9.]##[sm]([[:space:]]##|(#e)) ]]; then
-      REPLY=${ZI[col-time]}$rwmsg${ZI[col-rst]}
-      [[ $rwmsg != *[sm]* ]] && rest=$ZI[col-time]${(M)rest##[[:space:]]#[sm]}$ZI[col-rst]${rest##[[:space:]]#[sm]}
-    elif [[ $rwmsg == ([[:space:]]##|(#s))[0-9.]##([[:space:]]##|(#e)) ]]; then
-      REPLY=${ZI[col-num]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (#b)(--|)(${(~j:|:)ice_order})([:=\"\'\!a-zA-Z0-9-][^\"\']##[^a-zA-Z0-9]##) ]]; then
-      REPLY=${ZI[col-ice]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (${~ZI[cmd-list]}|${(~j:|:)ecmds}) ]]; then
-      REPLY=${ZI[col-cmd]}$rwmsg${ZI[col-rst]}
-    elif (( $+commands[$rwmsg] )); then
-      REPLY=${ZI[col-bcmd]}$rwmsg${ZI[col-rst]}
-    elif (( $+functions[$rwmsg] )); then
-      REPLY=${ZI[col-func]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (#b)((http(s|)|ftp(s|)|rsync|ssh|scp|ntp|file)://[[:alnum:].:+/]##) ]]; then
-      .zi-formatter-url $rwmsg
-    elif [[ $rwmsg == (OMZ|PZT|PZTM|OMZP|OMZT|OMZL)::* || $rwmsg == [^/]##/[^/]## || -d ${ZI[PLUGINS_DIR]}/${rwmsg//\//---} ]]; then
-      .zi-formatter-pid $rwmsg
-    elif [[ $rwmsg == (#b)(*)(...|'<->'|'<–>'|'<—>')(*) || $rwmsg == (#b)(*)(…|–|—|――|↔|...)(*) ]]; then
-      local -A map=( … … - dsh – ndsh — mdsh ―― mmdsh '<->' ↔ '<–>' ↔ '<—>' ↔ ↔ ↔ ... … )
-      local openq=$match[2] str=$match[3] closeq=$match[4] RST=$ZI[col-rst]
-      REPLY=$match[1]$ZI[col-${map[$openq]}]$str$RST$ZI[col-${map[$closeq]}]$match[5]$ZI[col-rst]
-    # \1 - preceding \2 - open, \3 - string, \4 - close, \5 - following
-    elif [[ $rwmsg == (#b)(*)([\'\`\"])([^\'\`\"]##)([\'\`\"])(*) ]]; then
-      local -A map=( \` bapo \' apo \" quo x\` baps x\' aps x\" quos )
-      local openq=$match[2] str=$match[3] closeq=$match[4] RST=$ZI[col-rst]
-      REPLY=$match[1]$ZI[col-${map[$openq]}]$openq$RST$ZI[col-${map[x$openq]}]$str$RST$ZI[col-${map[$closeq]}]$closeq$RST$match[5]$ZI[col-rst]
-    fi
-    in=$rest
-    out+=${spaces//$'\n'/$'\013\015'}$REPLY
-  done
-  REPLY=${out//$'\u00a0'/ }
-} # ]]]
-# FUNCTION: .zi-formatter-pid. [[[
-.zi-formatter-pid() {
-  builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
-  # Save whitespace location
-  local pbz=${(M)1##(#s)[[:space:]]##}
-  local kbz=${(M)1%%[[:space:]]##(#e)}
-  # Trim leading/trailing whitespace
-  1=${1//((#s)[[:space:]]##|[[:space:]]##(#e))/}
-  ((${+functions[.zi-first]})) || source ${ZI[BIN_DIR]}/lib/zsh/side.zsh
-  .zi-any-colorify-as-uspl2 "$1";
-  # Replace at least one character with an unbreakable space,
-  # because extreme whitespace is lost due to implementation problems ...
-  pbz=${pbz/[[:blank:]]/ }
-  local kbz_rev="${(j::)${(@Oas::)kbz}}"
-  kbz="${(j::)${(@Oas::)${kbz_rev/[[:blank:]]/ }}}"
-  # Restore whitespace location
-  REPLY=$pbz$REPLY$kbz
-} # ]]]
-# FUNCTION: .zi-formatter-bar. [[[
-.zi-formatter-bar() {
-  .zi-formatter-bar-util ─ bar
-} # ]]]
-# FUNCTION: .zi-formatter-th-bar. [[[
-.zi-formatter-th-bar() {
-  .zi-formatter-bar-util ━ th-bar
-}
-# FUNCTION: .zi-formatter-bar-util. [[[
-.zi-formatter-bar-util() {
-  if [[ $LANG == (#i)*utf-8* ]]; then
-    ch=$1
-  else
-    ch=-
+  if (( ! color_enabled )); then
+    REPLY=$1
+    return 1
   fi
-  REPLY=$ZI[col-$2]${(pl:COLUMNS-1::$ch:):-}$ZI[col-rst]
-} # ]]]
-# FUNCTION: .zi-formatter-url. [[[
-.zi-formatter-url() {
-  builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
-  #              1:proto        3:domain/5:start      6:end-of-it         7:no-dot-domain        9:file-path
-  if [[ $1 = (#b)([^:]#)(://|::)((([[:alnum:]._+-]##).([[:alnum:]_+-]##))|([[:alnum:].+_-]##))(|/(*)) ]] {
-    # The advanced coloring if recognized the format…
-    match[9]=${match[9]//\//"%F{227}%B"/"%F{81}%b"}
-    if [[ -n $match[4] ]]; then
-      # … this ·case· ends at: trailing component of the with-dot domain …
-      REPLY="$(builtin print -Pr -- %F{220}$match[1]%F{227}$match[2]%B%F{82}$match[5]%B%F{227}.%B%F{183}$match[6]%f%b)"
+
+  command_names=( ${(s:|:)ZI[cmd-list]} )
+  ice_names=( ${(s:|:)ZI[ice-list]} )
+  if [[ $mode == contextual ]]; then
+    extension_commands=( ${ZI_EXTS[(I)z-annex subcommand:*]#z-annex subcommand:} )
+    extension_ices=( ${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/} )
+  fi
+
+  while [[ -n $rest ]]; do
+    if [[ $rest == (#b)([[:space:]]##)(*) ]]; then
+      output+=$match[1]
+      rest=$match[2]
+      continue
+    fi
+
+    # Quotes may contain whitespace, so recognize a balanced span before the
+    # ordinary non-whitespace token path.
+    quote=$rest[1]
+    if [[ $quote == [\'\"\`] ]]; then
+      quote_end=0
+      for (( index = 2; index <= ${#rest}; ++index )); do
+        if [[ $rest[index] == "$quote" ]]; then
+          quote_end=$index
+          break
+        fi
+      done
+      if (( quote_end )); then
+        chunk=$rest[1,quote_end]
+        rest=$rest[quote_end+1,-1]
+        output+=${ZI[col-quo]}$chunk${ZI[col-rst]}$resume
+        styled=1
+        continue
+      fi
+    fi
+
+    [[ $rest == (#b)([^[:space:]]##)(*) ]] || {
+      REPLY=$output$rest
+      return $(( styled ? 0 : 1 ))
+    }
+    chunk=$match[1]
+    rest=$match[2]
+    core=$chunk
+    prefix=${(M)core##[(\[\{<]#}
+    core=${core#$prefix}
+    suffix=${(M)core%%[.,:;!?\)\]\}>]#}
+    core=${core%$suffix}
+    style=
+
+    if [[ $core == [[:alpha:]][[:alnum:]+.-]#://[^[:space:][:cntrl:]]## ]]; then
+      style=url
+    elif (( ${command_names[(Ie)$core]} )); then
+      style=cmd
     else
-      # … this ·case· ends at: no-dot domain …
-      REPLY="$(builtin print -Pr -- %F{220}$match[1]%F{227}$match[2]%B%F{82}$match[7]%f%b)"
+      ice_name=${core#--}
+      [[ $ice_name == "$core" ]] && ice_name=${core#-}
+      ice_name=${ice_name%%[=:\'\"]*}
+      if [[ $ice_name != "$core" ]] && (( ${ice_names[(Ie)$ice_name]} )); then
+        style=ice
+      elif [[ $core == (0|[1-9][0-9]#)(.[0-9]##|)(ms|s|m|h|d) ]]; then
+        style=time
+      elif [[ $core == (|[-+])(0|[1-9][0-9]#)(.[0-9]##|) ]]; then
+        style=num
+      elif [[ $mode == contextual ]]; then
+        if (( ${extension_commands[(Ie)$core]} )); then
+          style=cmd
+        elif (( ${extension_ices[(Ie)$ice_name]} )); then
+          style=ice
+        elif [[ -n ${builtins[(Ie)$core]} || -n ${commands[(Ie)$core]} || -n ${aliases[(Ie)$core]} ]] || (( ${reswords[(Ie)$core]} )); then
+          style=bcmd
+        elif [[ -n ${functions[(Ie)$core]} ]]; then
+          style=func
+        elif [[ $core == (OMZ|PZT|PZTM|OMZP|OMZT|OMZL)::* || -d "${ZI[PLUGINS_DIR]}/${core//\//---}" ]]; then
+          style=pname
+        elif [[ -e $core ]]; then
+          style=file
+        fi
+      fi
     fi
-    # Is there any file-path part in the URL?
-    if [[ -n $match[9] ]]; then
-      # … append it. This ends the URL.
-      REPLY+="$(print -Pr -- %F{227}%B/%F{81}%b$match[9]%f%b)"
+
+    if [[ -n $style ]]; then
+      output+=$prefix${ZI[col-$style]}$core${ZI[col-rst]}$resume$suffix
+      styled=1
+    else
+      output+=$chunk
     fi
-  #endif
-  } else {
-    # …revert to the basic if not…
-    REPLY=$ZI[col-url]$1$ZI[col-rst]
-  }
+  done
+
+  REPLY=$output
+  return $(( styled ? 0 : 1 ))
 } # ]]]
-# FUNCTION: +zi-message-formatter [[[
-.zi-main-message-formatter() {
-  if [[ -z $1 && -z $2 && -z $3 ]]; then
-    REPLY=""
-    return
+# FUNCTION: .zi-message-color-enabled. [[[
+.zi-message-color-enabled() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  local policy=$1 output_fd=$2
+
+  case $policy in
+    always) return 0 ;;
+    never) return 1 ;;
+    auto)
+      [[ -z $NO_COLOR && $TERM != dumb ]] || return 1
+      (( ${ZI[term-colors]:-0} > 0 )) || return 1
+      [[ -t $output_fd ]]
+      ;;
+    *) return 1 ;;
+  esac
+} # ]]]
+# FUNCTION: .zi-message-render. [[[
+.zi-message-render() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin setopt extended_glob no_short_loops
+
+  local input=$1 default_auto=$2 level=$4 rest segment tag output special special_style active_code base_code color_key style_tag
+  local current_auto=$default_auto
+  local MATCH
+  local -a match mbegin mend
+  local -A level_styles=( plain '' debug dbg info info warn warn error error success happy )
+  local -A style_aliases=( pid pname )
+  integer MBEGIN MEND color_enabled=$3 literal_mode=$5 explicit_style=0 styled=0 needs_reset=0 formatter_status width
+
+  style_tag=$level_styles[$level]
+  base_code=${style_tag:+${ZI[col-$style_tag]}}
+  active_code=$base_code
+  if (( color_enabled )) && [[ -n $base_code ]]; then
+    output+=$base_code
+    styled=1
+    needs_reset=1
   fi
-  local append influx in_prepend
-  if [[ $2 == (b|u|it|st|nb|nu|nit|nst) ]]; then
-    # Code repetition to preserve any leading/trailing whitespace and to allow accumulation of this code with others.
-    append=$ZI[col-$2]
-  elif [[ $2 == (…|ndsh|mdsh|mmdsh|-…|lr|) || -z $2 || -z $ZI[col-$2] ]]; then
-    # Resume previous escape code, if stored.
-    if [[ $ZI[__last-formatter-code] != (…|ndsh|mdsh|mmdsh|-…|lr|rst|nl|) ]]; then
-      in_prepend=$ZI[col-$ZI[__last-formatter-code]]
-      influx=$ZI[col-$ZI[__last-formatter-code]]
+
+  if (( literal_mode )); then
+    output+=$input
+    (( styled )) && output+=${ZI[col-rst]}
+    REPLY=$output
+    return $(( styled ? 0 : 1 ))
+  fi
+
+  rest=$input
+  while [[ -n $rest ]]; do
+    if [[ $rest == (#b)([^\{]#)(\{([^\{\}]##)\})(*) ]]; then
+      segment=$match[1]
+      tag=$match[3]
+      rest=$match[4]
+    else
+      segment=$rest
+      tag=
+      rest=
     fi
-  else
-    # End of escaping logic
-    append=$ZI[col-rst]
+
+    if [[ -n $segment ]]; then
+      if (( color_enabled && ! explicit_style )) && [[ $current_auto != off ]]; then
+        .zi-message-auto-format "$segment" "$current_auto" "$base_code" 1
+        formatter_status=$?
+        output+=$REPLY
+        if (( formatter_status == 0 )); then
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+      else
+        output+=$segment
+      fi
+    fi
+
+    [[ -n $tag ]] || continue
+    special=
+    special_style=
+    case $tag in
+      nl) special=$'\n' ;;
+      tab) special=$' \t ' ;;
+      bspc) special=$'\b' ;;
+      …) special=${${${(M)LANG:#*UTF-8*}:+…}:-...} ;;
+      ndsh) [[ $LANG == (#i)*utf-8* ]] && special=– || special=- ;;
+      mdsh) [[ $LANG == (#i)*utf-8* ]] && special=$'\u2014' || special=-; special_style=warn ;;
+      mmdsh) [[ $LANG == (#i)*utf-8* ]] && special=―― || special=--; special_style=warn ;;
+      -…) special=${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-...} ;;
+      lr|↔)
+        special=${${${(M)LANG:#*UTF-8*}:+↔}:-«-»}
+        [[ $tag == ↔ ]] && special_style=bar
+        ;;
+      bar|th-bar)
+        width=$(( COLUMNS > 1 ? COLUMNS - 1 : 0 ))
+        if [[ $LANG == (#i)*utf-8* ]]; then
+          [[ $tag == th-bar ]] && special=━ || special=─
+        else
+          special=-
+        fi
+        special=${(pl:$width::$special:):-}
+        special_style=$tag
+        ;;
+      rst)
+        explicit_style=0
+        current_auto=$default_auto
+        active_code=$base_code
+        if (( color_enabled )); then
+          output+=${ZI[col-rst]}$base_code
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+        continue
+        ;;
+      auto|contextual|no-auto)
+        explicit_style=0
+        [[ $tag == no-auto ]] && current_auto=off || current_auto=$tag
+        [[ $current_auto == auto ]] && current_auto=safe
+        active_code=$base_code
+        if (( color_enabled )); then
+          output+=${ZI[col-rst]}$base_code
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+        continue
+        ;;
+    esac
+
+    if [[ $tag == (nl|tab|bspc|…|ndsh|mdsh|mmdsh|-…|lr|↔|bar|th-bar) ]]; then
+      if (( color_enabled )) && [[ -n $special_style ]]; then
+        output+=${ZI[col-$special_style]}$special${ZI[col-rst]}$active_code
+        styled=1
+        [[ -n $active_code ]] && needs_reset=1 || needs_reset=0
+      else
+        output+=$special
+      fi
+      continue
+    fi
+
+    style_tag=${style_aliases[$tag]:-$tag}
+    color_key=col-$style_tag
+    if (( ${+ZI[$color_key]} )); then
+      explicit_style=1
+      current_auto=off
+      active_code=${ZI[$color_key]}
+      if (( color_enabled )); then
+        output+=$active_code
+        styled=1
+        needs_reset=1
+      fi
+    else
+      output+="{$tag}"
+    fi
+  done
+
+  (( needs_reset )) && output+=${ZI[col-rst]}
+  REPLY=$output
+  return $(( styled ? 0 : 1 ))
+} # ]]]
+# FUNCTION: .zi-message-emit. [[[
+.zi-message-emit() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+
+  local message_kind=$1 auto_mode=default color_mode=default level=plain message REPLY
+  integer output_fd=1 newline=1 line_mode=0 literal_mode=0 color_enabled=0 render_status
+  shift
+
+  while (( $# )); do
+    case $1 in
+      --) shift; break ;;
+      -n) newline=0; shift ;;
+      -l) line_mode=1; shift ;;
+      -r) shift ;;
+      -u)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: -u requires a descriptor'; return 2; }
+        output_fd=$2
+        shift 2
+        ;;
+      -u<->) output_fd=${1#-u}; shift ;;
+      --auto)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --auto requires a mode'; return 2; }
+        auto_mode=$2
+        shift 2
+        ;;
+      --auto=*) auto_mode=${1#--auto=}; shift ;;
+      --color)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --color requires a mode'; return 2; }
+        color_mode=$2
+        shift 2
+        ;;
+      --color=*) color_mode=${1#--color=}; shift ;;
+      --level)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --level requires a level'; return 2; }
+        level=$2
+        shift 2
+        ;;
+      --level=*) level=${1#--level=}; shift ;;
+      --literal) literal_mode=1; shift ;;
+      -*) builtin print -ru2 -- "+zi-message: invalid option: $1"; return 2 ;;
+      *) break ;;
+    esac
+  done
+
+  [[ $output_fd == <-> ]] || { builtin print -ru2 -- "+zi-message: invalid descriptor: $output_fd"; return 2; }
+  if [[ $auto_mode == default ]]; then
+    zstyle -s ':zi:message' auto auto_mode || auto_mode=safe
   fi
-  # Construct the text.
-  REPLY=$in_prepend${ZI[col-$2]:-$1}$influx$3$append
-  # Replace new lines with characters that work the same but are not deleted in the substitution
-  # $ (...) - vertical tab 0xB ↔ 13 in the system octagonal connected back carriage (015).
-  local nl=$'\n' vertical=$'\013' carriager=$'\015'
-  REPLY=${REPLY//$nl/$vertical$carriager}
+  if [[ $color_mode == default ]]; then
+    zstyle -s ':zi:message' color color_mode || color_mode=auto
+  fi
+  [[ $auto_mode == (off|safe|contextual) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid auto mode: $auto_mode"
+    return 2
+  }
+  [[ $color_mode == (default|auto|always|never) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid color mode: $color_mode"
+    return 2
+  }
+  [[ $level == (plain|debug|info|warn|error|success) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid level: $level"
+    return 2
+  }
+
+  (( line_mode )) && message="${(F)@}" || message="${(j: :)@}"
+  .zi-message-color-enabled "$color_mode" "$output_fd" && color_enabled=1
+  .zi-message-render "$message" "$auto_mode" "$color_enabled" "$level" "$literal_mode"
+  render_status=$?
+  (( render_status <= 1 )) || return $render_status
+
+  builtin print -rn -u "$output_fd" -- "$REPLY" || return $?
+  if [[ $message_kind == progress ]]; then
+    builtin print -rn -u "$output_fd" -- $'\r'
+  elif (( newline )); then
+    builtin print -rn -u "$output_fd" -- $'\n'
+  fi
 } # ]]]
 # FUNCTION: +zi-message. [[[
 +zi-message() {
-  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
-
-  local MATCH opt msg; integer MBEGIN MEND
-  local -a match mbegin mend
-
-  [[ $1 = -* ]] && { local opt=$1; shift; }
-
-  ZI[__last-formatter-code]=
-  msg=${${(j: :)${@:#--}}//\%/%%}
-
-  # First try a dedicated formatter, marking its empty output with ←→, then
-  # the general formatter and in the end filter-out the ←→ from the message.
-  msg=${${msg//(#b)(([\\]|(%F))([\{]([^\}]##)[\}])|([\{]([^\}]##)[\}])([^\%\{\\]#))/${match[4]:+${${match[3]:-$ZI[col-${ZI[__last-formatter-code]}]}:#%F}}$match[3]$match[4]${${functions[.zi-formatter-$match[7]]:+${$(.zi-formatter-$match[7] "$match[8]"; builtin print -rn -- $REPLY):-←→}}:-$(.zi-main-message-formatter "$match[6]" "$match[7]" "$match[8]"; builtin print -rn -- "$REPLY")${${ZI[__last-formatter-code]::=${${${match[7]:#(…|ndsh|mdsh|mmdsh|-…|lr)}:+$match[7]}:-${ZI[__last-formatter-code]}}}:+}}}//←→}
-  # Reset color attributes at the end of the message.
-  msg=$msg$ZI[col-rst]
-  # Output the processed message:
-  builtin print -Pr ${opt:#--} -- $msg
-
-  # Needed to properly end a message with {nl}.
-  if [[ -n ${opt:#*n*} || -z $opt ]]; then
-    print -n $'\015'
-  fi
+  .zi-message-emit message "$@"
+} # ]]]
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  .zi-message-emit progress "$@"
 } # ]]]
 # FUNCTION: +zi-prehelp-usage-message. [[[
 # Prints the usage message.
@@ -1972,7 +2186,7 @@ builtin setopt noaliases
         msg=${msg#($cmd|\*):\[}
       }
       local pre_msg=`+zi-message -n {opt}${(r:14:)${txt#opt_}}`
-      +zi-message ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
+      +zi-message -- ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
     }
   } elif [[ -n $allowed ]] {
     shift 2

--- a/zi.zsh
+++ b/zi.zsh
@@ -266,6 +266,7 @@ zmodload zsh/termcap 2>/dev/null || builtin true
 # The public ZI palette retains the legacy SOURCED suppression used by direct
 # consumers; +zi-message overlays missing entries only for its dynamic scope.
 typeset -gAH ZI_MESSAGE_PALETTE
+typeset -g ZI_MESSAGE_PUBLIC_PALETTE_READY
 if [[ ${ZI[term-colors]} != <-> ]]; then
   ZI[term-colors]=0
   [[ ${terminfo[colors]} == <-> ]] && ZI[term-colors]=${terminfo[colors]}
@@ -336,10 +337,11 @@ fi
     )
   fi
   ZI_MESSAGE_PALETTE=( "${(@kv)palette}" )
-  if [[ -z $SOURCED ]]; then
+  if [[ -z $SOURCED ]] && (( ${ZI[term-colors]} > 0 )); then
     for key in ${(k)palette}; do
       (( ${+ZI[$key]} )) || ZI[$key]=${palette[$key]}
     done
+    ZI_MESSAGE_PUBLIC_PALETTE_READY=1
   fi
 }
 
@@ -2118,7 +2120,7 @@ builtin setopt no_aliases
   integer output_fd=1 newline=1 line_mode=0 literal_mode=0 color_enabled=0 render_status
   shift
 
-  if [[ -n $SOURCED ]]; then
+  if [[ $ZI_MESSAGE_PUBLIC_PALETTE_READY != 1 ]]; then
     local -A message_zi=( "${(@kv)ZI}" )
     local -A ZI=( "${(@kv)message_zi}" )
     local palette_key


### PR DESCRIPTION
## Summary

- make byte-preserving `--auto=safe` formatting the default for `+zi-message`
- add strict options, literal mode, semantic levels, configurable color policy, descriptor-safe output, and `+zi-progress`
- preserve explicit Zi markup while keeping unknown tags literal
- add focused behavior, state-isolation, terminal-capability, contract, and performance coverage
- register `+zi-message` and `+zi-progress` as monitored public contract surfaces with SHA-pinned wiki evidence

Closes #456.

Companion documentation: z-shell/wiki#897

## Migration plan

The default auto mode changes from the legacy context-sensitive formatter to deterministic `safe` recognition. Callers that need exact unformatted bytes should use `--literal`, or combine `--auto=off --color=never`. Callers that intentionally relied on command, function, plugin-directory, or filesystem discovery should opt into `--auto=contextual` or configure `zstyle ':zi:message' auto contextual`.

`+zi-message` now terminates normal messages with LF unless `-n` is supplied. Progress updates that require carriage-return behavior should use `+zi-progress`. Option-like message text must follow `--`, and invalid options now fail with status 2 instead of passing through ambiguously.

The public-contract analyzer reports only informational definition and consumer-evidence additions, so no destructive contract-impact disposition marker is required.

## Public contract impact

- adds monitored `message-output` and `message-progress` surfaces
- adds SHA-pinned evidence for the new message guide and the existing overview consumer
- preserves all previously monitored surfaces

## Validation

- `zsh -f -n zi.zsh lib/zsh/autoload.zsh tests/message-formatting.zsh`
- `zcompile -R` for `zi.zsh`
- `tests/message-formatting.zsh`, including 27 behavior groups
- safe-auto benchmark: 819.5 microseconds per call, below the 1 millisecond guard
- real pseudo-terminal checks for automatic color and `NO_COLOR`
- exact Ubuntu 24.04 and Zsh 5.9 container reproduction
- archive extraction, completion refresh, parallel update, path resolution, Plugin Standard callbacks, public contract impact, self-update reload, directory mirror, and version reporting tests
- `actionlint`
- `git diff --check`

## Documentation

The companion guide documents the rendering pipeline, safe and contextual auto modes, options, semantic levels, color policy, progress output, migration examples, and compatibility boundaries.
