### PR TITLE
docs(branching): fix the promotion template ancestry precondition

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -16,11 +16,19 @@ Replace `BASE_SHA` and `HEAD_SHA` with the exact SHAs above. Immediately before
 merge, fetch again and confirm the pull request base and head still equal the
 recorded SHAs.
 
-- [ ] `git merge-base --is-ancestor <prior-main> <candidate-next>` succeeds.
+- [ ] `git diff --name-only <candidate-next>...<prior-main>` produces no output.
 - [ ] `git rev-parse '<candidate-next>^{tree}'` equals the recorded tree SHA.
 
-If `main` is not an ancestor of `next`, stop. Merge the stable-only hotfix or
-other commit forward into `next` through a reviewed pull request first.
+Do **not** test whether `<prior-main>` is an ancestor of `<candidate-next>`.
+That check cannot pass once any promotion has landed, because the promotion
+merge commit exists only on `main`. The empty three-dot diff is the real
+precondition: it confirms `main` holds no content the candidate lacks, and it
+still fails when a genuine stable-only commit is missing.
+
+If the diff is not empty, stop. Identify the omitted commit with
+`git log --oneline <candidate-next>..<prior-main>` and merge the stable-only
+hotfix or other commit forward into `next` through a reviewed pull request
+first.
 
 ## Required validation
 


### PR DESCRIPTION
## Summary

Fixes the promotion precondition in `.github/PULL_REQUEST_TEMPLATE/promotion.md`,
which required a check that cannot pass after any successful promotion.

Closes #461

## Problem

Line 19 of the promotion readiness record required:

```text
- [ ] `git merge-base --is-ancestor <prior-main> <candidate-next>` succeeds.
```

Promotion creates a merge commit on `main` that never reaches `next`, so `main`
stops being an ancestor of `next` as soon as a promotion lands. The template
then instructed the maintainer to stop and reconcile, on every promotion,
including healthy ones.

Three no-content reconciliation merges have already landed here as a result:
`9a4fa51`, `b0ebcc3`, and `73df7bf`. `git diff --name-only <merge>^1 <merge>`
returns zero files for each.

## Change

Replaces the checklist item with an empty three-dot content diff and corrects
the accompanying guidance to identify a genuinely omitted commit with
`git log --oneline <candidate-next>..<prior-main>`.

## Verification

| Scenario | old check | new check | Correct |
| -------- | --------- | --------- | ------- |
| Just promoted, healthy | fail | pass | pass |
| Work continued on `next`, healthy | fail | pass | pass |
| Unmerged hotfix on `main` | fail | **fail** | fail |
| Hotfix synchronized forward | pass | pass | pass |

The third row confirms a genuine stable-only commit is still caught, so this
removes a false negative without weakening the gate.

Against the live pending candidate:

```text
git merge-base --is-ancestor origin/main origin/next   ->  fails
git diff --name-only origin/next...origin/main         ->  empty
```

`trunk check` reports no issues on the changed file.

## Dependency

The canonical rule is corrected in z-shell/.github#574, which closes
z-shell/.github#573. This repository-local template must be fixed too, or the
impossible check is reimposed on the promotion pull request even after the
runbook is correct.

Both should land before the pending `next` to `main` promotion.
