### PR TITLE
fix(unload): track and remove plugin-owned hook callbacks

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -11,6 +11,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/hook-ownership.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -25,6 +26,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/hook-ownership.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -156,6 +158,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
+
+  hook-ownership:
+    name: Hook ownership
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test hook ownership
+        run: zsh -f tests/hook-ownership.zsh
 
   message-formatting:
     name: Message formatting

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -190,8 +190,9 @@ ZI[EXTENDED_GLOB]=""
 .zi-diff-hooks-compute() {
   builtin emulate -L zsh -o no_ksh_arrays -o extended_glob
   local uspl2="$1"
-  # A light load takes no snapshot, so there is nothing to attribute.
-  [[ -z ${ZI[ZSH_HOOKS_AFTER__$uspl2]} && -z ${ZI[ZSH_HOOKS_BEFORE__$uspl2]} ]] && return 1
+  # A light load takes no snapshot. Test the explicit marker rather than the
+  # serialized values because a normal load can start and end with no hooks.
+  [[ ${ZI[ZSH_HOOKS_DIFFED__$uspl2]} = 1 ]] || return 1
   typeset -a before after added removed
   before=( "${(z)ZI[ZSH_HOOKS_BEFORE__$uspl2]}" )
   after=( "${(z)ZI[ZSH_HOOKS_AFTER__$uspl2]}" )
@@ -282,6 +283,7 @@ ZI[EXTENDED_GLOB]=""
   ZI[ZSH_HOOKS_REMOVED__$REPLY]=""
   ZI[ZSH_HOOKS_BEFORE__$REPLY]=""
   ZI[ZSH_HOOKS_AFTER__$REPLY]=""
+  ZI[ZSH_HOOKS_DIFFED__$REPLY]=""
 } # ]]]
 # FUNCTION: .zi-exists-message [[[
 # Checks if plugin is loaded. Testable. Also outputs error message if plugin is not loaded.

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -175,6 +175,42 @@ ZI[EXTENDED_GLOB]=""
   ZI[PARAMETERS_POST__$uspl2]="${(j: :)${(qkv)params_post[@]}}"
   return 0
 } # ]]]
+# FUNCTION: .zi-diff-hooks-compute [[[
+# Computes ZI[ZSH_HOOKS__…] and ZI[ZSH_HOOKS_REMOVED__…] from the snapshots
+# gathered by .zi-diff-hooks().
+#
+# ZSH_HOOKS__ holds the entries the plugin added, which unload owns and may
+# remove. ZSH_HOOKS_REMOVED__ holds the entries that existed before the load
+# and were gone by the end of it, which unload reports but does not restore,
+# because a plugin removing a hook can be deliberate.
+#
+# Both are stored as quoted "array:entry" pairs.
+#
+# $1 - user/plugin
+.zi-diff-hooks-compute() {
+  builtin emulate -L zsh -o no_ksh_arrays -o extended_glob
+  local uspl2="$1"
+  # A light load takes no snapshot, so there is nothing to attribute.
+  [[ -z ${ZI[ZSH_HOOKS_AFTER__$uspl2]} && -z ${ZI[ZSH_HOOKS_BEFORE__$uspl2]} ]] && return 1
+  typeset -a before after added removed
+  before=( "${(z)ZI[ZSH_HOOKS_BEFORE__$uspl2]}" )
+  after=( "${(z)ZI[ZSH_HOOKS_AFTER__$uspl2]}" )
+  local pair
+  # An entry present afterwards but not before was registered during the load.
+  # Duplicate registrations collapse, because add-zsh-hook itself refuses to
+  # add an entry twice; the pair is either owned or it is not.
+  for pair in "${after[@]}"; do
+    [[ -z $pair ]] && continue
+    (( ${before[(I)$pair]} )) || added+=( "$pair" )
+  done
+  for pair in "${before[@]}"; do
+    [[ -z $pair ]] && continue
+    (( ${after[(I)$pair]} )) || removed+=( "$pair" )
+  done
+  ZI[ZSH_HOOKS__$uspl2]="${added[*]}"
+  ZI[ZSH_HOOKS_REMOVED__$uspl2]="${removed[*]}"
+  return 0
+} # ]]]
 # FUNCTION: .zi-any-to-uspl2 [[[
 # Converts given plugin-spec to format that's used in keys for hash tables.
 # So basically, creates string "user/plugin" (this format is called: uspl2).
@@ -241,6 +277,11 @@ ZI[EXTENDED_GLOB]=""
   ZI[PARAMETERS_POST__$REPLY]=""
   ZI[PARAMETERS_BEFORE__$REPLY]=""
   ZI[PARAMETERS_AFTER__$REPLY]=""
+  # Standard hook-array diffing
+  ZI[ZSH_HOOKS__$REPLY]=""
+  ZI[ZSH_HOOKS_REMOVED__$REPLY]=""
+  ZI[ZSH_HOOKS_BEFORE__$REPLY]=""
+  ZI[ZSH_HOOKS_AFTER__$REPLY]=""
 } # ]]]
 # FUNCTION: .zi-exists-message [[[
 # Checks if plugin is loaded. Testable. Also outputs error message if plugin is not loaded.
@@ -1181,12 +1222,42 @@ ZI[EXTENDED_GLOB]=""
     f="${(Q)f}"
     (( quiet )) || +zi-message "Deleting function $f"
     (( ${+functions[$f]} )) && unfunction -- "$f"
-    (( ${+precmd_functions} )) && precmd_functions=( ${precmd_functions[@]:#$f} )
-    (( ${+preexec_functions} )) && preexec_functions=( ${preexec_functions[@]:#$f} )
-    (( ${+chpwd_functions} )) && chpwd_functions=( ${chpwd_functions[@]:#$f} )
-    (( ${+periodic_functions} )) && periodic_functions=( ${periodic_functions[@]:#$f} )
-    (( ${+zshaddhistory_functions} )) && zshaddhistory_functions=( ${zshaddhistory_functions[@]:#$f} )
-    (( ${+zshexit_functions} )) && zshexit_functions=( ${zshexit_functions[@]:#$f} )
+  done
+
+  #
+  # 6a. Remove plugin-owned add-zsh-hook entries
+  #
+
+  # Ownership comes from the load-time snapshot, not from function deletion, so
+  # an entry the plugin registered for a function it did not define is still
+  # removed, and an entry another actor registered for a function the plugin
+  # did define is still preserved.
+  .zi-diff-hooks-compute "$uspl2"
+  typeset -a owned_hooks removed_hooks
+  owned_hooks=( "${(z)ZI[ZSH_HOOKS__$uspl2]}" )
+  local pair hook_array entry
+  for pair in "${owned_hooks[@]}"; do
+    [[ -z "$pair" ]] && continue
+    hook_array="${(Q)pair%%:*}"
+    entry="${(Q)pair#*:}"
+    [[ -z "$hook_array" || -z "$entry" ]] && continue
+    (( ${(P)+hook_array} )) || continue
+    # Only remove the entry if it is still the one recorded at load time.
+    (( ${${(@P)hook_array}[(I)$entry]} )) || continue
+    (( quiet )) || +zi-message "Removing hook {info}$entry{rst} from {var}\$$hook_array{rst}"
+    set -A "$hook_array" "${(@)${(@P)hook_array}:#$entry}"
+  done
+  # Entries the plugin removed during load are reported, never silently
+  # restored: a plugin removing a hook can be deliberate, and the user's
+  # original registration cannot be distinguished from a stale one here.
+  removed_hooks=( "${(z)ZI[ZSH_HOOKS_REMOVED__$uspl2]}" )
+  for pair in "${removed_hooks[@]}"; do
+    [[ -z "$pair" ]] && continue
+    hook_array="${(Q)pair%%:*}"
+    entry="${(Q)pair#*:}"
+    [[ -z "$hook_array" || -z "$entry" ]] && continue
+    (( ${(P)+hook_array} )) && (( ${${(@P)hook_array}[(I)$entry]} )) && continue
+    (( quiet )) || +zi-message "{warn}Note{rst}: the plugin removed {info}$entry{rst} from {var}\$$hook_array{rst}; not restoring it"
   done
 
   #
@@ -1246,9 +1317,10 @@ ZI[EXTENDED_GLOB]=""
       if [[ $v2 != '""' ]]; then
         # Don't unset readonly variables
         [[ ${(tP)k} == *-readonly(|-*) ]] && continue
-        # Don't unset arrays managed by add-zsh-hook,
-        # also ignore a few special parameters
-        # TODO: #108 remember and remove hooks
+        # Don't unset arrays managed by add-zsh-hook, also ignore a few
+        # special parameters. Individual plugin-owned entries are removed in
+        # step 6a from the load-time ownership record; the arrays themselves
+        # are shared and must survive.
         case "$k" in
           (chpwd_functions|precmd_functions|preexec_functions|periodic_functions|zshaddhistory_functions|zshexit_functions|zsh_directory_name_functions)
             continue

--- a/tests/hook-ownership.zsh
+++ b/tests/hook-ownership.zsh
@@ -232,11 +232,19 @@ add-zsh-hook -d precmd user_victim 2>/dev/null
 # 5. Repeated loads of the same plugin do not leave a stale hook entry behind
 #    after a single unload.
 #
-#    Scope: this asserts the hook-ownership contract only. The related defect
-#    where the function itself survives repeated loads belongs to the per-load
-#    identity work in #113, because Zi's function diff attributes a function to
-#    the first load that defined it. That is deliberately not asserted here.
+#    Start with every tracked array absent. Zi normally registers its scheduler
+#    in precmd_functions, which would make the first snapshot non-empty and
+#    conceal a bug that confuses "captured empty" with "not captured".
 #
+#    Scope: this asserts only the hook-ownership contract. Function ownership
+#    across repeated loads remains part of the broader per-load identity work
+#    coordinated in #113 and is deliberately not asserted here.
+#
+
+typeset hook_array
+for hook_array in "${ZI_ZSH_HOOKS_LIST[@]}"; do
+  unset -- "$hook_array"
+done
 
 make_plugin repeated '
 builtin autoload -Uz add-zsh-hook

--- a/tests/hook-ownership.zsh
+++ b/tests/hook-ownership.zsh
@@ -196,9 +196,10 @@ add-zsh-hook -d precmd user_after 2>/dev/null
 
 #
 # 4. A hook entry the plugin removed during load is recorded, so that unload
-#    can report it rather than silently losing the user's registration.
-#    Removal can be intentional, so restoration is not asserted here; the
-#    ownership record merely has to exist.
+#    reports it rather than silently losing the user's registration. Removal
+#    can be intentional, so restoration is not asserted; unload only has to
+#    surface it. Like every Zi diff, the record is computed at unload, so the
+#    contract is asserted through unload's own output.
 #
 
 user_victim() { : }
@@ -214,20 +215,27 @@ load_plugin remover || fail "load remover fixture"
 if in_hook precmd_functions user_victim; then
   fail "removal record: fixture did not remove the user entry, test is not exercising the case"
 else
-  if [[ -z ${ZI[ZSH_HOOKS_REMOVED__owner/remover]} ]]; then
-    fail "removal record: no record that the plugin removed \`user_victim' from \$precmd_functions"
+  # Unqualified unload, so the report is not suppressed by -q.
+  typeset remover_output
+  unsetopt warn_create_global
+  remover_output="$(.zi-unload owner remover 2>&1)"
+  if [[ $remover_output == *user_victim*precmd_functions* ]]; then
+    pass "unload reports hook entries the plugin removed during load"
   else
-    pass "unload records hook entries the plugin removed during load"
+    fail "removal record: unload did not report the removal of \`user_victim' from \$precmd_functions"
   fi
 fi
 
-unload_plugin remover
 add-zsh-hook -d precmd user_victim 2>/dev/null
 
 #
-# 5. Repeated loads of the same plugin do not leave a stale entry behind after
-#    a single unload. This is the hook-path form of the per-load identity
-#    defect tracked in #113.
+# 5. Repeated loads of the same plugin do not leave a stale hook entry behind
+#    after a single unload.
+#
+#    Scope: this asserts the hook-ownership contract only. The related defect
+#    where the function itself survives repeated loads belongs to the per-load
+#    identity work in #113, because Zi's function diff attributes a function to
+#    the first load that defined it. That is deliberately not asserted here.
 #
 
 make_plugin repeated '
@@ -240,13 +248,9 @@ load_plugin repeated || fail "load repeated fixture (first)"
 load_plugin repeated || fail "load repeated fixture (second)"
 unload_plugin repeated
 
-integer repeated_ok=1
-assert_absent precmd_functions repeated_hook "repeated load" || repeated_ok=0
-if (( ${+functions[repeated_hook]} )); then
-  fail "repeated load: \`repeated_hook' survived unload as a defined function"
-  repeated_ok=0
+if assert_absent precmd_functions repeated_hook "repeated load"; then
+  pass "a single unload clears hook entries left by repeated loads of one plugin"
 fi
-(( repeated_ok )) && pass "a single unload clears hook entries left by repeated loads of one plugin"
 
 if (( failures )); then
   builtin print -u2 -r -- "# $failures assertion(s) failed"

--- a/tests/hook-ownership.zsh
+++ b/tests/hook-ownership.zsh
@@ -1,0 +1,257 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Hook-ownership contract for plugin unload (z-shell/zi#108).
+#
+# Zi must record which standard add-zsh-hook entries a plugin registered, so
+# that unload removes exactly those and nothing else. Ownership is a property
+# of the registration, not of who defined the function: a plugin that
+# registers a function it did not define still owns that hook entry.
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-hook-ownership-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+integer failures=0
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  (( failures++ ))
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+# Membership test for a hook array named by $1.
+in_hook() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2"
+  local -a current=( "${(@P)array_name}" )
+  (( ${current[(I)$entry]} > 0 ))
+}
+
+assert_absent() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2" label="$3"
+  if in_hook "$array_name" "$entry"; then
+    fail "$label: \`$entry' still present in \$$array_name (${(j:,:)${(@P)array_name}})"
+    return 1
+  fi
+  return 0
+}
+
+assert_present() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2" label="$3"
+  if in_hook "$array_name" "$entry"; then
+    return 0
+  fi
+  fail "$label: \`$entry' missing from \$$array_name (${(j:,:)${(@P)array_name}})"
+  return 1
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" \
+  "$temp_root/tmp" || { builtin print -u2 "not ok - create isolated environment"; exit 1 }
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gx TMPDIR="$temp_root/tmp"
+typeset -gAH ZI OPTS ICE ZI_SICE
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || { builtin print -u2 "not ok - source Zi"; exit 1 }
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || { builtin print -u2 "not ok - source autoload library"; exit 1 }
+builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || { builtin print -u2 "not ok - source install library"; exit 1 }
+unsetopt warn_create_global
+OPTS[opt_-q,--quiet]=1
+
+builtin autoload -Uz add-zsh-hook
+
+# Write a plugin fixture into the isolated plugins directory.
+make_plugin() {
+  builtin emulate -L zsh
+  local name="$1" body="$2"
+  local dir="${ZI[PLUGINS_DIR]}/owner---$name"
+  command mkdir -p -- "$dir" || return 1
+  builtin print -r -- "$body" >| "$dir/$name.plugin.zsh" || return 1
+  REPLY="$dir"
+}
+
+load_plugin() {
+  builtin emulate -L zsh
+  ICE=()
+  .zi-load owner "$1" >/dev/null
+}
+
+unload_plugin() {
+  builtin emulate -L zsh
+  unsetopt warn_create_global
+  .zi-unload owner "$1" -q >/dev/null
+}
+
+#
+# 1. Every standard hook array is cleaned, including the one the unfunction
+#    step never covered.
+#
+
+make_plugin all-arrays '
+builtin autoload -Uz add-zsh-hook
+owned_chpwd() { : }
+owned_precmd() { : }
+owned_preexec() { : }
+owned_periodic() { : }
+owned_addhistory() { return 0 }
+owned_exit() { : }
+owned_dirname() { return 1 }
+add-zsh-hook chpwd owned_chpwd
+add-zsh-hook precmd owned_precmd
+add-zsh-hook preexec owned_preexec
+add-zsh-hook periodic owned_periodic
+add-zsh-hook zshaddhistory owned_addhistory
+add-zsh-hook zshexit owned_exit
+add-zsh-hook zsh_directory_name owned_dirname
+' || fail "create all-arrays fixture"
+
+load_plugin all-arrays || fail "load all-arrays fixture"
+unload_plugin all-arrays
+
+integer all_arrays_ok=1
+assert_absent chpwd_functions owned_chpwd "all hook arrays" || all_arrays_ok=0
+assert_absent precmd_functions owned_precmd "all hook arrays" || all_arrays_ok=0
+assert_absent preexec_functions owned_preexec "all hook arrays" || all_arrays_ok=0
+assert_absent periodic_functions owned_periodic "all hook arrays" || all_arrays_ok=0
+assert_absent zshaddhistory_functions owned_addhistory "all hook arrays" || all_arrays_ok=0
+assert_absent zshexit_functions owned_exit "all hook arrays" || all_arrays_ok=0
+assert_absent zsh_directory_name_functions owned_dirname "all hook arrays" || all_arrays_ok=0
+(( all_arrays_ok )) && pass "unload removes plugin-owned entries from all seven standard hook arrays"
+
+#
+# 2. A plugin owns a hook entry it registered even for a function it did not
+#    define. The function itself must survive, because the plugin did not
+#    create it.
+#
+
+preexisting_helper() { : }
+
+make_plugin borrower '
+builtin autoload -Uz add-zsh-hook
+add-zsh-hook precmd preexisting_helper
+' || fail "create borrower fixture"
+
+load_plugin borrower || fail "load borrower fixture"
+unload_plugin borrower
+
+integer borrower_ok=1
+assert_absent precmd_functions preexisting_helper "borrowed registration" || borrower_ok=0
+if (( ! ${+functions[preexisting_helper]} )); then
+  fail "borrowed registration: unload deleted a function the plugin did not define"
+  borrower_ok=0
+fi
+(( borrower_ok )) && pass "unload removes a registration for a function the plugin did not define"
+
+#
+# 3. Entries owned by another actor are preserved: those present before the
+#    load, and those added after it.
+#
+
+user_before() { : }
+add-zsh-hook precmd user_before
+
+make_plugin coexist '
+builtin autoload -Uz add-zsh-hook
+coexist_hook() { : }
+add-zsh-hook precmd coexist_hook
+' || fail "create coexist fixture"
+
+load_plugin coexist || fail "load coexist fixture"
+
+user_after() { : }
+add-zsh-hook precmd user_after
+
+unload_plugin coexist
+
+integer coexist_ok=1
+assert_present precmd_functions user_before "foreign ownership" || coexist_ok=0
+assert_present precmd_functions user_after "foreign ownership" || coexist_ok=0
+assert_absent precmd_functions coexist_hook "foreign ownership" || coexist_ok=0
+(( coexist_ok )) && pass "unload preserves hook entries owned by the user before and after the load"
+
+add-zsh-hook -d precmd user_before 2>/dev/null
+add-zsh-hook -d precmd user_after 2>/dev/null
+
+#
+# 4. A hook entry the plugin removed during load is recorded, so that unload
+#    can report it rather than silently losing the user's registration.
+#    Removal can be intentional, so restoration is not asserted here; the
+#    ownership record merely has to exist.
+#
+
+user_victim() { : }
+add-zsh-hook precmd user_victim
+
+make_plugin remover '
+builtin autoload -Uz add-zsh-hook
+add-zsh-hook -d precmd user_victim
+' || fail "create remover fixture"
+
+load_plugin remover || fail "load remover fixture"
+
+if in_hook precmd_functions user_victim; then
+  fail "removal record: fixture did not remove the user entry, test is not exercising the case"
+else
+  if [[ -z ${ZI[ZSH_HOOKS_REMOVED__owner/remover]} ]]; then
+    fail "removal record: no record that the plugin removed \`user_victim' from \$precmd_functions"
+  else
+    pass "unload records hook entries the plugin removed during load"
+  fi
+fi
+
+unload_plugin remover
+add-zsh-hook -d precmd user_victim 2>/dev/null
+
+#
+# 5. Repeated loads of the same plugin do not leave a stale entry behind after
+#    a single unload. This is the hook-path form of the per-load identity
+#    defect tracked in #113.
+#
+
+make_plugin repeated '
+builtin autoload -Uz add-zsh-hook
+repeated_hook() { : }
+add-zsh-hook precmd repeated_hook
+' || fail "create repeated fixture"
+
+load_plugin repeated || fail "load repeated fixture (first)"
+load_plugin repeated || fail "load repeated fixture (second)"
+unload_plugin repeated
+
+integer repeated_ok=1
+assert_absent precmd_functions repeated_hook "repeated load" || repeated_ok=0
+if (( ${+functions[repeated_hook]} )); then
+  fail "repeated load: \`repeated_hook' survived unload as a defined function"
+  repeated_ok=0
+fi
+(( repeated_ok )) && pass "a single unload clears hook entries left by repeated loads of one plugin"
+
+if (( failures )); then
+  builtin print -u2 -r -- "# $failures assertion(s) failed"
+  exit 1
+fi
+
+builtin print -r -- "# all hook-ownership assertions passed"
+exit 0

--- a/zi.zsh
+++ b/zi.zsh
@@ -981,7 +981,13 @@ builtin setopt no_aliases
     done
   done
   if [[ $2 = begin ]]; then
-    [[ -z ${ZI[ZSH_HOOKS_BEFORE__$1]} ]] && ZI[ZSH_HOOKS_BEFORE__$1]="${snapshot[*]}"
+    # Snapshot presence is tracked separately because an empty hook set is a
+    # valid baseline. Keep the first baseline across overwrite-loads so one
+    # unload still owns entries added by the first load.
+    if [[ -z ${ZI[ZSH_HOOKS_DIFFED__$1]} ]]; then
+      ZI[ZSH_HOOKS_BEFORE__$1]="${snapshot[*]}"
+      ZI[ZSH_HOOKS_DIFFED__$1]=1
+    fi
   else
     ZI[ZSH_HOOKS_AFTER__$1]="${snapshot[*]}"
   fi

--- a/zi.zsh
+++ b/zi.zsh
@@ -345,6 +345,20 @@ fi
   fi
 }
 
+# List of standard add-zsh-hook arrays whose entries are tracked per plugin.
+# Ownership is a property of the registration, not of who defined the function,
+# so these are diffed across a load rather than inferred from function deletion.
+typeset -gaH ZI_ZSH_HOOKS_LIST
+ZI_ZSH_HOOKS_LIST=(
+  chpwd_functions
+  precmd_functions
+  preexec_functions
+  periodic_functions
+  zshaddhistory_functions
+  zshexit_functions
+  zsh_directory_name_functions
+)
+
 # List of hooks.
 typeset -gAH ZI_ZLE_HOOKS_LIST
 ZI_ZLE_HOOKS_LIST=(
@@ -946,6 +960,32 @@ builtin setopt no_aliases
     ZI[PARAMETERS_AFTER__$1]+=" ${(j: :)${(qkv)parameters[@]}}"
   }
 } # ]]]
+# FUNCTION: .zi-diff-hooks. [[[
+# Implements detection of changes to the standard add-zsh-hook arrays.
+# Performs data gathering, computation is done in *-compute().
+#
+# Each snapshot records every tracked array as "array:entry" pairs, so a
+# registration is attributed to the plugin that made it regardless of which
+# actor defined the underlying function.
+#
+# $1 - user/plugin (i.e. uspl2 format)
+# $2 - command, can be "begin" or "end"
+.zi-diff-hooks() {
+  builtin emulate -L zsh -o no_ksh_arrays
+  local hook_array entry
+  typeset -a snapshot
+  for hook_array in "${ZI_ZSH_HOOKS_LIST[@]}"; do
+    (( ${(P)+hook_array} )) || continue
+    for entry in "${(@P)hook_array}"; do
+      snapshot+=( "${(q)hook_array}:${(q)entry}" )
+    done
+  done
+  if [[ $2 = begin ]]; then
+    [[ -z ${ZI[ZSH_HOOKS_BEFORE__$1]} ]] && ZI[ZSH_HOOKS_BEFORE__$1]="${snapshot[*]}"
+  else
+    ZI[ZSH_HOOKS_AFTER__$1]="${snapshot[*]}"
+  fi
+} # ]]]
 # FUNCTION: .zi-diff. [[[
 # Performs diff actions of all types
 .zi-diff() {
@@ -953,6 +993,7 @@ builtin setopt no_aliases
   .zi-diff-options "$1" "$2"
   .zi-diff-env "$1" "$2"
   .zi-diff-parameter "$1" "$2"
+  .zi-diff-hooks "$1" "$2"
 } # ]]]
 
 #


### PR DESCRIPTION
## Summary

Records which standard `add-zsh-hook` entries each plugin registers, and
removes exactly those on unload.

Cleanup previously happened as a side effect of deleting functions: the
unfunction step stripped each deleted function's name from six of the seven
hook arrays. That keyed ownership on which actor defined the function rather
than which actor registered the entry, with two consequences:

- a plugin that registered a function it did not define leaked its entry,
  because Zi never deleted that function and so never stripped its name;
- `zsh_directory_name_functions` was never cleaned at all, because the step
  omitted it, leaving a hook that dispatches to a just-deleted function.

## Approach

Ownership now comes from a snapshot diffed across the load, alongside the
existing function, option, environment, and parameter diffs:

- `.zi-diff-hooks` captures every tracked array as quoted `array:entry` pairs
  at the load's `begin` and `end` frames.
- An explicit snapshot marker distinguishes a captured empty hook set from
  `light` mode, which takes no snapshot. The first baseline is preserved across
  overwrite-loads.
- `.zi-diff-hooks-compute` splits the snapshots into entries the plugin added
  and entries it removed.
- Unload step 6a removes only recorded added entries that remain present, so
  pre-existing and distinct post-load registrations survive.

Entries the plugin removed during load are reported rather than restored. A
plugin removing a hook can be deliberate, and the original registration cannot
be distinguished from a stale one at unload time.

The hook arrays themselves stay exempt from the parameter-unset step. They are
shared, so only individual entries are ever removed.

## Verification

`tests/hook-ownership.zsh` is registered in `zsh-n.yml` as its own job and in
both push and pull-request path filters. Five assertions cover all seven arrays,
borrowed registrations, foreign ownership before and after the load, removal
reporting, and repeated loads from an empty hook baseline.

The test was committed failing first (`524c2a4`), then made to pass (`07a139a`).
Review found that Zi's scheduler made the repeated-load baseline non-empty and
masked an empty-snapshot ambiguity. Corrective commit `eb3a591` removes that
mask in the test and tracks snapshot presence explicitly.

Against unfixed code, four assertions fail while the foreign-ownership
preservation assertion passes, so the test discriminates rather than failing
uniformly.

The full local suite passes (11/11 under `zsh -f`). `zsh -f -n`, temporary
`zcompile -U -z`, and `git diff --check` pass on all changed Zsh files. No
public-contract surface is affected; every new identifier is internal.

## Scope note

Acceptance criterion 7 requires repeated loads not to leave a stale hook entry.
The hook half is fixed and asserted here. The related defect where the function
survives repeated loads remains owned by the broader per-load identity work in
#113, whose scope covers function, widget, and bindkey ownership.

`light` mode remains out of scope, as recorded on the issue: it takes no diff
and therefore cleans nothing by design.

Closes #108
