### PR TITLE
chore(contract): record the complete message-output consumer set

### DIFF
--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_version": 1,
-  "evidence_reviewed": "2026-08-28",
+  "evidence_reviewed": "2026-08-30",
   "renames": [],
   "surfaces": [
     {
@@ -102,6 +102,24 @@
       "path": "docs/getting_started/02_overview.mdx",
       "surfaces": ["message-output"],
       "evidence": "https://github.com/z-shell/wiki/blob/958209c2998023b387688a9e738a692dfe032ef1/docs/getting_started/02_overview.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/guides/syntax/01_standard.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/3c56c281fa0932183c1347f2f8b6acae77fc6c2e/docs/guides/syntax/01_standard.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "community/05_gallery/collection/03_programs.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/5f3450cb297410c2f03fe94cc2394c133ea8aa2e/community/05_gallery/collection/03_programs.mdx"
+    },
+    {
+      "repository": "z-shell/src",
+      "path": "public/zsh/snippets/welcome.zsh",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/src/blob/a715c1d01ff279cfdde9561a2a7f96e489f881e8/public/zsh/snippets/welcome.zsh"
     },
     {
       "repository": "z-shell/wiki",


### PR DESCRIPTION
## Summary

Records the three missing `message-output` consumers in
`contracts/public-contract-v1.json` and refreshes `evidence_reviewed`.

Closes #463

## Problem

The manifest listed two consumers of the `message-output` surface. A direct
search of the organization finds five consumer files across two repositories.

The registry exists so a breaking change to a public surface can be scoped
cheaply and completely. `e50d19e` (`feat!: rebuild message output with safe auto
formatting`, #457) changes the emitted byte stream of every message and is part
of the pending `next` to `main` promotion. Scoping it against the registry alone
would have covered two of five consumer files.

## Change

| Repository | Path | Evidence commit |
| ---------- | ---- | --------------- |
| `z-shell/wiki` | `docs/guides/syntax/01_standard.mdx` | `3c56c281` |
| `z-shell/wiki` | `community/05_gallery/collection/03_programs.mdx` | `5f3450cb` |
| `z-shell/src` | `public/zsh/snippets/welcome.zsh` | `a715c1d0` |

`z-shell/src` was already listed for `installer-git-output` only. Its welcome
snippet is a separate dependency on `message-output`.

`z-shell/z-a-meta-plugins/tests/prezto-meta-plugin.zsh` defines a local stub
`+zi-message() { :; }`. That is a test double, not a consumer, and is
deliberately excluded.

## Verification

Each path was fetched from the GitHub API at its proposed pin and confirmed to
contain the usage, rather than relying on a local checkout:

```text
docs/guides/syntax/01_standard.mdx @ 3c56c281
    atinit'+zi-message "{bapo}Cloned!"'
    atclone'+zi-message "{quos}Boom!"'
    atload'+zi-message "{apo}Loaded!"'

community/05_gallery/collection/03_programs.mdx @ 5f3450cb
    atclone'+zi-message "{auto}Installing brew …"'

public/zsh/snippets/welcome.zsh @ a715c1d0
    +zi-message "{auto}\`Welcome to Zi :)\`"
    +zi-message "{hi}I am the snippet\!"
```

`zsh scripts/public-contract-evidence.zsh` reports all three new pins `current`.
`zsh tests/public-contract-impact.zsh` passes, including
`consumer evidence must be complete and SHA-pinned` and
`evidence URLs must match their declared repository and path`.
`trunk check` reports no issues.

## Out of scope

The evidence detector reports five pre-existing stale pins unrelated to this
surface:

```text
z-shell/docs/code/zsdoc/asciidoc/zi.zsh.adoc
z-shell/src/public/sh/install.sh
z-shell/src/public/zsh/init.zsh
z-shell/zd/tests/helpers.zsh
z-shell/z-a-meta-plugins/z-a-meta-plugins.plugin.zsh
```

A stale pin is a review signal, not automatically a contract break. Re-reading
each consumer and bumping its pin is separate work.
