### PR TITLE
fix(scheduler): stop idle timer loop

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -16,6 +16,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
+      - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -31,6 +32,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
+      - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -136,6 +138,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test self-update reload
         run: zsh -f tests/self-update-reload.zsh
+
+  scheduler-idle:
+    name: Scheduler idle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test scheduler idle behavior
+        run: zsh -f tests/scheduler-idle.zsh
 
   archive-extraction:
     name: Archive extraction

--- a/tests/scheduler-idle.zsh
+++ b/tests/scheduler-idle.zsh
@@ -1,0 +1,82 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root=${0:A:h:h}
+typeset temp_root
+temp_root=$(command mktemp -d "${TMPDIR:-/tmp}/zi-scheduler-idle.XXXXXXXX") || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+typeset -gx HOME=$temp_root/home
+typeset -gx ZDOTDIR=$temp_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$temp_root/cache
+typeset -gx XDG_CONFIG_HOME=$temp_root/config
+typeset -gx XDG_DATA_HOME=$temp_root/data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -ru2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+in_hook() {
+  builtin emulate -L zsh
+  local array_name=$1 entry=$2
+  local -a current=( "${(@P)array_name}" )
+  (( ${current[(I)$entry]} > 0 ))
+}
+
+clear_events() {
+  builtin emulate -L zsh
+  while (( ${#zsh_scheduled_events} )); do
+    sched -1 || return 1
+  done
+}
+
+typeset -gAH ZI
+ZI[BIN_DIR]=$project_root
+builtin source "$project_root/zi.zsh" >/dev/null || fail 'source Zi'
+zmodload zsh/sched || fail 'load scheduler module'
+clear_events || fail 'clear initial events'
+
+# The test exercises scheduler state, not ZLE descriptor integration.
+zle() { builtin emulate -L zsh; return 0; }
+
+in_hook precmd_functions @zi-scheduler || fail 'source registers the dormant precmd hook'
+@zi-scheduler || fail 'idle precmd check returns success'
+(( ${#zsh_scheduled_events} == 0 )) || fail 'idle precmd check armed a timer'
+[[ -n ${ZI[START_TIME]} ]] || fail 'idle precmd check did not initialize timing'
+in_hook precmd_functions @zi-scheduler || fail 'idle precmd hook was removed'
+in_hook chpwd_functions @zi-scheduler && fail 'idle scheduler registered a chpwd hook'
+pass 'idle scheduler stays dormant'
+
+ZI_TASKS+=( "$(( EPOCHSECONDS + 60 ))+0+1 p 1 _ owner/repo" )
+@zi-scheduler || fail 'pending task activates scheduler'
+(( ${#zsh_scheduled_events} == 1 )) || fail 'pending task did not arm one timer'
+in_hook chpwd_functions @zi-scheduler || fail 'active scheduler did not register chpwd hook'
+in_hook precmd_functions @zi-scheduler && fail 'active scheduler kept the precmd hook'
+pass 'pending work activates scheduler'
+
+clear_events || fail 'clear active event'
+ZI_TASKS=( '<no-data>' )
+@zi-scheduler following || fail 'drained scheduler returns success'
+(( ${#zsh_scheduled_events} == 0 )) || fail 'drained scheduler rearmed a timer'
+in_hook precmd_functions @zi-scheduler || fail 'drained scheduler did not restore precmd hook'
+in_hook chpwd_functions @zi-scheduler && fail 'drained scheduler kept chpwd hook'
+pass 'drained scheduler returns to dormant state'
+
+ZI_TASKS+=( "$(( EPOCHSECONDS + 60 ))+0+1 p 1 _ owner/repo" )
+@zi-scheduler || fail 'later task reactivates scheduler'
+(( ${#zsh_scheduled_events} == 1 )) || fail 'later task did not rearm scheduler'
+pass 'later work reactivates scheduler'
+
+clear_events || fail 'clear final event'

--- a/zi.zsh
+++ b/zi.zsh
@@ -2489,10 +2489,18 @@ return retval
 @zi-scheduler() {
   integer ___ret="${${ZI[lro-data]%:*}##*:}"
   # lro stands for lastarg-retval-option.
-  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
   [[ -n $1 && $1 != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
   [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
   ZI[START_TIME]="${ZI[START_TIME]:-$EPOCHREALTIME}"
+  if (( ${#ZI_TASKS} <= 1 && ${#ZI_RUN} == 0 )); then
+    # Keep the prompt hook dormant so a later Zi command can reactivate the scheduler.
+    if [[ -n $1 ]]; then
+      add-zsh-hook -d -- chpwd @zi-scheduler
+      add-zsh-hook -- precmd @zi-scheduler
+    fi
+    [[ ${ZI[lro-data]##*:} = on ]] && return 0 || return ___ret
+  fi
+  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
 
   integer ___t=EPOCHSECONDS ___i correct
   local -a match mbegin mend reply


### PR DESCRIPTION
## Description

Stop `@zi-scheduler` from rearming its one-second timer after all delayed work drains. The scheduler restores its dormant `precmd` hook so a later Zi command can reactivate it.

Add focused lifecycle coverage and run it in the Zsh workflow.

## Related issues

Closes #465

## Type of change

- [x] `fix` - bug fix (non-breaking)
- [x] `test` - test addition or correction
- [x] `ci` - CI/workflow change

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] This is not a `next` to `main` promotion
- [x] Commit messages follow Conventional Commits format
- [x] No `Co-authored-by` trailer is present
- [x] I have read the contribution guidelines
- [x] Existing tests pass (`zsh -n zi.zsh` / Trunk checks)
- [x] Documentation is not needed for this internal scheduler correction

## Verification

- `zsh -f tests/scheduler-idle.zsh`
- all existing repository-owned Zsh tests
- 39-file `zsh -f -n` and `zcompile -U -z` sweep
- interactive idle smoke: zero scheduled events after more than five seconds
- `actionlint .github/workflows/zsh-n.yml`
- YAML parsing
- `trunk check --no-fix --no-progress .github/workflows/zsh-n.yml zi.zsh tests/scheduler-idle.zsh`
- `git diff --check`

The existing `lib/zsh/rpm2cpio.zsh:54` syntax warning is unchanged from `origin/next`.

## Migration plan

Not required. Public Contract Impact passed with no destructive change.
