### PR TITLE
chore: promote next to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -16,11 +16,19 @@ Replace `BASE_SHA` and `HEAD_SHA` with the exact SHAs above. Immediately before
 merge, fetch again and confirm the pull request base and head still equal the
 recorded SHAs.
 
-- [ ] `git merge-base --is-ancestor <prior-main> <candidate-next>` succeeds.
+- [ ] `git diff --name-only <candidate-next>...<prior-main>` produces no output.
 - [ ] `git rev-parse '<candidate-next>^{tree}'` equals the recorded tree SHA.
 
-If `main` is not an ancestor of `next`, stop. Merge the stable-only hotfix or
-other commit forward into `next` through a reviewed pull request first.
+Do **not** test whether `<prior-main>` is an ancestor of `<candidate-next>`.
+That check cannot pass once any promotion has landed, because the promotion
+merge commit exists only on `main`. The empty three-dot diff is the real
+precondition: it confirms `main` holds no content the candidate lacks, and it
+still fails when a genuine stable-only commit is missing.
+
+If the diff is not empty, stop. Identify the omitted commit with
+`git log --oneline <candidate-next>..<prior-main>` and merge the stable-only
+hotfix or other commit forward into `next` through a reviewed pull request
+first.
 
 ## Required validation
 

--- a/.github/workflows/public-contract-evidence.yml
+++ b/.github/workflows/public-contract-evidence.yml
@@ -1,0 +1,40 @@
+---
+name: Public Contract Evidence
+
+# Consumer evidence pins in contracts/public-contract-v1.json cite a fixed
+# commit. Nothing detects when the consumer file moves on, so a pin can
+# silently describe a version that no longer exists. This scheduled report
+# surfaces those pins for maintainer review; it never edits the manifest.
+
+on:
+  schedule:
+    # Weekly, Monday, offset off the hour to avoid the scheduler peak.
+    - cron: "23 7 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-contract-evidence
+  cancel-in-progress: false
+
+jobs:
+  evidence:
+    name: Consumer evidence freshness
+    if: github.repository == 'z-shell/zi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -yq jq zsh
+
+      - name: Report stale consumer evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zsh scripts/public-contract-evidence.zsh

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -13,6 +13,8 @@ on:
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-standard-callbacks.zsh"
+      - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -24,6 +26,8 @@ on:
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-standard-callbacks.zsh"
+      - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -106,6 +110,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test parallel update
         run: zsh -f tests/parallel-update.zsh
+
+  plugin-standard-callbacks:
+    name: Plugin Standard Callbacks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test plugin standard callbacks
+        run: zsh -f tests/plugin-standard-callbacks.zsh
 
   self-update-reload:
     name: Self-update reload

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -11,6 +11,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
@@ -24,6 +25,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
@@ -154,6 +156,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
+
+  message-formatting:
+    name: Message formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test message formatting
+        run: zsh -f tests/message-formatting.zsh
 
   snippet-directory-mirror:
     name: Snippet directory mirror

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -16,6 +16,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
+      - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -31,6 +32,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-standard-callbacks.zsh"
+      - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
@@ -136,6 +138,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test self-update reload
         run: zsh -f tests/self-update-reload.zsh
+
+  scheduler-idle:
+    name: Scheduler idle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test scheduler idle behavior
+        run: zsh -f tests/scheduler-idle.zsh
 
   archive-extraction:
     name: Archive extraction

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -11,6 +11,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/hook-ownership.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -25,6 +26,7 @@ on:
       - "lib/**"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
+      - "tests/hook-ownership.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -156,6 +158,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test completion refresh
         run: zsh tests/completion-refresh.zsh
+
+  hook-ownership:
+    name: Hook ownership
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test hook ownership
+        run: zsh -f tests/hook-ownership.zsh
 
   message-formatting:
     name: Message formatting

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -12,6 +12,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/parallel-update.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -22,6 +23,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/path-resolution.zsh"
+      - "tests/parallel-update.zsh"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
       - "tests/version-reporting.zsh"
@@ -93,6 +95,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test path resolution
         run: zsh -f tests/path-resolution.zsh
+
+  parallel-update:
+    name: Parallel Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test parallel update
+        run: zsh -f tests/parallel-update.zsh
 
   self-update-reload:
     name: Self-update reload

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,6 +7,14 @@ plugins:
       ref: v1.11.0
       uri: https://github.com/trunk-io/plugins
 lint:
+  definitions:
+    # This repository is consumed as a submodule, so `.git` is a file whose
+    # gitdir is relative to the superproject. Trunk's sandbox copy breaks that
+    # relative path, so anchor the command at the real workspace.
+    - name: git-diff-check
+      commands:
+        - name: lint
+          run: git -C "${workspace}" diff --check ${target}
   enabled:
     - oxipng@9.1.5
     - trufflehog@3.90.13

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_version": 1,
-  "evidence_reviewed": "2026-08-28",
+  "evidence_reviewed": "2026-08-30",
   "renames": [],
   "surfaces": [
     {
@@ -102,6 +102,24 @@
       "path": "docs/getting_started/02_overview.mdx",
       "surfaces": ["message-output"],
       "evidence": "https://github.com/z-shell/wiki/blob/958209c2998023b387688a9e738a692dfe032ef1/docs/getting_started/02_overview.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/guides/syntax/01_standard.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/3c56c281fa0932183c1347f2f8b6acae77fc6c2e/docs/guides/syntax/01_standard.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "community/05_gallery/collection/03_programs.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/5f3450cb297410c2f03fe94cc2394c133ea8aa2e/community/05_gallery/collection/03_programs.mdx"
+    },
+    {
+      "repository": "z-shell/src",
+      "path": "public/zsh/snippets/welcome.zsh",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/src/blob/a715c1d01ff279cfdde9561a2a7f96e489f881e8/public/zsh/snippets/welcome.zsh"
     },
     {
       "repository": "z-shell/wiki",

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract_version": 1,
-  "evidence_reviewed": "2026-08-24",
+  "evidence_reviewed": "2026-08-28",
   "renames": [],
   "surfaces": [
     {
@@ -127,13 +127,13 @@
       "repository": "z-shell/src",
       "path": "public/sh/install.sh",
       "surfaces": ["installer-git-output"],
-      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/sh/install.sh"
+      "evidence": "https://github.com/z-shell/src/blob/5ac79863d55baf056796e5e3afce5970506b8871/public/sh/install.sh"
     },
     {
       "repository": "z-shell/src",
       "path": "public/zsh/init.zsh",
       "surfaces": ["installer-git-output"],
-      "evidence": "https://github.com/z-shell/src/blob/5e301f2bb9d6e70c5aebb30b83217ac07b794025/public/zsh/init.zsh"
+      "evidence": "https://github.com/z-shell/src/blob/5ac79863d55baf056796e5e3afce5970506b8871/public/zsh/init.zsh"
     },
     {
       "repository": "z-shell/zd",

--- a/contracts/public-contract-v1.json
+++ b/contracts/public-contract-v1.json
@@ -35,6 +35,22 @@
       "description": "Hook registration API positional signature"
     },
     {
+      "id": "message-output",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "+zi-message",
+      "declaration_marker": "# FUNCTION: +zi-message. [[[",
+      "description": "Byte-preserving semantic message renderer and emitter"
+    },
+    {
+      "id": "message-progress",
+      "kind": "function",
+      "file": "zi.zsh",
+      "symbol": "+zi-progress",
+      "declaration_marker": "# FUNCTION: +zi-progress. [[[",
+      "description": "Carriage-return progress emitter sharing the message renderer"
+    },
+    {
       "id": "compatibility-functions",
       "kind": "function-region",
       "file": "zi.zsh",
@@ -75,6 +91,18 @@
     }
   ],
   "consumers": [
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/guides/04_messages.mdx",
+      "surfaces": ["message-output", "message-progress"],
+      "evidence": "https://github.com/z-shell/wiki/blob/32a2d7c33f4575df0876de600d8718d7446b4b4c/docs/guides/04_messages.mdx"
+    },
+    {
+      "repository": "z-shell/wiki",
+      "path": "docs/getting_started/02_overview.mdx",
+      "surfaces": ["message-output"],
+      "evidence": "https://github.com/z-shell/wiki/blob/958209c2998023b387688a9e738a692dfe032ef1/docs/getting_started/02_overview.mdx"
+    },
     {
       "repository": "z-shell/wiki",
       "path": "ecosystem/annexes/0_overview.mdx",

--- a/lib/zsh/additional.zsh
+++ b/lib/zsh/additional.zsh
@@ -22,7 +22,7 @@
   local ___data="$(<$1)"
 
   () {
-    builtin emulate -LR zsh -o extendedglob -o interactivecomments ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin emulate -LR zsh -o extended_glob -o interactive_comments ${=${options[xtrace]:#off}:+-o xtrace}
     local ___subst ___tabspc=$'\t'
     for ___subst ( "${___substs[@]}" ) {
       ___ab=( "${(@)${(@)${(@s:->:)___subst}##[[:space:]]##}%%[[:space:]]##}" )
@@ -43,7 +43,7 @@
 # $3 - id - URL or plugin ID or alias name (from id-as'')
 .zi-service() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   local ___tpe="$1" ___mode="$2" ___id="$3" ___fle="${ZI[SERVICES_DIR]}/${ICE[service]}.lock" ___fd ___cmd ___tmp ___lckd ___strd=0
   { builtin print -n >! "$___fle"; } 2>/dev/null 1>&2
   [[ ! -e ${___fle:r}.fifo ]] && command mkfifo "${___fle:r}.fifo" 2>/dev/null 1>&2

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -821,7 +821,7 @@ ZI[EXTENDED_GLOB]=""
 } # ]]]
 # FUNCTION: .zi-unload [[[
 # 0. Call the Zsh Plugin's Standard *_plugin_unload function
-# 0. Call the code provided by the Zsh Plugin's Standard @zsh-plugin-run-at-update
+# 0. Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload
 # 1. Delete bindkeys (...)
 # 2. Delete zstyles
 # 3. Restore options
@@ -840,6 +840,7 @@ ZI[EXTENDED_GLOB]=""
   .zi-any-to-user-plugin "$1" "$2"
   local uspl2="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]}" user="${reply[-2]}" plugin="${reply[-1]}" quiet="${${3:+1}:-0}"
   local k
+  integer callback_rc=0
   .zi-any-colorify-as-uspl2 "$uspl2"
   (( quiet )) || builtin print -r -- "${ZI[col-bar]}---${ZI[col-rst]} Unloading plugin: $REPLY ${ZI[col-bar]}---${ZI[col-rst]}"
   local ___dir
@@ -864,7 +865,7 @@ ZI[EXTENDED_GLOB]=""
   (( ${+functions[${plugin}_plugin_unload]} )) && ${plugin}_plugin_unload
 
   #
-  # Call the code provided by the Zsh Plugin's Standard @zsh-plugin-run-at-update
+  # Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload
   #
 
   local -a tmp
@@ -873,10 +874,8 @@ ZI[EXTENDED_GLOB]=""
   (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )) && sice=( "${(Q)tmp[@]}" ) || sice=()
   if [[ -n ${sice[ps-on-unload]} ]]; then
     (( quiet )) || builtin print -r "Running plugin's provided unload code: ${ZI[col-info]}${sice[ps-on-unload][1,50]}${sice[ps-on-unload][51]:+…}${ZI[col-rst]}"
-    local ___oldcd="$PWD"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___dir"; }
-    eval "${sice[ps-on-unload]}"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
+    .zi-run-plugin-standard-unload-callback "${sice[ps-on-unload]}" "$___dir" "$@"
+    callback_rc=$?
   fi
 
   #
@@ -1295,6 +1294,7 @@ ZI[EXTENDED_GLOB]=""
     .zi-clear-report-for "$user" "$plugin"
     (( quiet )) || +zi-message "Plugin's report saved to {var}\$LASTREPORT{rst}"
   fi
+  return "$callback_rc"
 } # ]]]
 # FUNCTION: .zi-show-report [[[
 # Displays report of the plugin given.

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -175,6 +175,43 @@ ZI[EXTENDED_GLOB]=""
   ZI[PARAMETERS_POST__$uspl2]="${(j: :)${(qkv)params_post[@]}}"
   return 0
 } # ]]]
+# FUNCTION: .zi-diff-hooks-compute [[[
+# Computes ZI[ZSH_HOOKS__…] and ZI[ZSH_HOOKS_REMOVED__…] from the snapshots
+# gathered by .zi-diff-hooks().
+#
+# ZSH_HOOKS__ holds the entries the plugin added, which unload owns and may
+# remove. ZSH_HOOKS_REMOVED__ holds the entries that existed before the load
+# and were gone by the end of it, which unload reports but does not restore,
+# because a plugin removing a hook can be deliberate.
+#
+# Both are stored as quoted "array:entry" pairs.
+#
+# $1 - user/plugin
+.zi-diff-hooks-compute() {
+  builtin emulate -L zsh -o no_ksh_arrays -o extended_glob
+  local uspl2="$1"
+  # A light load takes no snapshot. Test the explicit marker rather than the
+  # serialized values because a normal load can start and end with no hooks.
+  [[ ${ZI[ZSH_HOOKS_DIFFED__$uspl2]} = 1 ]] || return 1
+  typeset -a before after added removed
+  before=( "${(z)ZI[ZSH_HOOKS_BEFORE__$uspl2]}" )
+  after=( "${(z)ZI[ZSH_HOOKS_AFTER__$uspl2]}" )
+  local pair
+  # An entry present afterwards but not before was registered during the load.
+  # Duplicate registrations collapse, because add-zsh-hook itself refuses to
+  # add an entry twice; the pair is either owned or it is not.
+  for pair in "${after[@]}"; do
+    [[ -z $pair ]] && continue
+    (( ${before[(I)$pair]} )) || added+=( "$pair" )
+  done
+  for pair in "${before[@]}"; do
+    [[ -z $pair ]] && continue
+    (( ${after[(I)$pair]} )) || removed+=( "$pair" )
+  done
+  ZI[ZSH_HOOKS__$uspl2]="${added[*]}"
+  ZI[ZSH_HOOKS_REMOVED__$uspl2]="${removed[*]}"
+  return 0
+} # ]]]
 # FUNCTION: .zi-any-to-uspl2 [[[
 # Converts given plugin-spec to format that's used in keys for hash tables.
 # So basically, creates string "user/plugin" (this format is called: uspl2).
@@ -241,6 +278,12 @@ ZI[EXTENDED_GLOB]=""
   ZI[PARAMETERS_POST__$REPLY]=""
   ZI[PARAMETERS_BEFORE__$REPLY]=""
   ZI[PARAMETERS_AFTER__$REPLY]=""
+  # Standard hook-array diffing
+  ZI[ZSH_HOOKS__$REPLY]=""
+  ZI[ZSH_HOOKS_REMOVED__$REPLY]=""
+  ZI[ZSH_HOOKS_BEFORE__$REPLY]=""
+  ZI[ZSH_HOOKS_AFTER__$REPLY]=""
+  ZI[ZSH_HOOKS_DIFFED__$REPLY]=""
 } # ]]]
 # FUNCTION: .zi-exists-message [[[
 # Checks if plugin is loaded. Testable. Also outputs error message if plugin is not loaded.
@@ -1181,12 +1224,42 @@ ZI[EXTENDED_GLOB]=""
     f="${(Q)f}"
     (( quiet )) || +zi-message "Deleting function $f"
     (( ${+functions[$f]} )) && unfunction -- "$f"
-    (( ${+precmd_functions} )) && precmd_functions=( ${precmd_functions[@]:#$f} )
-    (( ${+preexec_functions} )) && preexec_functions=( ${preexec_functions[@]:#$f} )
-    (( ${+chpwd_functions} )) && chpwd_functions=( ${chpwd_functions[@]:#$f} )
-    (( ${+periodic_functions} )) && periodic_functions=( ${periodic_functions[@]:#$f} )
-    (( ${+zshaddhistory_functions} )) && zshaddhistory_functions=( ${zshaddhistory_functions[@]:#$f} )
-    (( ${+zshexit_functions} )) && zshexit_functions=( ${zshexit_functions[@]:#$f} )
+  done
+
+  #
+  # 6a. Remove plugin-owned add-zsh-hook entries
+  #
+
+  # Ownership comes from the load-time snapshot, not from function deletion, so
+  # an entry the plugin registered for a function it did not define is still
+  # removed, and an entry another actor registered for a function the plugin
+  # did define is still preserved.
+  .zi-diff-hooks-compute "$uspl2"
+  typeset -a owned_hooks removed_hooks
+  owned_hooks=( "${(z)ZI[ZSH_HOOKS__$uspl2]}" )
+  local pair hook_array entry
+  for pair in "${owned_hooks[@]}"; do
+    [[ -z "$pair" ]] && continue
+    hook_array="${(Q)pair%%:*}"
+    entry="${(Q)pair#*:}"
+    [[ -z "$hook_array" || -z "$entry" ]] && continue
+    (( ${(P)+hook_array} )) || continue
+    # Only remove the entry if it is still the one recorded at load time.
+    (( ${${(@P)hook_array}[(I)$entry]} )) || continue
+    (( quiet )) || +zi-message "Removing hook {info}$entry{rst} from {var}\$$hook_array{rst}"
+    set -A "$hook_array" "${(@)${(@P)hook_array}:#$entry}"
+  done
+  # Entries the plugin removed during load are reported, never silently
+  # restored: a plugin removing a hook can be deliberate, and the user's
+  # original registration cannot be distinguished from a stale one here.
+  removed_hooks=( "${(z)ZI[ZSH_HOOKS_REMOVED__$uspl2]}" )
+  for pair in "${removed_hooks[@]}"; do
+    [[ -z "$pair" ]] && continue
+    hook_array="${(Q)pair%%:*}"
+    entry="${(Q)pair#*:}"
+    [[ -z "$hook_array" || -z "$entry" ]] && continue
+    (( ${(P)+hook_array} )) && (( ${${(@P)hook_array}[(I)$entry]} )) && continue
+    (( quiet )) || +zi-message "{warn}Note{rst}: the plugin removed {info}$entry{rst} from {var}\$$hook_array{rst}; not restoring it"
   done
 
   #
@@ -1246,9 +1319,10 @@ ZI[EXTENDED_GLOB]=""
       if [[ $v2 != '""' ]]; then
         # Don't unset readonly variables
         [[ ${(tP)k} == *-readonly(|-*) ]] && continue
-        # Don't unset arrays managed by add-zsh-hook,
-        # also ignore a few special parameters
-        # TODO: #108 remember and remove hooks
+        # Don't unset arrays managed by add-zsh-hook, also ignore a few
+        # special parameters. Individual plugin-owned entries are removed in
+        # step 6a from the load-time ownership record; the arrays themselves
+        # are shared and must survive.
         case "$k" in
           (chpwd_functions|precmd_functions|preexec_functions|periodic_functions|zshaddhistory_functions|zshexit_functions|zsh_directory_name_functions)
             continue

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1846,91 +1846,113 @@ ZI[EXTENDED_GLOB]=""
 # FUNCTION: .zi-update-in-parallel [[[
 .zi-update-all-parallel() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops nomonitor nonotify
-  local id_as repo snip uspl user plugin PUDIR="$(mktemp -d)"
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops no_monitor no_notify
+  local id_as repo snip uspl user plugin pid PUDIR
+  PUDIR="$(command mktemp -d "${TMPDIR:-/tmp}/zi-update.XXXXXXXX")" || return 1
+  local MATCH
+  integer MBEGIN MEND
   local -A PUAssocArray map
   map=( / --  "=" -EQ-  "?" -QM-  "&" -AMP-  : - )
   local -a files
-  integer main_counter counter PUPDATE=1
-  files=( ${ZI[SNIPPETS_DIR]}/**/(._zi|._zinit|._zplugin)/mode(ND) )
-  main_counter=${#files}
-  if (( OPTS[opt_-s,--snippets] || !OPTS[opt_-l,--plugins] )) {
-    for snip ( "${files[@]}" ) {
-      main_counter=main_counter-1
-      # The continue may cause the tail of processes to
-      # fall-through to the following plugins-specific `wait'
-      # Should happen only in a very special conditions
-      # TODO #114 handle this
-      [[ ! -f ${snip:h}/url ]] && continue
-      [[ -f ${snip:h}/id-as ]] && id_as="$(<${snip:h}/id-as)" || id_as=
-      counter+=1
-      local ef_id="${id_as:-$(<${snip:h}/url)}"
-      local PUFILEMAIN=${${ef_id#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
-      local PUFILE=$PUDIR/${counter}_$PUFILEMAIN.out
-      .zi-update-or-status-snippet "$st" "$ef_id" &>! $PUFILE &
-      PUAssocArray[$!]=$PUFILE
-      .zi-wait-for-update-jobs snippets
+  integer counter=0 PUPDATE=1 retval=0
+  builtin trap 'retval=130; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 130' INT
+  builtin trap 'retval=129; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 129' HUP
+  builtin trap 'retval=143; for pid in ${(k)PUAssocArray}; do builtin kill -TERM "$pid" 2>/dev/null; done; return 143' TERM
+  {
+    files=( ${ZI[SNIPPETS_DIR]}/**/(._zi|._zinit|._zplugin)/mode(ND) )
+    if (( OPTS[opt_-s,--snippets] || !OPTS[opt_-l,--plugins] )) {
+      for snip ( "${files[@]}" ) {
+        [[ ! -f ${snip:h}/url ]] && continue
+        [[ -f ${snip:h}/id-as ]] && id_as="$(<${snip:h}/id-as)" || id_as=
+        (( ++counter ))
+        local ef_id="${id_as:-$(<${snip:h}/url)}"
+        local PUFILEMAIN=${${ef_id#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
+        local PUFILE=$PUDIR/${(l:8::0:)counter}_$PUFILEMAIN.out
+        .zi-update-or-status-snippet "$st" "$ef_id" &>! "$PUFILE" &
+        PUAssocArray[$!]=$PUFILE
+        .zi-wait-for-update-jobs snippets
+      }
+      .zi-wait-for-update-jobs snippets flush
     }
-  }
 
-  counter=0
-  PUAssocArray=()
-  if (( OPTS[opt_-l,--plugins] || !OPTS[opt_-s,--snippets] )) {
-    local -a files2
-    files=( ${ZI[PLUGINS_DIR]}/*(ND/) )
-    # Pre-process plugins
-    for repo ( $files ) {
-      uspl=${repo:t}
-      # Two special cases
-      [[ $uspl = custom || $uspl = _local---zi ]] && continue
-      # Check if repository has a remote set
-      if [[ -f $repo/.git/config ]] {
-        local -a config
-        config=( ${(f)"$(<$repo/.git/config)"} )
-        if [[ ${#${(M)config[@]:#\[remote[[:blank:]]*\]}} -eq 0 ]] {
+    counter=0
+    PUAssocArray=()
+    if (( OPTS[opt_-l,--plugins] || !OPTS[opt_-s,--snippets] )) {
+      local -a files2
+      files=( ${ZI[PLUGINS_DIR]}/*(ND/) )
+      # Pre-process plugins
+      for repo ( $files ) {
+        uspl=${repo:t}
+        # Two special cases
+        [[ $uspl = custom || $uspl = _local---zi ]] && continue
+        # Check if repository has a remote set
+        if [[ -f $repo/.git/config ]] {
+          local -a config
+          config=( ${(f)"$(<$repo/.git/config)"} )
+          if [[ ${#${(M)config[@]:#\[remote[[:blank:]]*\]}} -eq 0 ]] {
+            continue
+          }
+        }
+        .zi-any-to-user-plugin "$uspl"
+        local user=${reply[-2]} plugin=${reply[-1]}
+        # Must be a git repository or a binary release
+        if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]] {
           continue
         }
+        files2+=( $repo )
       }
-      .zi-any-to-user-plugin "$uspl"
-      local user=${reply[-2]} plugin=${reply[-1]}
-      # Must be a git repository or a binary release
-      if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]] {
-        continue
+      for repo ( "${files2[@]}" ) {
+        uspl=${repo:t}
+        id_as=${uspl//---//}
+        (( ++counter ))
+        local PUFILEMAIN=${${id_as#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
+        local PUFILE=$PUDIR/${(l:8::0:)counter}_$PUFILEMAIN.out
+        .zi-any-colorify-as-uspl2 "$uspl"
+        +zi-message "Updating{ehi}:{rst} $REPLY{rst}" >! "$PUFILE"
+        .zi-any-to-user-plugin "$uspl"
+        local user=${reply[-2]} plugin=${reply[-1]}
+        .zi-update-or-status update "$user" "$plugin" &>>! "$PUFILE" &
+        PUAssocArray[$!]=$PUFILE
+        .zi-wait-for-update-jobs plugins
       }
-      files2+=( $repo )
+      .zi-wait-for-update-jobs plugins flush
     }
-    main_counter=${#files2}
-    for repo ( "${files2[@]}" ) {
-      main_counter=main_counter-1
-      uspl=${repo:t}
-      id_as=${uspl//---//}
-      counter+=1
-      local PUFILEMAIN=${${id_as#/}//(#m)[\/=\?\&:]/${map[$MATCH]}}
-      local PUFILE=$PUDIR/${counter}_$PUFILEMAIN.out
-      .zi-any-colorify-as-uspl2 "$uspl"
-      +zi-message "Updating{ehi}:{rst} $REPLY{rst}" >! $PUFILE
-      .zi-any-to-user-plugin "$uspl"
-      local user=${reply[-2]} plugin=${reply[-1]}
-      .zi-update-or-status update "$user" "$plugin" &>>! $PUFILE &
-      PUAssocArray[$!]=$PUFILE
-      .zi-wait-for-update-jobs plugins
-    }
+  } always {
+    # Reap every child before removing its output directory, including when an
+    # error or signal interrupts a phase between normal flushes.
+    (( ${#PUAssocArray} )) && .zi-wait-for-update-jobs cleanup flush
+    [[ -n $PUDIR && -d $PUDIR ]] && command rm -rf -- "$PUDIR"
   }
-  # Shouldn't happen
-  # (( ${#PUAssocArray} > 0 )) && wait ${(k)PUAssocArray}
+  return "$retval"
 }
 # ]]]
 # FUNCTION: .zi-wait-for-update-jobs [[[
 .zi-wait-for-update-jobs() {
-  local tpe=$1
-  if (( counter > OPTS[value] || main_counter == 0 )) {
-    wait ${(k)PUAssocArray}
-    local ind_file
-    for ind_file ( ${^${(von)PUAssocArray}}.ind(DN.) ) {
-      command cat ${ind_file:r}
-      (( !OPTS[opt_-d,--debug] && !ZI[DEBUG_MODE] )) && command rm -f $ind_file
-    }
-    (( !OPTS[opt_-d,--debug] && !ZI[DEBUG_MODE] )) && command rm -f ${(v)PUAssocArray}
+  local tpe="$1"
+  integer force_flush=0 max_jobs=${OPTS[value]:-1}
+  [[ $2 == flush ]] && force_flush=1
+  (( max_jobs > 0 )) || max_jobs=1
+  if (( ${#PUAssocArray} && ( counter >= max_jobs || force_flush ) )) {
+    local pid output_file
+    integer wait_rc output_rc
+    local -A failed_files
+    for pid in ${(on)${(k)PUAssocArray}}; do
+      wait "$pid"
+      wait_rc=$?
+      if (( wait_rc != 0 )); then
+        (( retval == 0 )) && retval=$wait_rc
+        failed_files[${PUAssocArray[$pid]}]=$wait_rc
+      fi
+    done
+    for output_file in ${(on)${(v)PUAssocArray}}; do
+      if [[ -f $output_file.ind || -n ${failed_files[$output_file]} ]] ||
+        (( OPTS[opt_-d,--debug] || ZI[DEBUG_MODE] )); then
+        command cat -- "$output_file"
+        output_rc=$?
+        (( output_rc != 0 && retval == 0 )) && retval=$output_rc
+      fi
+      command rm -f -- "$output_file.ind" "$output_file"
+    done
     counter=0
     PUAssocArray=()
   } elif (( counter == 1 && !OPTS[opt_-q,--quiet] )) {

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -32,7 +32,7 @@ ZI[EXTENDED_GLOB]=""
   local uspl2="$1"
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[FUNCTIONS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[FUNCTIONS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A func
   local i
@@ -61,7 +61,7 @@ ZI[EXTENDED_GLOB]=""
   local uspl2="$1"
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[OPTIONS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[OPTIONS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A opts_before opts_after opts
   opts_before=( "${(z)ZI[OPTIONS_BEFORE__$uspl2]}" )
@@ -90,7 +90,7 @@ ZI[EXTENDED_GLOB]=""
   typeset -a tmp
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[PATH_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[PATH_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   [[ "${ZI[FPATH_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[FPATH_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   typeset -A path_state fpath_state
@@ -140,7 +140,7 @@ ZI[EXTENDED_GLOB]=""
   typeset -a tmp
   # Cannot run diff if *_BEFORE or *_AFTER variable is not set
   # Following is paranoid for *_BEFORE and *_AFTER being only spaces
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   [[ "${ZI[PARAMETERS_BEFORE__$uspl2]}" != *[$'! \t']* || "${ZI[PARAMETERS_AFTER__$uspl2]}" != *[$'! \t']* ]] && return 1
   # Un-concatenated parameters from moment of diff start and of diff end
   typeset -A params_before params_after
@@ -185,17 +185,17 @@ ZI[EXTENDED_GLOB]=""
   .zi-any-to-user-plugin "$1" "$2"
   [[ "${reply[-2]}" = "%" ]] && REPLY="${reply[-2]}${reply[-1]}" || REPLY="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]//---//}"
 } # ]]]
-# FUNCTION: .zi-save-set-extendedglob [[[
-# Enables extendedglob-option first saving if it was already
+# FUNCTION: .zi-save-set-extended_glob [[[
+# Enables extended_glob-option first saving if it was already
 # enabled, for restoration of this state later.
-.zi-save-set-extendedglob() {
-  [[ -o "extendedglob" ]] && ZI[EXTENDED_GLOB]="1" || ZI[EXTENDED_GLOB]="0"
-  builtin setopt extendedglob
+.zi-save-set-extended_glob() {
+  [[ -o "extended_glob" ]] && ZI[EXTENDED_GLOB]="1" || ZI[EXTENDED_GLOB]="0"
+  builtin setopt extended_glob
 } # ]]]
-# FUNCTION: .zi-restore-extendedglob [[[
-# Restores extendedglob-option from state saved earlier.
-.zi-restore-extendedglob() {
-  [[ "${ZI[EXTENDED_GLOB]}" = "0" ]] && builtin unsetopt extendedglob || builtin setopt extendedglob
+# FUNCTION: .zi-restore-extended_glob [[[
+# Restores extended_glob-option from state saved earlier.
+.zi-restore-extended_glob() {
+  [[ "${ZI[EXTENDED_GLOB]}" = "0" ]] && builtin unsetopt extended_glob || builtin setopt extended_glob
 } # ]]]
 # FUNCTION: .zi-prepare-readlink [[[
 # Prepares readlink command, used for establishing completion's owner.
@@ -322,9 +322,9 @@ ZI[EXTENDED_GLOB]=""
   REPLY=""
   # Paranoid, don't want bad key/value pair error
   integer empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[OPTIONS__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   (( empty )) && return 0
   typeset -A opts
   opts=( "${(z)ZI[OPTIONS__$uspl2]}" )
@@ -371,7 +371,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - user/plugin (i.e. uspl2 format of plugin-spec)
 .zi-format-parameter() {
   local uspl2="$1" infoc="${ZI[col-info]}" k
-  builtin setopt localoptions extendedglob nokshglob noksharrays
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays
   REPLY=""
   [[ "${ZI[PARAMETERS_PRE__$uspl2]}" != *[$'! \t']* || "${ZI[PARAMETERS_POST__$uspl2]}" != *[$'! \t']* ]] && return 0
   typeset -A elem_pre elem_post
@@ -419,7 +419,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - absolute path to completion file (in COMPLETIONS_DIR)
 # $2 - readlink command (":" or "readlink")
 .zi-get-completion-owner() {
-  builtin setopt localoptions extendedglob nokshglob noksharrays noshwordsplit
+  builtin setopt local_options extended_glob no_ksh_glob no_ksh_arrays no_sh_word_split
 
   local cpath="$1"
   local readlink_cmd="$2"
@@ -464,7 +464,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-find-completions-of-plugin() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
   .zi-any-to-user-plugin "${1}" "${2}"
   local user="${reply[-2]}" plugin="${reply[-1]}" uspl
   [[ "$user" = "%" ]] && uspl="${user}${plugin}" || uspl="${reply[-2]}${reply[-2]:+---}${reply[-1]//\//---}"
@@ -799,7 +799,7 @@ ZI[EXTENDED_GLOB]=""
 # User-action entry point.
 .zi-show-registered-plugins() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   typeset -a filtered
   local keyword="$1"
   keyword="${keyword## ##}"
@@ -845,9 +845,9 @@ ZI[EXTENDED_GLOB]=""
   (( quiet )) || builtin print -r -- "${ZI[col-bar]}---${ZI[col-rst]} Unloading plugin: $REPLY ${ZI[col-bar]}---${ZI[col-rst]}"
   local ___dir
   [[ "$user" = "%" ]] && ___dir="$plugin" || ___dir="${ZI[PLUGINS_DIR]}/${user:+${user}---}${plugin//\//---}"
-  # KSH_ARRAYS immunity
+  # ksh_arrays immunity
   integer correct=0
-  [[ -o "KSH_ARRAYS" ]] && correct=1
+  [[ -o "ksh_arrays" ]] && correct=1
   # Allow unload for debug user
   if [[ "$uspl2" != "_dtrace/_dtrace" ]]; then
     .zi-exists-message "$1" "$2" || return 1
@@ -901,7 +901,7 @@ ZI[EXTENDED_GLOB]=""
     if [[ "$sw_arr4" = "-M" && "$sw_arr6" != "-R" ]]; then
       if [[ -n "$sw_arr3" ]]; then
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3 ${ZI[col-info]}in map ${ZI[col-rst]}$sw_arr5"
         }
         bindkey -M "$sw_arr5" "$sw_arr1" "$sw_arr3"
@@ -934,7 +934,7 @@ ZI[EXTENDED_GLOB]=""
     else
       if [[ -n "$sw_arr3" ]]; then
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3"
         }
         bindkey "$sw_arr1" "$sw_arr3"
@@ -972,9 +972,9 @@ ZI[EXTENDED_GLOB]=""
   # Paranoid, don't want bad key/value pair error
   .zi-diff-options-compute "$uspl2"
   integer empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[OPTIONS__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   if (( empty != 1 )); then
     typeset -A opts
     opts=( "${(z)ZI[OPTIONS__$uspl2]}" )
@@ -1052,7 +1052,7 @@ ZI[EXTENDED_GLOB]=""
   keys=( "${(@on)ZI[(I)TIME_<->_*]}" )
   integer keys_size=${#keys}
   () {
-    builtin setopt localoptions extendedglob noksharrays typesetsilent
+    builtin setopt local_options extended_glob no_ksh_arrays typeset_silent
     typeset -a restore_widgets skip_delete
     local wid
     restore_widgets=( "${(z)ZI[WIDGETS_SAVED__$uspl2]}" )
@@ -1227,9 +1227,9 @@ ZI[EXTENDED_GLOB]=""
 
   .zi-diff-parameter-compute "$uspl2"
   empty=0
-  .zi-save-set-extendedglob
+  .zi-save-set-extended_glob
   [[ "${ZI[PARAMETERS_POST__$uspl2]}" != *[$'! \t']* ]] && empty=1
-  .zi-restore-extendedglob
+  .zi-restore-extended_glob
   if (( empty != 1 )); then
     typeset -A elem_pre elem_post
     elem_pre=( "${(z)ZI[PARAMETERS_PRE__$uspl2]}" )
@@ -1304,7 +1304,7 @@ ZI[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-show-report() {
-  builtin setopt localoptions extendedglob warncreateglobal typesetsilent noksharrays
+  builtin setopt local_options extended_glob warn_create_global typeset_silent no_ksh_arrays
   .zi-any-to-user-plugin "$1" "$2"
   local user="${reply[-2]}" plugin="${reply[-1]}" uspl2="${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]}"
   # Allow debug report
@@ -1326,7 +1326,7 @@ ZI[EXTENDED_GLOB]=""
   )
   # Print report gathered via shadowing
   () {
-    builtin setopt localoptions extendedglob
+    builtin setopt local_options extended_glob
     builtin print -rl -- "${(@)${(f@)ZI_REPORTS[$uspl2]}/(#b)(#s)([^[:space:]]##)([[:space:]]##)/${map[${match[1]}]:-${ZI[col-keyword]}}${match[1]}${ZI[col-rst]}${match[2]}}"
   }
   # Print report gathered via $functions-diffing
@@ -1407,9 +1407,9 @@ ZI[EXTENDED_GLOB]=""
 # $2 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $3 - plugin (only when $1 - i.e. user - given)
 .zi-update-or-status() {
-  # Set the localtraps option.
+  # Set the local_traps option.
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob null_glob warn_create_global typeset_silent no_short_loops
   local -a arr
   ZI[first-plugin-mark]=${${ZI[first-plugin-mark]:#init}:-1}
   ZI[-r/--reset-opt-hook-has-been-run]=0
@@ -1722,7 +1722,7 @@ ZI[EXTENDED_GLOB]=""
 # $2 - snippet URL
 .zi-update-or-status-snippet() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
   local st="$1" URL="${2%/}" local_dir filename is_snippet
   (( ${#ICE[@]} > 0 )) && { ZI_SICE[$URL]=""; local nf="-nftid"; }
   local -A ICE2
@@ -1767,7 +1767,7 @@ ZI[EXTENDED_GLOB]=""
 # User-action entry point.
 .zi-update-or-status-all() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob null_glob warn_create_global typeset_silent no_short_loops
   local -F2 SECONDS=0
   integer retval
   if (( OPTS[opt_-p,--parallel] )) && [[ $1 = update ]] {
@@ -1965,7 +1965,7 @@ ZI[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zi-show-zstatus() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   local infoc="${ZI[col-info2]}"
   +zi-message "{info}Directories set{ehi}:{rst} "
@@ -2095,9 +2095,9 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 .zi-list-bindkeys() {
   local uspl2 uspl2col sw first=1
   local -a string_widget
-  # KSH_ARRAYS immunity
+  # ksh_arrays immunity
   integer correct=0
-  [[ -o "KSH_ARRAYS" ]] && correct=1
+  [[ -o "ksh_arrays" ]] && correct=1
   for uspl2 in "${(@ko)ZI[(I)BINDKEYS__*]}"; do
     [[ -z "${ZI[$uspl2]}" ]] && continue
     (( !first )) && builtin print
@@ -2141,7 +2141,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-compiled() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
 
   typeset -a matches m
   matches=( ${ZI[PLUGINS_DIR]}/*/*.zwc(DN) )
@@ -2170,7 +2170,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-compile-uncompile-all() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
 
   local compile="$1"
   typeset -a plugins
@@ -2198,7 +2198,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user (+ plugin in $2), plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-uncompile-plugin() {
-  builtin setopt localoptions nullglob
+  builtin setopt local_options null_glob
   .zi-any-to-user-plugin "${1}" "${2}"
   local user="${reply[-2]}" plugin="${reply[-1]}" silent="$3"
   # There are plugins having ".plugin.zsh"
@@ -2231,7 +2231,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-show-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   local count="${1:-3}"
   typeset -a completions
@@ -2311,7 +2311,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-clear-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   typeset -a completions
   completions=( "${ZI[COMPLETIONS_DIR]}"/_[^_.]*~*.zwc "${ZI[COMPLETIONS_DIR]}"/[^_.]*~*.zwc )
@@ -2361,7 +2361,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 #
 # User-action entry point.
 .zi-search-completions() {
-  builtin setopt localoptions nullglob extendedglob nokshglob noksharrays
+  builtin setopt local_options null_glob extended_glob no_ksh_glob no_ksh_arrays
 
   typeset -a plugin_paths
   plugin_paths=( "${ZI[PLUGINS_DIR]}"/*(DN) )
@@ -2500,7 +2500,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-cd() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent rc_quotes
 
   .zi-get-path "$1" "$2" && {
     if [[ -e $REPLY ]]; then
@@ -2545,7 +2545,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-delete() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local -a opts match mbegin mend
   local MATCH; integer MBEGIN MEND _retval
@@ -2710,7 +2710,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $1 - time spec, e.g. "1 week"
 .zi-recently() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt nullglob extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt null_glob extended_glob warn_create_global typeset_silent no_short_loops
   local IFS=.
   local gitout
   local timespec=${*// ##/.}
@@ -2742,7 +2742,7 @@ builtin print -Pr \"\$ZI[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $2 - (optional) plugin (only when $1 - i.e. user - given)
 .zi-create() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt localoptions extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt local_options extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   .zi-any-to-user-plugin "$1" "$2"
   local user="${reply[-2]}" plugin="${reply[-1]}"
@@ -2955,7 +2955,7 @@ EOF
   )
   (
     builtin emulate -LR ksh ${=${options[xtrace]:#off}:+-o xtrace}
-    builtin unsetopt shglob kshglob
+    builtin unsetopt sh_glob ksh_glob
     for i in "${ZI_STRESS_TEST_OPTIONS[@]}"; do
       builtin setopt "$i"
       builtin print -n "Stress-testing ${fname:t} for option $i "
@@ -2985,7 +2985,7 @@ EOF
 # FUNCTION: .zi-ls [[[
 .zi-ls() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   if (( ${+commands[tree]} )); then
     ZI[TREE]="${commands[tree]} -L 3 -C --charset utf-8"
@@ -3020,7 +3020,7 @@ EOF
 # ("%" "/home/..." and also "%SNIPPETS/..." etc.), or a plugin nickname (i.e. id-as'' ice-mod), or a snippet nickname.
 .zi-get-path() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   [[ $1 == % ]] && local id_as=%$2 || local id_as=$1${1:+/}$2
   .zi-get-object-path snippet "$id_as" || .zi-get-object-path plugin "$id_as"
   return $(( 1 - reply[3] ))
@@ -3028,7 +3028,7 @@ EOF
 # FUNCTION: .zi-recall [[[
 .zi-recall() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
 
   local -A ice
   local el val cand1 cand2 local_dir filename is_snippet

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -1570,7 +1570,7 @@ ZI[EXTENDED_GLOB]=""
               } || +zi-message "{nl}Updating{ehi}:{rst} $REPLY{rst}"
             }
           }
-          +zi-message "$line" | command tee .zi_lastupd | .zi-pager &
+          +zi-message --literal -- "$line" | command tee .zi_lastupd | .zi-pager &
           integer pager_pid=$!
           { sleep 20 && kill -9 $pager_pid 2>/dev/null 1>&2; } &!
           { wait $pager_pid; } > /dev/null 2>&1
@@ -1822,7 +1822,7 @@ ZI[EXTENDED_GLOB]=""
     local user=${reply[-2]} plugin=${reply[-1]}
     # Must be a git repository or a binary release
     if [[ ! -d $repo/.git && ! -f $repo/._zi/is_release ]]; then
-      (( OPTS[opt_-q,--quiet] )) || +zi-message "$REPLY: not a git repository"
+      (( OPTS[opt_-q,--quiet] )) || +zi-message -- "$REPLY: not a git repository"
       continue
     fi
     if [[ $st = status ]]; then
@@ -2086,7 +2086,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     elif [[ ( ${sice[pick]} = /dev/null || ${sice[as]} = null ) && ${+sice[make]} = 1 ]]; then
       line="$line {mdsh} {faint} ({dir}/dev/null{rst} {cmd}make{rst} {p}plugin{rst}{faint}){rst}"
     fi
-    +zi-message "$line"
+    +zi-message -- "$line"
     (( sum += ZI[$entry] ))
   done
   +zi-message "{mmdsh}{rst} {b}Total{ehi}:{rst} {auto}${sum}s"
@@ -2159,10 +2159,10 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     if [[ "$cur_plugin" != "$uspl1" ]]; then
       [[ -n "$cur_plugin" ]] && builtin print # newline
       .zi-any-colorify-as-uspl2 "$user" "$plugin"
-      +zi-message "$REPLY:"
+      +zi-message -- "$REPLY:"
       cur_plugin="$uspl1"
     fi
-    +zi-message "$file"
+    +zi-message --literal -- "$file"
   done
 } # ]]]
 # FUNCTION: .zi-compile-uncompile-all [[[
@@ -2212,7 +2212,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
       +zi-message "not compiled"
     else
       .zi-any-colorify-as-uspl2 "$user" "$plugin"
-      +zi-message "$REPLY not compiled"
+      +zi-message -- "$REPLY not compiled"
     fi
     return 1
   fi
@@ -2346,7 +2346,7 @@ builtin setopt extended_glob warn_create_global typeset_silent \
     fi
     if (( unknown == 1 || stray == 1 )); then
       +zi-message -n "Removing completion{ehi}:{rst} ${(r:longest+1:: :)c} $REPLY"
-      (( disabled )) && +zi-message -n " {error}[disabled]{col-rst]}"
+      (( disabled )) && +zi-message -n " {error}[disabled]{rst}"
       (( unknown )) && +zi-message -n " {error}[unknown file]{rst}"
       (( stray )) && +zi-message -n " {error}[stray]{rst}"
       builtin print
@@ -3357,5 +3357,5 @@ sleep 0.04 && +zi-message "❯ loaded|lists      {p}[keyword]{rst} {mdsh}{rst} {
   +zi-message "{mmdsh}{info} Registered ice-modifiers{ehi}:{rst}"
   local -a ice_order
   ice_order=( ${${(As:|:)ZI[ice-list]}:#teleid} ${(@)${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}:#(.*|dynamic-unscope)} )
-  +zi-message "${ice_order[*]}"
+  +zi-message -- "${ice_order[*]}"
 } # ]]]

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -1750,10 +1750,76 @@ ziextract() {
     command mv -f *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) ._backup 2>/dev/null
   }
 
+  .zi-archive-members-safe() {
+    builtin emulate -LR zsh
+    builtin setopt extendedglob
+
+    local member component
+    for member in "${(@f)1}"; do
+      while [[ $member == ./* ]]; do
+        member=${member#./}
+      done
+      [[ -z $member || $member == . ]] && continue
+      [[ $member != /* && $member != [[:alpha:]]:[/\\]* && $member != *\\* ]] || return 1
+      for component in "${(@s:/:)member}"; do
+        [[ $component != .. ]] || return 1
+      done
+    done
+  }
+
+  .zi-extraction-targets-safe() {
+    builtin emulate -LR zsh
+    builtin setopt extendedglob
+
+    local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved link_target
+    local -a staged_files
+    staged_files=( "$stage"/**/*(DN) )
+    for staged_file in "${staged_files[@]}"; do
+      relative=${staged_file#${stage}/}
+      if [[ -L $staged_file ]]; then
+        link_target="$(command readlink "$staged_file")" || return 1
+        [[ $link_target != /* && $link_target != [[:alpha:]]:[/\\]* && $link_target != *\\* ]] || return 1
+        resolved=${staged_file:h}/${link_target}
+        resolved=${resolved:A}
+        [[ $resolved == ${stage:A} || $resolved == ${stage:A}/* ]] || return 1
+      fi
+      target_path=$target_dir
+      for target_component in "${(@s:/:)relative}"; do
+        target_path+="/$target_component"
+        [[ ! -L $target_path ]] || return 1
+      done
+    done
+  }
+
   .zi-extract-wrapper() {
-    local file="$1" fun="$2" retval
+    local file="$1" fun="$2" retval=0 original_file="$1" original_dir="$PWD"
+    local source_file="${1:A}" stage listing
     (( !OPTS[opt_-q,--quiet] )) && +zi-message "{annex}ziextract{ehi}:{rst} Unpacking the files from{ehi}:{rst} \`{file}$file{rst}'{…}{rst}"
-    $fun; retval=$?
+    file=$source_file
+    if [[ $(typeset -f + →zi-list) == "→zi-list" ]]; then
+      listing="$(→zi-list)" || retval=$?
+      (( retval )) || .zi-archive-members-safe "$listing" || retval=1
+    fi
+    if (( !retval && stage_extract )); then
+      stage="$(command mktemp -d "${TMPDIR:-/tmp}/zi-extract.XXXXXXXX")" || retval=1
+      if (( !retval )); then
+        builtin cd -q "$stage" || retval=1
+      fi
+      if (( !retval )); then
+        $fun || retval=$?
+      fi
+      builtin cd -q "$original_dir" || retval=1
+      if (( !retval )); then
+        .zi-extraction-targets-safe "$stage" "$original_dir" || retval=1
+      fi
+      if (( !retval )); then
+        command cp -a "$stage"/. "$original_dir"/ || retval=$?
+      fi
+      [[ -z $stage ]] || command rm -rf -- "$stage"
+    elif (( !retval )); then
+      $fun || retval=$?
+    fi
+    file=$original_file
     if (( retval == 0 )) {
       local -a files
       files=( *~(._zi*|._backup|.git|.svn|.hg|$file)(DN) )
@@ -1763,27 +1829,42 @@ ziextract() {
   }
 
   →zi-check() { (( ${+commands[$1]} )) || +zi-message "{annex}ziextract{ehi}:{rst} {error}No command {cmd}$1{msg2},{error} it is required to unpack {file}$2{rst}"; }
+  integer stage_extract=0
 
   case "${${ext:+.$ext}:-$file}" in
     ((#i)*.zip)
+      stage_extract=1
+      →zi-list() { command unzip -Z1 "$file"; }
       →zi-extract() { →zi-check unzip "$file" || return 1; command unzip -o "$file"; }
       ;;
     ((#i)*.rar)
+      stage_extract=1
+      →zi-list() { command unrar lb "$file"; }
       →zi-extract() { →zi-check unrar "$file" || return 1; command unrar x "$file"; }
       ;;
     ((#i)*.tar.bz2|(#i)*.tbz|(#i)*.tbz2)
+      stage_extract=1
+      →zi-list() { command bzip2 -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check bzip2 "$file" || return 1; command bzip2 -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.gz|(#i)*.tgz)
+      stage_extract=1
+      →zi-list() { command gzip -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check gzip "$file" || return 1; command gzip -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.xz|(#i)*.txz)
+      stage_extract=1
+      →zi-list() { command xz -dc "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check xz "$file" || return 1; command xz -dc "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar.7z|(#i)*.t7z)
+      stage_extract=1
+      →zi-list() { command 7z x -so "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check 7z "$file" || return 1; command 7z x -so "$file" | command tar -xf -; }
       ;;
     ((#i)*.tar)
+      stage_extract=1
+      →zi-list() { command tar -tf "$file"; }
       →zi-extract() { →zi-check tar "$file" || return 1; command tar -xf "$file"; }
       ;;
     ((#i)*.gz|(#i)*.gzip)
@@ -1829,9 +1910,12 @@ ziextract() {
       }
       ;;
     ((#i)*.7z|(#i)*.7-zip)
+      stage_extract=1
+      →zi-list() { command 7z l -ba -slt "$file" | command sed -n 's/^Path = //p'; }
       →zi-extract() { →zi-check 7z "$file" || return 1; command 7z x "$file" >/dev/null;  }
       ;;
     ((#i)*.dmg)
+      stage_extract=1
       →zi-extract() {
         local prog
         for prog ( hdiutil cp ) { →zi-check $prog "$file" || return 1; }
@@ -1848,9 +1932,13 @@ ziextract() {
       }
       ;;
     ((#i)*.deb)
+      stage_extract=1
+      →zi-list() { command dpkg-deb --fsys-tarfile "$file" | command tar -tf -; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check dpkg-deb "$file" || return 1; command dpkg-deb -R "$file" .; }
       ;;
     ((#i)*.rpm)
+      stage_extract=1
+      →zi-list() { "$ZI[BIN_DIR]"/lib/zsh/rpm2cpio.zsh "$file" | command cpio -t; local -a statuses=( $pipestatus ); (( !statuses[1] && !statuses[2] )); }
       →zi-extract() { →zi-check cpio "$file" || return 1; $ZI[BIN_DIR]/lib/zsh/rpm2cpio.zsh "$file" | command cpio -imd --no-absolute-filenames; }
       ;;
     ((#i)*.exe|(#i)*.pe32)
@@ -1871,14 +1959,15 @@ ziextract() {
         command mv ._backup/*(DN) . 2>/dev/null
       }
       +zi-message ".{rst}"
-      unfunction -- →zi-extract →zi-check 2>/dev/null
+      unfunction -- →zi-extract →zi-check →zi-list 2>/dev/null
+      unfunction -- .zi-archive-members-safe .zi-extraction-targets-safe 2>/dev/null
       return 1
     }
-    unfunction -- →zi-extract →zi-check
+    unfunction -- →zi-extract →zi-check →zi-list 2>/dev/null
   } else {
     integer warning=1
   }
-  unfunction -- .zi-extract-wrapper
+  unfunction -- .zi-extract-wrapper .zi-archive-members-safe .zi-extraction-targets-safe
 
   local -a execs
   execs=( **/*~(._zi(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -772,6 +772,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message "{error}Error{ehi}:{rst} Refusing to replace a symlinked GitHub directory snippet or metadata directory"
     return 4
   }
+  local -a metadata_symlinks
+  metadata_symlinks=( "$directory/._zi"/**/*(@DN) )
+  (( !${#metadata_symlinks} )) || {
+    +zi-message "{error}Error{ehi}:{rst} Refusing GitHub directory snippet metadata containing symlinks"
+    return 4
+  }
 
   local temp_root
   temp_root=$(command mktemp -d ".zi-git-mirror.XXXXXXXX") || return 4
@@ -785,6 +791,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     command git -C "$repository_dir" sparse-checkout set --cone -- "$subpath" || return 4
     source_dir=$repository_dir/$subpath
     [[ -d $source_dir ]] || return 4
+    local -a source_symlinks
+    source_symlinks=( "$source_dir"/**/*(@DN) )
+    (( !${#source_symlinks} )) || {
+      +zi-message "{error}Error{ehi}:{rst} Refusing a GitHub directory snippet containing symlinks"
+      return 4
+    }
 
     remote_revision=$(command git -C "$repository_dir" rev-parse HEAD) || return 4
     command mkdir -p -- "$payload_dir" || return 4

--- a/lib/zsh/install.zsh
+++ b/lib/zsh/install.zsh
@@ -10,7 +10,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # Retrievies the ice-list from given profile from the JSON of the package.json.
 .zi-parse-json() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local -A ___pos_to_level ___level_to_pos ___pair_map ___final_pairs ___Strings ___Counts
   local ___input=$1 ___workbuf=$1 ___key=$2 ___varname=$3 ___style ___quoting
@@ -284,7 +284,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - plugin
 .zi-setup-plugin-dir() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global no_short_loops rc_quotes
 
   local user=$1 plugin=$2 id_as=$3 remote_url_path=${1:+$1/}$2 local_path tpe=$4 update=$5 version=$6
 
@@ -357,7 +357,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       command mkdir -p "$local_path"
       [[ -d "$local_path" ]] || return 1
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_path"; } || return 1
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_path"; } || return 1
         integer count
 
         for REPLY ( $reply ) {
@@ -395,7 +395,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       command mkdir -p "$local_path/._zi"
       [[ -d "$local_path" ]] || return 1
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_path"; } || return 1
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_path"; } || return 1
         .zi-get-cygwin-package "$remote_url_path" || return 1
         builtin print -r -- $REPLY >! ._zi/is_release
         ziextract "$REPLY"
@@ -600,7 +600,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 .zi-download-file-stdout() {
   local url="$1" restart="$2" progress="${(M)3:#1}"
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt localtraps extendedglob
+  builtin setopt local_traps extended_glob
 
   if (( restart )) {
     (( ${path[(I)/usr/local/bin]} )) || {
@@ -651,7 +651,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   local url="$1" IFS line header
   local -a cmd
 
-  builtin setopt localoptions localtraps
+  builtin setopt local_options local_traps
 
   (( !${path[(I)/usr/local/bin]} )) && {
     path+=( "/usr/local/bin" );
@@ -690,7 +690,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - URL in https://github.com/OWNER/REPOSITORY/trunk/PATH form
 .zi-parse-github-svn-url() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   local url=${1%/}
   [[ $url = http(|s)://github.com/* ]] || return 1
@@ -725,7 +725,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $3 - installed directory
 .zi-mirror-using-git() {
   builtin emulate -L zsh
-  builtin setopt extendedglob
+  builtin setopt extended_glob
 
   local url=$1 mode=$2 directory=$3
   (( ${+commands[git]} )) || {
@@ -860,7 +860,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $3 - subdirectory (not path) with working copy, needed for -t and -u
 .zi-mirror-using-svn() {
   builtin emulate -L zsh
-  builtin setopt extendedglob warncreateglobal
+  builtin setopt extended_glob warn_create_global
   local url="$1" update="$2" directory="$3"
 
   (( ${+commands[svn]} )) || {
@@ -869,7 +869,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
   }
 
   if [[ "$update" = "-t" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$directory"; }
       local -a out1 out2
       out1=( "${(f@)"$(LANG=C svn info -r HEAD)"}" )
       out2=( "${(f@)"$(LANG=C svn info)"}" )
@@ -882,7 +882,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     return $?
   fi
   if [[ "$update" = "-u" && -d "$directory" && -d "$directory/.svn" ]]; then
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$directory"; }
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$directory"; }
     command svn update
     return $? )
   else
@@ -898,7 +898,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $1 - completion function name, e.g. "_cp"; can also be "cp"
 .zi-forget-completion() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal
+  builtin setopt extended_glob typeset_silent warn_create_global
 
   local f="$1" quiet="$2"
 
@@ -926,7 +926,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-compile-plugin() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}} first plugin_dir filename is_snippet
   local -a list
@@ -964,7 +964,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     +zi-message -n "Compiling{ehi}:{rst} {b}{file}$fname{rst}{…}"
     if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
       () {
-        builtin emulate -LR zsh -o extendedglob
+        builtin emulate -LR zsh -o extended_glob
         if { ! zcompile -U "$first" } {
           +zi-message "{error}Warning{ehi}:{rst} Compilation failed. Don't worry, the plugin will work also without compilation"
           +zi-message "{error}Warning{ehi}:{rst} Consider submitting an error report to ❮ Zi ❯ or to the plugin's author"
@@ -991,7 +991,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
       integer retval
       for first in $list; do
         () {
-          builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+          builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
           zcompile -U "$first"; retval+=$?
         }
       done
@@ -1014,7 +1014,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # svn ice is active. This provides a layer of support for Oh-My-Zsh and Prezto.
 .zi-download-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
 
   local save_url=$1 url=$2 id_as=$3 local_dir=$4 dirname=$5 filename=$6 update=$7
 
@@ -1078,7 +1078,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
     if [[ $url = (http|https|ftp|ftps|scp)://* ]] {
       # URL
       (
-        () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
+        () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir"; } || return 4
         local mirror_name=Subversion
         [[ $url = http(|s)://github.com/* ]] && mirror_name="Git sparse checkout"
         (( !OPTS[opt_-q,--quiet] )) && \
@@ -1142,7 +1142,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
             fi
             if [[ -e ${list[1]} && ${list[1]} != */dev/null && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && ${+ICE[nocompile]} -eq 0 ]] {
               () {
-                builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+                builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
                 zcompile -U "${list[1]}" &>/dev/null || \
                   +zi-message "{error}Warning{ehi}:{rst} Couldn't compile {apo}\`{file}${list[1]}{rst}'"
               }
@@ -1231,7 +1231,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
         fi
         if [[ -e $file_path && -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} && $file_path != */dev/null && ${+ICE[nocompile]} -eq 0 ]] {
           () {
-            builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+            builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
             if ! zcompile -U "$file_path" 2>/dev/null; then
               builtin print -r "Couldn't compile \`${file_path:t}', it MIGHT be wrongly downloaded"
               builtin print -r "(snippet URL points to a directory instead of a file?"
@@ -1424,12 +1424,12 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # FUNCTION: .zi-update-snippet [[[
 .zi-update-snippet() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
 
   local -a tmp opts
   local url=$1
   integer correct=0
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
   opts=( -u ) # for z-a-readurl
 
   # Create a local copy of OPTS,
@@ -1644,7 +1644,7 @@ builtin source "${ZI[BIN_DIR]}/lib/zsh/side.zsh" || { builtin print -P "${ZI[col
 # $2 - file
 ziextract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops # warncreateglobal
+  builtin setopt extended_glob typeset_silent no_short_loops # warn_create_global
 
   if (( $+commands[file] != 1 )) { +zi-message "{annex}ziextract{ehi}:{rst} {error}The {cmd}file{error} command is required for recognizing the type of data to be processed{rst}"
     return 1
@@ -1752,7 +1752,7 @@ ziextract() {
 
   .zi-archive-members-safe() {
     builtin emulate -LR zsh
-    builtin setopt extendedglob
+    builtin setopt extended_glob
 
     local member component
     for member in "${(@f)1}"; do
@@ -1769,7 +1769,7 @@ ziextract() {
 
   .zi-extraction-targets-safe() {
     builtin emulate -LR zsh
-    builtin setopt extendedglob
+    builtin setopt extended_glob
 
     local stage="$1" target_dir="$2" staged_file relative target_component target_path resolved link_target
     local -a staged_files
@@ -2020,7 +2020,7 @@ ziextract() {
 # FUNCTION: .zi-extract() [[[
 .zi-extract() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent
+  builtin setopt extended_glob warn_create_global typeset_silent
   local tpe=$1 extract=$2 local_dir=$3
   (
     builtin cd -q "$local_dir" || {
@@ -2142,7 +2142,7 @@ ziextract() {
 # FUNCTION zicp [[[
 zicp() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
   local -a mbegin mend match
   local cmd=cp
   if [[ $1 = (-m|--mv) ]] { cmd=mv; shift; }
@@ -2298,13 +2298,13 @@ zimv() {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
       () {
-        builtin setopt localoptions noautopushd
+        builtin setopt local_options no_auto_pushd
         builtin cd -q "$dir"
       }
     }
     eval "$atclone"
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }
   }
   return "$rc"
 } # ]]]
@@ -2328,7 +2328,7 @@ zimv() {
   @zi-substitute from to
   local -a mv_args=("-f")
   local -a afr
-    ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+    ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; } || return 1
       afr=( ${~from}(DN) )
       if (( ! ${#afr} )) {
         +zi-message "{warn}Warning{ehi}:{rst} {auto}mv ice didn't match any file{rst} [{error}$ICE[mv]{rst}]" \
@@ -2359,7 +2359,7 @@ zimv() {
   @zi-substitute from to
 
   local -a afr retval
-  ( () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+  ( () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; } || return 1
     afr=( ${~from}(DN) )
     if (( ${#afr} )); then
       if (( !OPTS[opt_-q,--quiet] )); then
@@ -2383,7 +2383,7 @@ zimv() {
     if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
       () {
         builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-        builtin setopt extendedglob warncreateglobal
+        builtin setopt extended_glob warn_create_global
         if [[ $tpe == snippet ]] {
           .zi-compile-plugin "%$dir" ""
         } else {
@@ -2405,11 +2405,11 @@ zimv() {
   .zi-countdown atpull && {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
-      () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; }
+      () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; }
     }
     .zi-at-eval "$atpull" "$ICE[atclone]"
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; };
   }
   return "$rc"
 } # ]]]
@@ -2425,11 +2425,11 @@ zimv() {
   .zi-countdown atpull && {
     local ___oldcd=$PWD
     (( ${+ICE[nocd]} == 0 )) && {
-      () { builtin setopt localoptions noautopushd; builtin cd -q "$dir"; }
+      () { builtin setopt local_options no_auto_pushd; builtin cd -q "$dir"; }
     }
     .zi-at-eval "$atpull" $ICE[atclone]
     rc="$?"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; };
   }
   return "$rc"
 } # ]]]

--- a/lib/zsh/side.zsh
+++ b/lib/zsh/side.zsh
@@ -28,7 +28,7 @@
 # $2 - plugin (only when $1 - i.e. user - given)
 .zi-exists-physically-message() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes
   if ! .zi-exists-physically "$1" "$2"; then
     .zi-any-to-user-plugin "$1" "$2"
     if [[ $reply[1] = % ]] {
@@ -77,7 +77,7 @@
     reply=( "$dname" "" )
     return 1
   fi
-  # Take first entry (ksharrays resilience)
+  # Take first entry (ksh_arrays resilience)
   reply=( "$dname" "${reply[-${#reply}]}" )
   return 0
 } # ]]]
@@ -116,7 +116,7 @@
 # returns 2 possible paths for further examination
 .zi-two-paths() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal noshortloops
+  builtin setopt extended_glob typeset_silent warn_create_global no_short_loops
 
   local url=$1 url1 url2 local_dirA dirnameA svn_dirA local_dirB dirnameB
   local -a fileB_there
@@ -157,7 +157,7 @@
 # $6 - name of output string parameter, to hold is-snippet 0/1-bool ("is_snippet")
 .zi-compute-ice() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent warncreateglobal noshortloops
+  builtin setopt extended_glob typeset_silent warn_create_global no_short_loops
 
   local ___URL="${1%/}" ___pack="$2" ___is_snippet=0
   local ___var_name1="${3:-ZI_ICE}" ___var_name2="${4:-local_dir}" ___var_name3="${5:-filename}" ___var_name4="${6:-is_snippet}"
@@ -345,7 +345,7 @@
 # successfully reaches 0, or 1 if Ctrl-C will be pressed.
 .zi-countdown() {
   (( !${+ICE[countdown]} )) && return 0
-  builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   trap "+zi-message \"{ehi}ABORTING, the ice {ice}$ice{ehi} not ran{rst}\"; return 1" INT
   local count=5 tpe="$1" ice
   ice="${ICE[$tpe]}"

--- a/scripts/public-contract-evidence.zsh
+++ b/scripts/public-contract-evidence.zsh
@@ -1,0 +1,128 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# public-contract-evidence.zsh -- report stale consumer evidence pins.
+#
+# Every entry in contracts/public-contract-v1.json cites a consumer file at a
+# fixed commit. Nothing detects when that consumer file moves on, so an
+# evidence URL can silently describe a version that no longer exists. This
+# script compares the Git blob object of each pinned path against the blob
+# currently on the consumer repository's default branch.
+#
+# A stale pin is a review signal, not automatically a contract break: the
+# consumer may have changed lines unrelated to the surfaces it claims. Re-read
+# the consumer, then bump the pin when the claim still holds.
+#
+# Usage:
+#   zsh scripts/public-contract-evidence.zsh [--manifest PATH] [--quiet]
+#
+# Exit codes:
+#   0  every pin resolves and matches the consumer default branch
+#   1  at least one pin is stale or unresolvable
+#   2  usage or dependency error
+
+emulate -LR zsh
+setopt errexit nounset pipefail
+
+typeset manifest_path="contracts/public-contract-v1.json"
+integer quiet=0
+
+usage() {
+  print "usage: ${0:t} [--manifest PATH] [--quiet]"
+}
+
+while (( $# )); do
+  case "$1" in
+    --manifest)
+      manifest_path="${2-}"
+      shift 2
+      ;;
+    --quiet)
+      quiet=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      print -u2 "public-contract-evidence: unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for command_name in gh jq; do
+  (( $+commands[$command_name] )) || {
+    print -u2 "public-contract-evidence: required command not found: ${command_name}"
+    exit 2
+  }
+done
+
+[[ -r $manifest_path ]] || {
+  print -u2 "public-contract-evidence: cannot read manifest: ${manifest_path}"
+  exit 2
+}
+
+# Resolve a path's blob object id. With a ref, read that exact commit;
+# without one, read the repository default branch.
+blob_at() {
+  local repository="$1" file_path="$2" ref="${3-}" endpoint
+  endpoint="repos/${repository}/contents/${file_path}"
+  [[ -n $ref ]] && endpoint+="?ref=${ref}"
+  command gh api "$endpoint" --jq '.sha' 2>/dev/null
+}
+
+typeset -a stale=() unresolved=()
+typeset line repository file_path evidence commit pinned_blob head_blob
+integer checked=0
+
+while IFS=$'\t' read -r repository file_path evidence; do
+  [[ -n $repository ]] || continue
+  (( checked += 1 ))
+  commit="${${evidence#*/blob/}%%/*}"
+
+  pinned_blob="$(blob_at "$repository" "$file_path" "$commit")" || pinned_blob=""
+  head_blob="$(blob_at "$repository" "$file_path")" || head_blob=""
+
+  if [[ -z $pinned_blob || -z $head_blob ]]; then
+    unresolved+=( "${repository}/${file_path}" )
+    continue
+  fi
+  if [[ $pinned_blob != $head_blob ]]; then
+    stale+=( "${repository}/${file_path}"$'\t'"${commit}"$'\t'"${pinned_blob}"$'\t'"${head_blob}" )
+    continue
+  fi
+  (( quiet )) || print -r -- "current   ${repository}/${file_path}"
+done < <(jq -r '.consumers[] | [.repository, .path, .evidence] | @tsv' "$manifest_path")
+
+if (( ${#unresolved} )); then
+  print -u2 -r -- ""
+  print -u2 -r -- "Unresolvable evidence (moved, renamed, or private):"
+  for line in "${unresolved[@]}"; do
+    print -u2 -r -- "  ${line}"
+  done
+fi
+
+if (( ${#stale} )); then
+  print -u2 -r -- ""
+  print -u2 -r -- "Stale evidence pins (consumer file changed since the pinned commit):"
+  for line in "${stale[@]}"; do
+    print -u2 -r -- "  ${${(s:	:)line}[1]}"
+    print -u2 -r -- "    pinned commit : ${${(s:	:)line}[2]}"
+    print -u2 -r -- "    pinned blob   : ${${(s:	:)line}[3]}"
+    print -u2 -r -- "    current blob  : ${${(s:	:)line}[4]}"
+  done
+  print -u2 -r -- ""
+  print -u2 -r -- "Re-read each consumer, confirm the claimed surfaces still apply,"
+  print -u2 -r -- "then bump its evidence commit and evidence_reviewed."
+fi
+
+if (( ${#stale} || ${#unresolved} )); then
+  exit 1
+fi
+
+(( quiet )) || print -r -- ""
+print -r -- "public-contract-evidence: ${checked} consumer pins current"

--- a/scripts/public-contract-impact.zsh
+++ b/scripts/public-contract-impact.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 emulate -LR zsh
-setopt errexit nounset pipefail extendedglob
+setopt err_exit no_unset pipe_fail extended_glob
 
 typeset repository="."
 typeset manifest_path="contracts/public-contract-v1.json"

--- a/tests/archive-extraction.zsh
+++ b/tests/archive-extraction.zsh
@@ -35,6 +35,7 @@ prepare_unzip() {
   command mkdir -p -- "$shim_dir" || fail "create unzip shim directory"
   {
     print -r -- '#!/bin/sh'
+    print -r -- 'if [ "$1" = "-Z1" ]; then exec bsdtar -tf "$2"; fi'
     print -r -- 'exec bsdtar -xf "$2"'
   } >| "${shim_dir}/unzip" || fail "write unzip shim"
   command chmod +x -- "${shim_dir}/unzip" || fail "make unzip shim executable"
@@ -59,6 +60,8 @@ new_fixture() {
 
   print -r -- one >| "$REPLY/one/one.txt" || fail "write first payload"
   print -r -- two >| "$REPLY/two/two.txt" || fail "write second payload"
+  print -r -- one >| "$REPLY/one/order.txt" || fail "write first ordered payload"
+  print -r -- two >| "$REPLY/two/order.txt" || fail "write second ordered payload"
   command tar -cf "$REPLY/staging/one.tar" -C "$REPLY/one" . || fail "create first nested archive"
   command tar -cf "$REPLY/staging/two.tar" -C "$REPLY/two" . || fail "create second nested archive"
   (
@@ -93,6 +96,7 @@ prepare_unzip
   ziextract --auto >/dev/null || fail "extract nested archives"
   [[ -f one.txt ]] || fail "extract first nested payload"
   [[ -f two.txt ]] || fail "extract second nested payload"
+  [[ $(<order.txt) = two ]] || fail "extract nested archives in lexical order"
   [[ ! -e outer.bin ]] || fail "remove outer archive after success"
   [[ ! -e ._backup/two.tar ]] || fail "do not back up a nested sibling"
 ) || exit 1
@@ -107,7 +111,7 @@ pass "extract every nested archive"
   command mkdir -p -- "$shim_dir" || fail "create tar shim directory"
   {
     print -r -- '#!/bin/sh'
-    print -r -- 'if [ "$2" = "two.tar" ]; then exit 42; fi'
+    print -r -- 'case "$2" in two.tar|*/two.tar) [ "$1" = "-xf" ] && exit 42;; esac'
     print -r -- "exec ${(q)real_tar} \"\$@\""
   } >| "$shim_dir/tar" || fail "write tar shim"
   command chmod +x -- "$shim_dir/tar" || fail "make tar shim executable"
@@ -125,3 +129,80 @@ pass "extract every nested archive"
   [[ ! -e ._backup/two.tar ]] || fail "do not back up failed nested archive"
 ) || exit 1
 pass "preserve outer archive after nested failure"
+
+# Member paths are rejected before extraction when they can escape the target.
+(
+  new_fixture traversal
+  typeset fixture_root="$REPLY"
+  print -r -- escaped >| "$fixture_root/staging/payload" || fail "write traversal payload"
+  if (( ${+commands[bsdtar]} )); then
+    command bsdtar -cf "$fixture_root/work/traversal.tar" \
+      -s '|^payload$|../escaped.txt|' -C "$fixture_root/staging" payload || fail "create traversal archive"
+  else
+    command tar -cf "$fixture_root/work/traversal.tar" \
+      --transform='s|^payload$|../escaped.txt|' -C "$fixture_root/staging" payload || fail "create traversal archive"
+  fi
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter traversal fixture"
+
+  if ziextract traversal.tar --nobkp >/dev/null 2>&1; then
+    fail "traversal archive reports success"
+  fi
+  [[ -f traversal.tar ]] || fail "preserve rejected traversal archive"
+  [[ ! -e "$fixture_root/escaped.txt" ]] || fail "write traversal member outside target"
+) || exit 1
+pass "reject archive member traversal"
+
+# Promotion rejects an existing destination symlink instead of writing through it.
+(
+  new_fixture symlink-target
+  typeset fixture_root="$REPLY"
+  command mkdir -p -- "$fixture_root/staging/link" "$fixture_root/external" || fail "create symlink target fixture"
+  print -r -- unsafe >| "$fixture_root/staging/link/payload.txt" || fail "write symlink target payload"
+  command tar -cf "$fixture_root/work/target.tar" -C "$fixture_root/staging" link || fail "create symlink target archive"
+  command ln -s -- "$fixture_root/external" "$fixture_root/work/link" || fail "create destination symlink"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter symlink target fixture"
+
+  if ziextract target.tar --nobkp >/dev/null 2>&1; then
+    fail "unsafe destination target reports success"
+  fi
+  [[ -L link ]] || fail "replace destination symlink"
+  [[ ! -e "$fixture_root/external/payload.txt" ]] || fail "write through destination symlink"
+  [[ -f target.tar ]] || fail "preserve archive rejected for unsafe target"
+) || exit 1
+pass "reject unsafe destination symlinks"
+
+# Relative links that remain inside the extracted tree retain archive behavior.
+(
+  new_fixture safe-archive-link
+  typeset fixture_root="$REPLY"
+  print -r -- safe >| "$fixture_root/staging/payload.txt" || fail "write safe linked payload"
+  command ln -s -- payload.txt "$fixture_root/staging/linked.txt" || fail "create safe archive symlink"
+  command tar -cf "$fixture_root/work/safe-link.tar" -C "$fixture_root/staging" payload.txt linked.txt || \
+    fail "create safe archive link fixture"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter safe archive link fixture"
+
+  ziextract safe-link.tar --nobkp >/dev/null || fail "extract safe archive symlink"
+  [[ -L linked.txt && $(<linked.txt) = safe ]] || fail "preserve safe archive symlink"
+) || exit 1
+pass "preserve safe archive symlinks"
+
+# Links escaping the staged tree are rejected before any result is promoted.
+(
+  new_fixture unsafe-archive-link
+  typeset fixture_root="$REPLY"
+  command ln -s -- ../external "$fixture_root/staging/linked" || fail "create unsafe archive symlink"
+  command tar -cf "$fixture_root/work/unsafe-link.tar" -C "$fixture_root/staging" linked || \
+    fail "create unsafe archive link fixture"
+  load_zi "$fixture_root"
+  builtin cd -- "$fixture_root/work" || fail "enter unsafe archive link fixture"
+
+  if ziextract unsafe-link.tar --nobkp >/dev/null 2>&1; then
+    fail "escaping archive symlink reports success"
+  fi
+  [[ ! -e linked && ! -L linked ]] || fail "promote escaping archive symlink"
+  [[ -f unsafe-link.tar ]] || fail "preserve archive containing escaping symlink"
+) || exit 1
+pass "reject escaping archive symlinks"

--- a/tests/fixtures/plugin-standard-callbacks/plugin.plugin.zsh
+++ b/tests/fixtures/plugin-standard-callbacks/plugin.plugin.zsh
@@ -1,0 +1,9 @@
+@zsh-plugin-run-on-unload \
+  'builtin print -r -- "plugin-unload:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "plugin-unload:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_UNLOAD_RETURN:-0}'
+
+@zsh-plugin-run-on-update \
+  'builtin print -r -- "plugin-update:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "plugin-update:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_RETURN:-0}'

--- a/tests/fixtures/plugin-standard-callbacks/snippet.zsh
+++ b/tests/fixtures/plugin-standard-callbacks/snippet.zsh
@@ -1,0 +1,9 @@
+@zsh-plugin-run-on-unload \
+  'builtin print -r -- "snippet-unload:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "snippet-unload:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_UNLOAD_RETURN:-0}'
+
+@zsh-plugin-run-on-update \
+  'builtin print -r -- "snippet-update:first:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'builtin print -r -- "snippet-update:second:$PWD:$#:${(j:,:)@}" >> "$ZI_CALLBACK_LOG"' \
+  'return ${ZI_CALLBACK_RETURN:-0}'

--- a/tests/fixtures/public-contract/addition/zi.zsh
+++ b/tests/fixtures/public-contract/addition/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update|doctor"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/base/zi.zsh
+++ b/tests/fixtures/public-contract/base/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|load|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/breaking/zi.zsh
+++ b/tests/fixtures/public-contract/breaking/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|fetch|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/conditional/zi.zsh
+++ b/tests/fixtures/public-contract/conditional/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (
   pmodload() {

--- a/tests/fixtures/public-contract/dead-alias/zi.zsh
+++ b/tests/fixtures/public-contract/dead-alias/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|load|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/foreach/zi.zsh
+++ b/tests/fixtures/public-contract/foreach/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 foreach item (one)
   pmodload() {

--- a/tests/fixtures/public-contract/guards/zi.zsh
+++ b/tests/fixtures/public-contract/guards/zi.zsh
@@ -13,6 +13,20 @@ true || @zi-register-hook() {
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
+false && {
+  +zi-message() {
+    print -r -- "$@"
+  }
+}
+
+# FUNCTION: +zi-progress. [[[
+false && {
+  +zi-progress() {
+    print -r -- "$@"
+  }
+}
+
 # FUNCTION: pmodload. [[[
 true || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/multiple-renames/zi.zsh
+++ b/tests/fixtures/public-contract/multiple-renames/zi.zsh
@@ -13,6 +13,16 @@ ZI[cmd-list]="help|fetch|\
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() {
   print -r -- "$@"

--- a/tests/fixtures/public-contract/nested/zi.zsh
+++ b/tests/fixtures/public-contract/nested/zi.zsh
@@ -11,6 +11,16 @@ ZI[cmd-list]="help|load|update"
   local name="$1" type="$2" handler="$3" icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message() {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 outer_runtime() {
   helper_runtime() {

--- a/tests/fixtures/public-contract/one-line-functions/zi.zsh
+++ b/tests/fixtures/public-contract/one-line-functions/zi.zsh
@@ -7,6 +7,12 @@ ZI[cmd-list]="help|load|update"
 # FUNCTION: @zi-register-hook. [[[
 @zi-register-hook() { local name="$1" type="$2" handler="$3" icemods="$4"; }
 
+# FUNCTION: +zi-message. [[[
++zi-message() { print -r -- "$@"; }
+
+# FUNCTION: +zi-progress. [[[
++zi-progress() { print -r -- "$@"; }
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload() { print -r -- "$@"; }
 

--- a/tests/fixtures/public-contract/refactor/zi.zsh
+++ b/tests/fixtures/public-contract/refactor/zi.zsh
@@ -20,6 +20,16 @@ ZI[cmd-list]="update|help|\
   local icemods="$4"
 }
 
+# FUNCTION: +zi-message. [[[
++zi-message () {
+  print -r -- "$@"
+}
+
+# FUNCTION: +zi-progress. [[[
++zi-progress () {
+  print -r -- "$@"
+}
+
 # FUNCTION: pmodload. [[[
 (( ${+functions[pmodload]} )) || pmodload () {
   print -r -- "$@"

--- a/tests/hook-ownership.zsh
+++ b/tests/hook-ownership.zsh
@@ -1,0 +1,269 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Hook-ownership contract for plugin unload (z-shell/zi#108).
+#
+# Zi must record which standard add-zsh-hook entries a plugin registered, so
+# that unload removes exactly those and nothing else. Ownership is a property
+# of the registration, not of who defined the function: a plugin that
+# registers a function it did not define still owns that hook entry.
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-hook-ownership-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+integer failures=0
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  (( failures++ ))
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+# Membership test for a hook array named by $1.
+in_hook() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2"
+  local -a current=( "${(@P)array_name}" )
+  (( ${current[(I)$entry]} > 0 ))
+}
+
+assert_absent() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2" label="$3"
+  if in_hook "$array_name" "$entry"; then
+    fail "$label: \`$entry' still present in \$$array_name (${(j:,:)${(@P)array_name}})"
+    return 1
+  fi
+  return 0
+}
+
+assert_present() {
+  builtin emulate -L zsh
+  local array_name="$1" entry="$2" label="$3"
+  if in_hook "$array_name" "$entry"; then
+    return 0
+  fi
+  fail "$label: \`$entry' missing from \$$array_name (${(j:,:)${(@P)array_name}})"
+  return 1
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" \
+  "$temp_root/tmp" || { builtin print -u2 "not ok - create isolated environment"; exit 1 }
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gx TMPDIR="$temp_root/tmp"
+typeset -gAH ZI OPTS ICE ZI_SICE
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || { builtin print -u2 "not ok - source Zi"; exit 1 }
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || { builtin print -u2 "not ok - source autoload library"; exit 1 }
+builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || { builtin print -u2 "not ok - source install library"; exit 1 }
+unsetopt warn_create_global
+OPTS[opt_-q,--quiet]=1
+
+builtin autoload -Uz add-zsh-hook
+
+# Write a plugin fixture into the isolated plugins directory.
+make_plugin() {
+  builtin emulate -L zsh
+  local name="$1" body="$2"
+  local dir="${ZI[PLUGINS_DIR]}/owner---$name"
+  command mkdir -p -- "$dir" || return 1
+  builtin print -r -- "$body" >| "$dir/$name.plugin.zsh" || return 1
+  REPLY="$dir"
+}
+
+load_plugin() {
+  builtin emulate -L zsh
+  ICE=()
+  .zi-load owner "$1" >/dev/null
+}
+
+unload_plugin() {
+  builtin emulate -L zsh
+  unsetopt warn_create_global
+  .zi-unload owner "$1" -q >/dev/null
+}
+
+#
+# 1. Every standard hook array is cleaned, including the one the unfunction
+#    step never covered.
+#
+
+make_plugin all-arrays '
+builtin autoload -Uz add-zsh-hook
+owned_chpwd() { : }
+owned_precmd() { : }
+owned_preexec() { : }
+owned_periodic() { : }
+owned_addhistory() { return 0 }
+owned_exit() { : }
+owned_dirname() { return 1 }
+add-zsh-hook chpwd owned_chpwd
+add-zsh-hook precmd owned_precmd
+add-zsh-hook preexec owned_preexec
+add-zsh-hook periodic owned_periodic
+add-zsh-hook zshaddhistory owned_addhistory
+add-zsh-hook zshexit owned_exit
+add-zsh-hook zsh_directory_name owned_dirname
+' || fail "create all-arrays fixture"
+
+load_plugin all-arrays || fail "load all-arrays fixture"
+unload_plugin all-arrays
+
+integer all_arrays_ok=1
+assert_absent chpwd_functions owned_chpwd "all hook arrays" || all_arrays_ok=0
+assert_absent precmd_functions owned_precmd "all hook arrays" || all_arrays_ok=0
+assert_absent preexec_functions owned_preexec "all hook arrays" || all_arrays_ok=0
+assert_absent periodic_functions owned_periodic "all hook arrays" || all_arrays_ok=0
+assert_absent zshaddhistory_functions owned_addhistory "all hook arrays" || all_arrays_ok=0
+assert_absent zshexit_functions owned_exit "all hook arrays" || all_arrays_ok=0
+assert_absent zsh_directory_name_functions owned_dirname "all hook arrays" || all_arrays_ok=0
+(( all_arrays_ok )) && pass "unload removes plugin-owned entries from all seven standard hook arrays"
+
+#
+# 2. A plugin owns a hook entry it registered even for a function it did not
+#    define. The function itself must survive, because the plugin did not
+#    create it.
+#
+
+preexisting_helper() { : }
+
+make_plugin borrower '
+builtin autoload -Uz add-zsh-hook
+add-zsh-hook precmd preexisting_helper
+' || fail "create borrower fixture"
+
+load_plugin borrower || fail "load borrower fixture"
+unload_plugin borrower
+
+integer borrower_ok=1
+assert_absent precmd_functions preexisting_helper "borrowed registration" || borrower_ok=0
+if (( ! ${+functions[preexisting_helper]} )); then
+  fail "borrowed registration: unload deleted a function the plugin did not define"
+  borrower_ok=0
+fi
+(( borrower_ok )) && pass "unload removes a registration for a function the plugin did not define"
+
+#
+# 3. Entries owned by another actor are preserved: those present before the
+#    load, and those added after it.
+#
+
+user_before() { : }
+add-zsh-hook precmd user_before
+
+make_plugin coexist '
+builtin autoload -Uz add-zsh-hook
+coexist_hook() { : }
+add-zsh-hook precmd coexist_hook
+' || fail "create coexist fixture"
+
+load_plugin coexist || fail "load coexist fixture"
+
+user_after() { : }
+add-zsh-hook precmd user_after
+
+unload_plugin coexist
+
+integer coexist_ok=1
+assert_present precmd_functions user_before "foreign ownership" || coexist_ok=0
+assert_present precmd_functions user_after "foreign ownership" || coexist_ok=0
+assert_absent precmd_functions coexist_hook "foreign ownership" || coexist_ok=0
+(( coexist_ok )) && pass "unload preserves hook entries owned by the user before and after the load"
+
+add-zsh-hook -d precmd user_before 2>/dev/null
+add-zsh-hook -d precmd user_after 2>/dev/null
+
+#
+# 4. A hook entry the plugin removed during load is recorded, so that unload
+#    reports it rather than silently losing the user's registration. Removal
+#    can be intentional, so restoration is not asserted; unload only has to
+#    surface it. Like every Zi diff, the record is computed at unload, so the
+#    contract is asserted through unload's own output.
+#
+
+user_victim() { : }
+add-zsh-hook precmd user_victim
+
+make_plugin remover '
+builtin autoload -Uz add-zsh-hook
+add-zsh-hook -d precmd user_victim
+' || fail "create remover fixture"
+
+load_plugin remover || fail "load remover fixture"
+
+if in_hook precmd_functions user_victim; then
+  fail "removal record: fixture did not remove the user entry, test is not exercising the case"
+else
+  # Unqualified unload, so the report is not suppressed by -q.
+  typeset remover_output
+  unsetopt warn_create_global
+  remover_output="$(.zi-unload owner remover 2>&1)"
+  if [[ $remover_output == *user_victim*precmd_functions* ]]; then
+    pass "unload reports hook entries the plugin removed during load"
+  else
+    fail "removal record: unload did not report the removal of \`user_victim' from \$precmd_functions"
+  fi
+fi
+
+add-zsh-hook -d precmd user_victim 2>/dev/null
+
+#
+# 5. Repeated loads of the same plugin do not leave a stale hook entry behind
+#    after a single unload.
+#
+#    Start with every tracked array absent. Zi normally registers its scheduler
+#    in precmd_functions, which would make the first snapshot non-empty and
+#    conceal a bug that confuses "captured empty" with "not captured".
+#
+#    Scope: this asserts only the hook-ownership contract. Function ownership
+#    across repeated loads remains part of the broader per-load identity work
+#    coordinated in #113 and is deliberately not asserted here.
+#
+
+typeset hook_array
+for hook_array in "${ZI_ZSH_HOOKS_LIST[@]}"; do
+  unset -- "$hook_array"
+done
+
+make_plugin repeated '
+builtin autoload -Uz add-zsh-hook
+repeated_hook() { : }
+add-zsh-hook precmd repeated_hook
+' || fail "create repeated fixture"
+
+load_plugin repeated || fail "load repeated fixture (first)"
+load_plugin repeated || fail "load repeated fixture (second)"
+unload_plugin repeated
+
+if assert_absent precmd_functions repeated_hook "repeated load"; then
+  pass "a single unload clears hook entries left by repeated loads of one plugin"
+fi
+
+if (( failures )); then
+  builtin print -u2 -r -- "# $failures assertion(s) failed"
+  exit 1
+fi
+
+builtin print -r -- "# all hook-ownership assertions passed"
+exit 0

--- a/tests/message-formatting.zsh
+++ b/tests/message-formatting.zsh
@@ -1,0 +1,334 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -LR zsh
+builtin setopt pipe_fail extended_glob
+
+typeset project_root=${0:A:h:h}
+typeset temp_root
+temp_root=$(command mktemp -d "${TMPDIR:-/tmp}/zi-message-formatting.XXXXXXXX")
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+typeset -gx HOME=$temp_root/home
+typeset -gx ZDOTDIR=$temp_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$temp_root/cache
+typeset -gx XDG_CONFIG_HOME=$temp_root/config
+typeset -gx XDG_DATA_HOME=$temp_root/data
+typeset -gx TERM=xterm-256color
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+
+typeset -gAH ZI
+ZI[BIN_DIR]=$project_root
+builtin source "$project_root/zi.zsh" >/dev/null
+builtin setopt err_exit pipe_fail extended_glob
+
+fail() {
+  builtin print -ru2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin print -r -- "ok - $1"
+}
+
+assert_equal() {
+  [[ $1 == "$2" ]] || fail "$3: expected ${(qqq)2}, got ${(qqq)1}"
+}
+
+assert_contains() {
+  [[ $1 == *"$2"* ]] || fail "$3: ${(qqq)1} does not contain ${(qqq)2}"
+}
+
+assert_not_contains() {
+  [[ $1 != *"$2"* ]] || fail "$3: ${(qqq)1} unexpectedly contains ${(qqq)2}"
+}
+
+strip_ansi() {
+  REPLY=${1//$'\e'\[[0-9\;]#m/}
+}
+
+typeset sample output expected stdout_file stderr_file selected_file
+integer command_status output_fd
+stdout_file=$temp_root/stdout
+stderr_file=$temp_root/stderr
+selected_file=$temp_root/selected
+
+sample=$'tabs\tremain  doubled\nnew line {unknown} 100% -leading Unicode: λ sentinel: ←→ control: \e[31m'
+output=$(+zi-message -n --color=never -- "$sample")
+assert_equal "$output" "$sample" 'safe auto preserves unstyled bytes'
+pass 'safe auto preserves unstyled bytes'
+
+output=$(+zi-message -n --color=never --literal -- '{error}literal{rst} {auto}load')
+assert_equal "$output" '{error}literal{rst} {auto}load' 'literal mode bypasses markup and auto'
+pass 'literal mode bypasses markup and auto'
+
+output=$(+zi-message -n --color=never -- 'before {unknown} after')
+assert_equal "$output" 'before {unknown} after' 'unknown tags remain literal'
+pass 'unknown tags remain literal'
+
+output=$(+zi-message -n --color=never -- $'{profile}I have been loaded{nl}{auto}`Zi Rocks ♥`')
+assert_equal "$output" $'I have been loaded\n`Zi Rocks ♥`' 'existing wiki markup example'
+pass 'existing documented markup remains compatible'
+
+expected='See https://example.com/a-b?x=1#frag and ssh://user@example.com/repo; load --wait=1 in 1.5s with 42 and `two words`.'
+output=$(+zi-message -n --color=always -- "$expected")
+strip_ansi "$output"
+assert_equal "$REPLY" "$expected" 'safe auto preserves recognized text'
+assert_contains "$output" "${ZI[col-url]}https://example.com/a-b?x=1#frag${ZI[col-rst]}" 'HTTP URL style'
+assert_contains "$output" "${ZI[col-url]}ssh://user@example.com/repo${ZI[col-rst]}" 'SSH URL style'
+assert_contains "$output" "${ZI[col-cmd]}load${ZI[col-rst]}" 'Zi command style'
+assert_contains "$output" "${ZI[col-ice]}--wait=1${ZI[col-rst]}" 'ice style'
+assert_contains "$output" "${ZI[col-time]}1.5s${ZI[col-rst]}" 'duration style'
+assert_contains "$output" "${ZI[col-num]}42${ZI[col-rst]}" 'number style'
+assert_contains "$output" "${ZI[col-quo]}\`two words\`${ZI[col-rst]}" 'balanced quote style'
+assert_not_contains "$output" "${ZI[col-rst]}${ZI[col-rst]}" 'redundant trailing reset'
+pass 'safe auto recognizes deterministic forms'
+
+expected='ambiguous owner/repo usr/bin 1..2 ... are plain'
+output=$(+zi-message -n --color=always -- "$expected")
+assert_equal "$output" "$expected" 'safe auto rejects ambiguous forms'
+pass 'safe auto rejects ambiguous forms'
+
+zi_message_test_function() { :; }
+@zi-register-annex message-test subcommand:annexcmd message-test-handler '' annexice
+command mkdir -p -- "${ZI[PLUGINS_DIR]}/owner---repo" "$temp_root/existing-path"
+output=$(builtin cd -q -- "$temp_root" && +zi-message -n --color=always --auto=contextual -- 'print zi_message_test_function annexcmd --annexice=value owner/repo existing-path')
+assert_contains "$output" "${ZI[col-bcmd]}print${ZI[col-rst]}" 'contextual command style'
+assert_contains "$output" "${ZI[col-func]}zi_message_test_function${ZI[col-rst]}" 'contextual function style'
+assert_contains "$output" "${ZI[col-cmd]}annexcmd${ZI[col-rst]}" 'contextual annex command style'
+assert_contains "$output" "${ZI[col-ice]}--annexice=value${ZI[col-rst]}" 'contextual annex ice style'
+assert_contains "$output" "${ZI[col-pname]}owner/repo${ZI[col-rst]}" 'contextual plugin style'
+assert_contains "$output" "${ZI[col-file]}existing-path${ZI[col-rst]}" 'contextual path style'
+pass 'contextual auto recognizes shell and filesystem forms'
+
+output=$(+zi-message -n --color=always -- '{error}load{rst}')
+assert_contains "$output" "${ZI[col-error]}load" 'explicit tag style'
+assert_not_contains "$output" "${ZI[col-cmd]}load" 'explicit tag precedence'
+output=$(+zi-message -n --color=always -- '{error}load{rst} update')
+assert_contains "$output" "${ZI[col-cmd]}update${ZI[col-rst]}" 'reset resumes safe auto'
+output=$(+zi-message -n --color=always -- '{no-auto}load {auto}update')
+assert_not_contains "$output" "${ZI[col-cmd]}load${ZI[col-rst]}" 'inline no-auto mode'
+assert_contains "$output" "${ZI[col-cmd]}update${ZI[col-rst]}" 'inline safe auto mode'
+pass 'explicit tags take precedence over auto'
+
+output=$(+zi-message -n --color=always --auto=off --level=error -- 'level message')
+strip_ansi "$output"
+assert_equal "$REPLY" 'level message' 'semantic level text'
+assert_contains "$output" "$ZI[col-error]" 'semantic level style'
+pass 'semantic levels preserve text and apply style'
+
+typeset level level_style
+typeset -A expected_level_styles=(
+  debug dbg
+  info info
+  warn warn
+  error error
+  success happy
+)
+for level level_style in ${(kv)expected_level_styles}; do
+  output=$(+zi-message -n --color=always --auto=off --level="$level" -- message)
+  assert_contains "$output" "$ZI[col-$level_style]" "$level level style"
+  strip_ansi "$output"
+  assert_equal "$REPLY" message "$level level text"
+done
+output=$(+zi-message -n --color=always --auto=off --level=plain -- message)
+assert_equal "$output" message 'plain level does not add a style'
+pass 'all semantic levels have stable mappings'
+
+zstyle ':zi:message' auto off
+output=$(+zi-message -n --color=always -- load)
+assert_equal "$output" load 'zstyle disables auto'
+zstyle -d ':zi:message' auto
+pass 'zstyle configures default auto mode'
+
+zstyle ':zi:message' color never
+output=$(+zi-message -n -- load)
+assert_equal "$output" load 'zstyle disables color'
+zstyle -d ':zi:message' color
+pass 'zstyle configures default color mode'
+
+zstyle ':zi:message' auto invalid
+unsetopt err_exit
++zi-message message >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid zstyle auto mode did not return status 2'
+zstyle -d ':zi:message' auto
+zstyle ':zi:message' color invalid
+unsetopt err_exit
++zi-message message >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid zstyle color mode did not return status 2'
+zstyle -d ':zi:message' color
+pass 'invalid zstyle modes fail explicitly'
+
+typeset -gx NO_COLOR=1
+output=$(+zi-message -n --color=auto -- load)
+assert_equal "$output" load 'NO_COLOR disables automatic color'
+output=$(+zi-message -n --color=always -- load)
+assert_contains "$output" "$ZI[col-cmd]" 'explicit color overrides NO_COLOR'
+unset NO_COLOR
+pass 'color policy honors NO_COLOR and explicit override'
+
+typeset saved_term=$TERM
+typeset -gx TERM=dumb
+output=$(+zi-message -n --color=auto -- load)
+assert_equal "$output" load 'TERM dumb disables automatic color'
+typeset -gx TERM=$saved_term
+pass 'color policy honors TERM dumb'
+
+output=$(
+  TERM=xterm-color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/eight-home ZDOTDIR=$ZI_TEST_ROOT/eight-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/eight-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/eight-config XDG_DATA_HOME=$ZI_TEST_ROOT/eight-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+typeset key
+for key in ${(k)ZI}; do
+  [[ $key == col-* && ${ZI[$key]} == *'38;5'* ]] && builtin print -r -- "$key=${ZI[$key]}"
+done
+builtin true
+ZSH
+)
+assert_equal "$output" '' 'eight-color palette has no 256-color sequences'
+output=$(
+  TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/full-home ZDOTDIR=$ZI_TEST_ROOT/full-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/full-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/full-config XDG_DATA_HOME=$ZI_TEST_ROOT/full-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -rn -- "$ZI[col-url]"
+ZSH
+)
+assert_contains "$output" '38;5' '256-color palette'
+pass 'palette follows terminal color capability'
+
+output=$(
+  SOURCED=1 TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/sourced-home ZDOTDIR=$ZI_TEST_ROOT/sourced-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/sourced-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/sourced-config XDG_DATA_HOME=$ZI_TEST_ROOT/sourced-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -r -- "legacy=${ZI[col-url]-}"
++zi-message -n --color=always --auto=off -- '{url}https://example.com{rst}'
+ZSH
+)
+assert_equal "${${(f)output}[1]}" 'legacy=' 'SOURCED suppresses the legacy public palette'
+assert_contains "${${(f)output}[2]}" $'\e[' 'explicit color uses the private message palette'
+pass 'SOURCED compatibility does not weaken explicit message color'
+
+output=$(
+  TERM=xterm-256color ZI_TEST_ROOT=$temp_root ZI_TEST_PROJECT=$project_root zsh -f <<'ZSH'
+typeset -gx HOME=$ZI_TEST_ROOT/custom-home ZDOTDIR=$ZI_TEST_ROOT/custom-zdotdir
+typeset -gx XDG_CACHE_HOME=$ZI_TEST_ROOT/custom-cache XDG_CONFIG_HOME=$ZI_TEST_ROOT/custom-config XDG_DATA_HOME=$ZI_TEST_ROOT/custom-data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+typeset -gAH ZI
+ZI[BIN_DIR]=$ZI_TEST_PROJECT
+ZI[col-url]='custom-url-color'
+builtin source "$ZI_TEST_PROJECT/zi.zsh" >/dev/null
+builtin print -r -- "$ZI[col-url]"
+builtin print -r -- "$ZI[col-error]"
+ZSH
+)
+assert_equal "${${(f)output}[1]}" 'custom-url-color' 'partial palette customization'
+assert_contains "${${(f)output}[2]}" $'\e[' 'missing palette entries initialized'
+pass 'partial palette customization is preserved and completed'
+
+typeset saved_url_color=$ZI[col-url]
+ZI[col-url]='custom-url-color'
+builtin source "$project_root/zi.zsh" >/dev/null
+assert_equal "$ZI[col-url]" 'custom-url-color' 'reload preserves customized palette'
+ZI[col-url]=$saved_url_color
+builtin setopt err_exit pipe_fail extended_glob
+pass 'reload preserves customized palette'
+
+exec {output_fd}>| "$selected_file"
++zi-message -u "$output_fd" --color=never -- 'selected descriptor' >| "$stdout_file" 2>| "$stderr_file"
+exec {output_fd}>&-
+assert_equal "$(<"$selected_file")" 'selected descriptor' 'selected descriptor content'
+[[ ! -s $stdout_file ]] || fail 'selected descriptor leaked to stdout'
+[[ ! -s $stderr_file ]] || fail 'selected descriptor wrote to stderr'
+pass 'output and newline use only the selected descriptor'
+
+unsetopt err_exit
++zi-message -u 999 --color=never -- invalid >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status != 0 )) || fail 'invalid descriptor returned success'
+[[ ! -s $stdout_file ]] || fail 'invalid descriptor wrote to stdout'
+pass 'invalid descriptors return failure'
+
+unset zi_message_option_target
+unsetopt err_exit
++zi-message -vzi_message_option_target value >| "$stdout_file" 2>| "$stderr_file"
+command_status=$?
+setopt err_exit
+(( command_status == 2 )) || fail 'invalid option did not return status 2'
+(( ! ${+parameters[zi_message_option_target]} )) || fail 'invalid option created a parameter'
+pass 'strict option parsing prevents print option injection'
+
+output=$(+zi-message -n --color=never -- 'literal %F{red} percent')
+assert_equal "$output" 'literal %F{red} percent' 'percent text remains literal'
+output=$(+zi-message -n --color=never -- -leading)
+assert_equal "$output" -leading 'option boundary preserves leading hyphen'
+pass 'literal output does not perform prompt expansion'
+
++zi-message --color=never -- message >| "$stdout_file"
+assert_equal "$(command od -An -tx1 -v "$stdout_file" | tr -d ' \n')" 6d6573736167650a 'ordinary message terminator'
++zi-progress --color=never -- message >| "$stdout_file"
+assert_equal "$(command od -An -tx1 -v "$stdout_file" | tr -d ' \n')" 6d6573736167650d 'progress terminator'
+pass 'message and progress terminators are separated'
+
+typeset saved_columns=$COLUMNS
+integer COLUMNS=1
+output=$(+zi-message -n --color=always --auto=off -- '{bar}X')
+assert_contains "$output" "${ZI[col-bar]}${ZI[col-rst]}X" 'zero-width bar resets before following text'
+strip_ansi "$output"
+assert_equal "$REPLY" X 'zero-width bar text'
+integer COLUMNS=$saved_columns
+pass 'structural tags remain structural with empty output'
+
+output=$(+zi-message -n -l --color=never -- one two three)
+assert_equal "$output" $'one\ntwo\nthree' 'line mode'
+pass 'line mode preserves argument boundaries'
+
+typeset before_directory=$PWD
+typeset -g REPLY='caller reply'
+typeset -g MATCH='caller match'
+typeset -ga match=( 'caller match array' )
+unset 'ZI[__last-formatter-code]'
+() {
+  builtin emulate -L zsh
+  setopt ksh_arrays sh_word_split no_rc_quotes
+  typeset hostile_options=${(j:,:)${(ok)options}}
+  +zi-message -n --color=never -- 'caller state' >| "$stdout_file"
+  assert_equal "${(j:,:)${(ok)options}}" "$hostile_options" 'hostile options restored'
+  assert_equal "$PWD" "$before_directory" 'working directory restored'
+  assert_equal "$REPLY" 'caller reply' 'caller REPLY restored'
+  assert_equal "$MATCH" 'caller match' 'caller MATCH restored'
+  assert_equal "${(j: :)match}" 'caller match array' 'caller match array restored'
+  (( ! ${+ZI[__last-formatter-code]} )) || fail 'global formatter scratch was created'
+}
+pass 'caller state is preserved'
+
+if [[ ${ZI_MESSAGE_BENCHMARK:-0} == 1 ]]; then
+  zmodload zsh/datetime
+  typeset payload='Zi update --wait=1 from https://example.com/a-b?x=1#frag in 1.5s, then load `tree`.'
+  integer iterations=1000 index
+  float started=$EPOCHREALTIME elapsed microseconds_per_call
+  for (( index = 1; index <= iterations; ++index )); do
+    +zi-message -n --color=always -- "$payload" >/dev/null
+  done
+  elapsed=$(( EPOCHREALTIME - started ))
+  microseconds_per_call=$(( elapsed * 1000000.0 / iterations ))
+  (( microseconds_per_call < 1000.0 )) || fail "safe auto benchmark exceeded 1 ms: $microseconds_per_call us"
+  builtin printf 'ok - safe auto benchmark: %.1f us per call\n' $microseconds_per_call
+fi

--- a/tests/parallel-update.zsh
+++ b/tests/parallel-update.zsh
@@ -1,0 +1,221 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-parallel-update-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" || fail "create isolated environment"
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gAH ZI OPTS
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload library"
+
+new_case() {
+  builtin emulate -L zsh
+  local label="$1"
+  REPLY="$temp_root/$label"
+  command mkdir -p -- "$REPLY/snippets" "$REPLY/plugins" "$REPLY/tmp" ||
+    fail "create $label fixture"
+  ZI[SNIPPETS_DIR]="$REPLY/snippets"
+  ZI[PLUGINS_DIR]="$REPLY/plugins"
+  ZI[DEBUG_MODE]=0
+  OPTS=()
+  OPTS[value]=2
+  OPTS[opt_-q,--quiet]=1
+  OPTS[opt_-d,--debug]=0
+  OPTS[opt_-s,--snippets]=1
+  OPTS[opt_-l,--plugins]=0
+  typeset -gx TMPDIR="$REPLY/tmp"
+}
+
+add_snippet() {
+  builtin emulate -L zsh
+  local case_root="$1" name="$2" url="$3"
+  local metadata="$case_root/snippets/$name/._zi"
+  command mkdir -p -- "$metadata" || fail "create $name snippet metadata"
+  builtin print -r -- single >| "$metadata/mode" || fail "write $name mode"
+  builtin print -r -- "$url" >| "$metadata/url" || fail "write $name URL"
+}
+
+add_invalid_snippet() {
+  builtin emulate -L zsh
+  local case_root="$1" name="$2"
+  local metadata="$case_root/snippets/$name/._zi"
+  command mkdir -p -- "$metadata" || fail "create invalid $name metadata"
+  builtin print -r -- single >| "$metadata/mode" || fail "write invalid $name mode"
+}
+
+assert_temp_clean() {
+  builtin emulate -L zsh
+  local case_root="$1" label="$2"
+  local -a remaining=( "$case_root/tmp"/*(ND) )
+  (( ${#remaining} == 0 )) || fail "$label left temporary output behind"
+}
+
+run_parallel() {
+  builtin emulate -L zsh
+  local st=update
+  .zi-update-all-parallel
+}
+
+# A valid job followed by malformed metadata must still be reaped.
+(
+  new_case trailing-invalid
+  local case_root="$REPLY" completed="$REPLY/completed"
+  add_snippet "$case_root" a-valid https://example.invalid/valid
+  add_invalid_snippet "$case_root" z-invalid
+  .zi-update-or-status-snippet() {
+    command sleep 0.15
+    builtin print -r -- "$2" >> "$completed"
+  }
+  run_parallel >/dev/null || fail "trailing invalid metadata returned failure"
+  [[ -f $completed && "$(<$completed)" == https://example.invalid/valid ]] ||
+    fail "trailing invalid metadata allowed a live job to escape"
+  assert_temp_clean "$case_root" "trailing invalid metadata"
+) || exit 1
+pass "trailing invalid metadata does not skip the final wait"
+
+# A child failure must become the aggregate updater status and remain visible.
+(
+  new_case child-failure
+  local case_root="$REPLY"
+  add_snippet "$case_root" failing https://example.invalid/failing
+  .zi-update-or-status-snippet() {
+    builtin print -r -- "simulated update failure"
+    return 7
+  }
+  run_parallel >/dev/null
+  local update_rc=$?
+  (( update_rc == 7 )) || fail "child status 7 became $update_rc"
+  assert_temp_clean "$case_root" "child failure"
+) || exit 1
+pass "child failures propagate from the parallel updater"
+
+# The configured bound is an upper limit, not a threshold exceeded by one.
+(
+  new_case concurrency
+  local case_root="$REPLY" event_log="$REPLY/events"
+  local index
+  for index in {1..5}; do
+    add_snippet "$case_root" "$index" "https://example.invalid/$index"
+  done
+  .zi-update-or-status-snippet() {
+    builtin print -r -- start >> "$event_log"
+    command sleep 0.12
+    builtin print -r -- end >> "$event_log"
+  }
+  run_parallel >/dev/null || fail "bounded parallel update failed"
+  integer active=0 peak=0
+  local event
+  while IFS= builtin read -r event; do
+    if [[ $event == start ]]; then
+      (( ++active ))
+      (( active > peak )) && peak=$active
+    else
+      (( --active ))
+    fi
+  done < "$event_log"
+  (( peak == 2 && active == 0 )) ||
+    fail "parallel limit 2 observed peak $peak with $active unfinished: ${(j: :)${(@f)$(<$event_log)}}"
+  assert_temp_clean "$case_root" "bounded parallel update"
+) || exit 1
+pass "parallel updates honor the configured concurrency limit"
+
+# Snippet and plugin phases own separate complete job batches.
+(
+  new_case both-phases
+  local case_root="$REPLY" phase_log="$REPLY/phases"
+  OPTS[opt_-s,--snippets]=0
+  OPTS[opt_-l,--plugins]=0
+  add_snippet "$case_root" snippet https://example.invalid/snippet
+  command mkdir -p -- "$case_root/plugins/owner---plugin/._zi" || fail "create plugin fixture"
+  builtin print -r -- 1 >| "$case_root/plugins/owner---plugin/._zi/is_release" ||
+    fail "mark plugin fixture as a release"
+  .zi-update-or-status-snippet() {
+    builtin print -r -- snippet >> "$phase_log"
+  }
+  .zi-update-or-status() {
+    builtin print -r -- plugin >> "$phase_log"
+  }
+  run_parallel >/dev/null || fail "combined phases failed"
+  local -a phases=( "${(@f)$(<$phase_log)}" )
+  [[ "${(j: :)phases}" == "snippet plugin" ]] ||
+    fail "combined phases ran ${(j: :)phases}"
+  assert_temp_clean "$case_root" "combined phases"
+) || exit 1
+pass "snippet and plugin phases flush independently"
+
+# Output follows discovery order even when jobs complete out of order.
+(
+  new_case output-order
+  local case_root="$REPLY" output
+  add_snippet "$case_root" first https://example.invalid/first
+  add_snippet "$case_root" second https://example.invalid/second
+  .zi-update-or-status-snippet() {
+    [[ $2 == */first ]] && command sleep 0.12 || command sleep 0.01
+    builtin print -r -- "${2:t}"
+    builtin print -r -- 1 >| "$PUFILE.ind"
+  }
+  output="$(run_parallel)" || fail "ordered output update failed"
+  [[ $output == $'first\nsecond' ]] || fail "parallel output order was ${(qqq)output}"
+  assert_temp_clean "$case_root" "ordered output"
+) || exit 1
+pass "parallel output is deterministic"
+
+# Pattern captures are scoped and the temporary directory is removed on TERM.
+(
+  new_case interruption
+  local case_root="$REPLY" started="$REPLY/started" result="$REPLY/result"
+  add_snippet "$case_root" interrupted https://example.invalid/interrupted
+  builtin unset MATCH MBEGIN MEND
+  .zi-update-or-status-snippet() {
+    builtin print -r -- started >| "$started"
+    command sleep 10
+  }
+  (
+    run_parallel >/dev/null
+    builtin print -r -- $? >| "$result"
+  ) &
+  local updater_pid=$!
+  integer attempt=0
+  while [[ ! -f $started && attempt -lt 100 ]]; do
+    command sleep 0.02
+    (( ++attempt ))
+  done
+  [[ -f $started ]] || fail "interrupted child did not start"
+  builtin kill -TERM "$updater_pid" || fail "signal parallel updater"
+  wait "$updater_pid" || fail "interrupted updater wrapper failed"
+  [[ -f $result && "$(<$result)" == 143 ]] || fail "TERM status was not preserved"
+  (( ! ${+parameters[MATCH]} && ! ${+parameters[MBEGIN]} && ! ${+parameters[MEND]} )) ||
+    fail "pattern capture parameters leaked globally"
+  assert_temp_clean "$case_root" "interrupted update"
+) || exit 1
+pass "parallel updater scopes captures and cleans up after interruption"

--- a/tests/path-resolution.zsh
+++ b/tests/path-resolution.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit pipefail
+setopt err_exit pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset temp_root
@@ -61,7 +61,7 @@ assert_paths() {
 
 run_case() (
   builtin emulate -LR zsh
-  setopt errexit pipefail
+  setopt err_exit pipe_fail
 
   local label="$1" case_root="${temp_root}/$1"
   local source_path="$project_root/zi.zsh"

--- a/tests/path-resolution.zsh
+++ b/tests/path-resolution.zsh
@@ -244,6 +244,108 @@ run_case() (
   fi
 )
 
+run_manpath_case() (
+  builtin emulate -LR zsh
+  setopt err_exit pipe_fail
+
+  local label="$1" case_root="${temp_root}/manpath-$1"
+  local custom_manpath="$case_root/custom-man" expected_manpath
+  integer expected_count expected_export
+
+  command mkdir -p -- \
+    "$case_root/home" \
+    "$case_root/zdotdir" \
+    "$case_root/tmp" \
+    "$case_root/zi-home/prefix/man/man1" \
+    "$case_root/cache" \
+    "$case_root/config"
+
+  case "$label" in
+    unset)
+      expected_manpath="${case_root}/zi-home/prefix/man:"
+      expected_count=2
+      expected_export=0
+      ;;
+    export-only)
+      expected_manpath="${case_root}/zi-home/prefix/man:"
+      expected_count=2
+      expected_export=1
+      ;;
+    assigned-empty)
+      expected_manpath="${case_root}/zi-home/prefix/man:"
+      expected_count=2
+      expected_export=1
+      ;;
+    custom)
+      expected_manpath="${case_root}/zi-home/prefix/man:${custom_manpath}"
+      expected_count=2
+      expected_export=1
+      ;;
+    default-first)
+      expected_manpath="${case_root}/zi-home/prefix/man::${custom_manpath}"
+      expected_count=3
+      expected_export=1
+      ;;
+    default-last)
+      expected_manpath="${case_root}/zi-home/prefix/man:${custom_manpath}:"
+      expected_count=3
+      expected_export=1
+      ;;
+    *)
+      fail "unknown manpath case: $label"
+      ;;
+  esac
+
+  command env -u MANPATH zsh -f -c '
+    local project_root="$1" case_root="$2" label="$3"
+    local expected_manpath="$4" custom_manpath="$case_root/custom-man"
+    integer expected_count="$5" expected_export="$6"
+
+    typeset -gx HOME="$case_root/home"
+    typeset -gx ZDOTDIR="$case_root/zdotdir"
+    typeset -gx TMPDIR="$case_root/tmp"
+    unset XDG_DATA_HOME XDG_CACHE_HOME XDG_CONFIG_HOME
+    unset ZPFX XDG_ZI_HOME XDG_ZI_CACHE XDG_ZI_CONFIG
+
+    case "$label" in
+      unset) ;;
+      export-only) export MANPATH ;;
+      assigned-empty) typeset -gx MANPATH="" ;;
+      custom) typeset -gx MANPATH="$custom_manpath" ;;
+      default-first) typeset -gx MANPATH=":${custom_manpath}" ;;
+      default-last) typeset -gx MANPATH="${custom_manpath}:" ;;
+    esac
+
+    typeset -gAH ZI
+    ZI=()
+    ZI[BIN_DIR]="$project_root"
+    ZI[HOME_DIR]="$case_root/zi-home"
+    ZI[CACHE_DIR]="$case_root/cache"
+    ZI[CONFIG_DIR]="$case_root/config"
+    typeset -gx ZPFX="$case_root/zi-home/prefix"
+
+    builtin source "$project_root/zi.zsh" >/dev/null || exit 11
+    [[ $MANPATH == "$expected_manpath" ]] || {
+      builtin print -u2 -r -- "not ok - $label MANPATH: expected ${(qqq)expected_manpath}, got ${(qqq)MANPATH}"
+      exit 12
+    }
+    (( $#manpath == expected_count )) || {
+      builtin print -u2 -r -- "not ok - $label manpath element count: expected $expected_count, got $#manpath"
+      exit 13
+    }
+    if (( expected_export )); then
+      [[ ${(t)MANPATH} == *export* ]] || exit 14
+    else
+      [[ ${(t)MANPATH} != *export* ]] || exit 15
+    fi
+
+    builtin source "$project_root/zi.zsh" >/dev/null || exit 16
+    [[ $MANPATH == "$expected_manpath" ]] || exit 17
+    (( $#manpath == expected_count )) || exit 18
+  ' _ "$project_root" "$case_root" "$label" "$expected_manpath" "$expected_count" "$expected_export" || \
+    fail "$label manpath resolution"
+)
+
 typeset case_name
 for case_name in \
   explicit \
@@ -259,4 +361,15 @@ for case_name in \
   both-xdg-source; do
   run_case "$case_name"
   pass "$case_name path resolution"
+done
+
+for case_name in \
+  unset \
+  export-only \
+  assigned-empty \
+  custom \
+  default-first \
+  default-last; do
+  run_manpath_case "$case_name"
+  pass "$case_name manpath resolution"
 done

--- a/tests/plugin-standard-callbacks.zsh
+++ b/tests/plugin-standard-callbacks.zsh
@@ -1,0 +1,173 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root="${0:A:h:h}"
+typeset fixture_root="$project_root/tests/fixtures/plugin-standard-callbacks"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-plugin-callback-test.XXXXXXXX")" || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+assert_lines() {
+  builtin emulate -L zsh
+  local file="$1" label="$2"
+  shift 2
+  local -a actual=( "${(@f)$(<$file)}" )
+  local -a expected=( "$@" )
+  [[ "${(j:\n:)actual}" == "${(j:\n:)expected}" ]] ||
+    fail "$label: expected ${(qqq)${(j:\n:)expected}}, got ${(qqq)${(j:\n:)actual}}"
+}
+
+load_stored_ice() {
+  builtin emulate -L zsh
+  local object_id="$1"
+  local -a packed=( "${(z@)ZI_SICE[$object_id]}" )
+  (( ${#packed} > 1 && ${#packed} % 2 == 0 )) ||
+    fail "invalid packed ICE for $object_id"
+  ICE=( "${(Q)packed[@]}" )
+}
+
+command mkdir -p -- \
+  "$temp_root/home" \
+  "$temp_root/zdotdir" \
+  "$temp_root/data" \
+  "$temp_root/cache" \
+  "$temp_root/config" \
+  "$temp_root/tmp" || fail "create isolated environment"
+
+typeset -gx HOME="$temp_root/home"
+typeset -gx ZDOTDIR="$temp_root/zdotdir"
+typeset -gx XDG_DATA_HOME="$temp_root/data"
+typeset -gx XDG_CACHE_HOME="$temp_root/cache"
+typeset -gx XDG_CONFIG_HOME="$temp_root/config"
+typeset -gx TMPDIR="$temp_root/tmp"
+typeset -gx ZI_CALLBACK_LOG="$temp_root/callbacks.log"
+typeset -gx ZI_CALLBACK_RETURN=0
+typeset -gx ZI_CALLBACK_UNLOAD_RETURN=0
+typeset -gAH ZI OPTS ICE ZI_SICE
+ZI[BIN_DIR]="$project_root"
+builtin source "$project_root/zi.zsh" >/dev/null || fail "source Zi"
+builtin source "$project_root/lib/zsh/autoload.zsh" >/dev/null || fail "source autoload library"
+builtin source "$project_root/lib/zsh/install.zsh" >/dev/null || fail "source install library"
+unsetopt warn_create_global
+OPTS[opt_-q,--quiet]=1
+
+[[ $PMSPEC == *U* && $PMSPEC == *p* ]] ||
+  fail "PMSPEC does not advertise the implemented unload and update callbacks"
+pass "PMSPEC advertises both callback capabilities"
+
+# Registration outside an active load must fail even if a stale dynamic name exists.
+typeset -g id_as=stale/object
+ZI[CUR_USPL2]=
+ICE=()
+@zsh-plugin-run-on-unload ':' >/dev/null 2>&1
+integer unload_registration_rc=$?
+@zsh-plugin-run-on-update ':' >/dev/null 2>&1
+integer update_registration_rc=$?
+(( unload_registration_rc != 0 && update_registration_rc != 0 )) ||
+  fail "callback registration succeeded without an active object"
+(( ! ${+ICE[ps-on-unload]} && ! ${+ICE[ps-on-update]} )) ||
+  fail "rejected callback registration mutated ICE"
+[[ -z ${ZI_SICE[stale/object]} ]] || fail "rejected callback used a stale dynamic identity"
+pass "callback registration rejects missing active-load identity"
+
+# Load a regular plugin and verify exact persistence plus update execution.
+typeset plugin_id=owner/plugin
+typeset plugin_dir="${ZI[PLUGINS_DIR]}/owner---plugin"
+command mkdir -p -- "$plugin_dir" || fail "create regular plugin directory"
+command cp -- "$fixture_root/plugin.plugin.zsh" "$plugin_dir/plugin.plugin.zsh" ||
+  fail "copy regular plugin fixture"
+ICE=()
+.zi-load owner plugin light >/dev/null || fail "load regular plugin fixture"
+[[ -n ${ZI_SICE[$plugin_id]} && -z ${ZI_SICE[stale/object]} ]] ||
+  fail "regular plugin callbacks were not stored under $plugin_id"
+load_stored_ice "$plugin_id"
+[[ ${ICE[ps-on-unload]} == *plugin-unload:first*\;\ *plugin-unload:second*\;\ *ZI_CALLBACK_UNLOAD_RETURN* ]] ||
+  fail "regular plugin unload callback order was not preserved"
+[[ ${ICE[ps-on-update]} == *plugin-update:first*\;\ *plugin-update:second*\;\ *ZI_CALLBACK_RETURN* ]] ||
+  fail "regular plugin update callback order was not preserved"
+pass "regular plugin callbacks persist under the effective ID"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=23
+typeset original_pwd="$PWD"
+∞zi-ps-on-update-hook plugin owner plugin "$plugin_id" "$plugin_dir" atpull-post update:1 >/dev/null
+integer plugin_update_rc=$?
+(( plugin_update_rc == 23 )) || fail "regular plugin update callback returned $plugin_update_rc instead of 23"
+[[ $PWD == "$original_pwd" ]] || fail "regular plugin update callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "regular plugin update callback" \
+  "plugin-update:first:$plugin_dir:7:plugin,owner,plugin,$plugin_id,$plugin_dir,atpull-post,update:1" \
+  "plugin-update:second:$plugin_dir:7:plugin,owner,plugin,$plugin_id,$plugin_dir,atpull-post,update:1"
+pass "regular plugin update callback preserves order, cwd, arguments, and status"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=0
+ZI_CALLBACK_UNLOAD_RETURN=31
+unsetopt warn_create_global
+.zi-unload owner plugin -q >/dev/null
+integer plugin_unload_rc=$?
+(( plugin_unload_rc == 31 )) || fail "regular plugin unload callback returned $plugin_unload_rc instead of 31"
+[[ $PWD == "$original_pwd" ]] || fail "regular plugin unload callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "regular plugin unload callback" \
+  "plugin-unload:first:$plugin_dir:3:owner,plugin,-q" \
+  "plugin-unload:second:$plugin_dir:3:owner,plugin,-q"
+[[ -z ${ZI_REGISTERED_PLUGINS[(r)$plugin_id]} ]] || fail "regular plugin remained registered after unload"
+pass "regular plugin unload callback preserves order, cwd, and arguments"
+
+# Load a snippet, then exercise its persisted callbacks with the same manager
+# callback frames used by snippet update and unload execution.
+typeset snippet_id=snippet/effective
+typeset snippet_source="$fixture_root/snippet.zsh"
+ICE=()
+ICE[id-as]="$snippet_id"
+unsetopt warn_create_global
+.zi-load-snippet "$snippet_source" >/dev/null || fail "load snippet fixture"
+[[ -n ${ZI_SICE[$snippet_id]} && -z ${ZI_SICE[stale/object]} ]] ||
+  fail "snippet callbacks were not stored under $snippet_id"
+load_stored_ice "$snippet_id"
+[[ ${ICE[ps-on-unload]} == *snippet-unload:first*\;\ *snippet-unload:second*\;\ *ZI_CALLBACK_UNLOAD_RETURN* ]] ||
+  fail "snippet unload callback order was not preserved"
+[[ ${ICE[ps-on-update]} == *snippet-update:first*\;\ *snippet-update:second*\;\ *ZI_CALLBACK_RETURN* ]] ||
+  fail "snippet update callback order was not preserved"
+pass "snippet callbacks persist under the effective ID"
+
+.zi-get-object-path snippet "$snippet_id" >/dev/null || fail "resolve loaded snippet directory"
+typeset snippet_dir="$REPLY"
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_RETURN=29
+∞zi-ps-on-update-hook snippet "$snippet_source" "$snippet_id" "$snippet_dir" atpull-post update:1 >/dev/null
+integer snippet_update_rc=$?
+(( snippet_update_rc == 29 )) || fail "snippet update callback returned $snippet_update_rc instead of 29"
+[[ $PWD == "$original_pwd" ]] || fail "snippet update callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "snippet update callback" \
+  "snippet-update:first:$snippet_dir:6:snippet,$snippet_source,$snippet_id,$snippet_dir,atpull-post,update:1" \
+  "snippet-update:second:$snippet_dir:6:snippet,$snippet_source,$snippet_id,$snippet_dir,atpull-post,update:1"
+pass "snippet update callback preserves order, cwd, arguments, and status"
+
+: >| "$ZI_CALLBACK_LOG"
+ZI_CALLBACK_UNLOAD_RETURN=37
+.zi-run-plugin-standard-unload-callback "${ICE[ps-on-unload]}" "$snippet_dir" \
+  snippet "$snippet_source" "$snippet_id" "$snippet_dir" unload
+integer snippet_unload_rc=$?
+(( snippet_unload_rc == 37 )) || fail "snippet unload callback returned $snippet_unload_rc instead of 37"
+[[ $PWD == "$original_pwd" ]] || fail "snippet unload callback changed the caller cwd"
+assert_lines "$ZI_CALLBACK_LOG" "snippet unload callback" \
+  "snippet-unload:first:$snippet_dir:5:snippet,$snippet_source,$snippet_id,$snippet_dir,unload" \
+  "snippet-unload:second:$snippet_dir:5:snippet,$snippet_source,$snippet_id,$snippet_dir,unload"
+pass "snippet unload callback preserves order, cwd, arguments, and status"
+
+builtin unset id_as

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -122,6 +122,8 @@ assert_contains "$output" '`zpcompinit` was removed'
 assert_contains "$output" '`pmodload` was removed'
 assert_contains "$output" '`@zi-register-annex` was removed'
 assert_contains "$output" '`@zi-register-hook` was removed'
+assert_contains "$output" '`+zi-message` was removed'
+assert_contains "$output" '`+zi-progress` was removed'
 assert_contains "$output" '`extraction-policy`'
 print "ok - only manifested declaration guards are accepted"
 

--- a/tests/public-contract-impact.zsh
+++ b/tests/public-contract-impact.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 emulate -LR zsh
-setopt errexit nounset pipefail
+setopt err_exit no_unset pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset fixture_root="${project_root}/tests/fixtures/public-contract"

--- a/tests/scheduler-idle.zsh
+++ b/tests/scheduler-idle.zsh
@@ -1,0 +1,82 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+typeset project_root=${0:A:h:h}
+typeset temp_root
+temp_root=$(command mktemp -d "${TMPDIR:-/tmp}/zi-scheduler-idle.XXXXXXXX") || exit 1
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+typeset -gx HOME=$temp_root/home
+typeset -gx ZDOTDIR=$temp_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$temp_root/cache
+typeset -gx XDG_CONFIG_HOME=$temp_root/config
+typeset -gx XDG_DATA_HOME=$temp_root/data
+command mkdir -p -- "$HOME" "$ZDOTDIR"
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -ru2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  builtin emulate -L zsh
+  builtin print -r -- "ok - $1"
+}
+
+in_hook() {
+  builtin emulate -L zsh
+  local array_name=$1 entry=$2
+  local -a current=( "${(@P)array_name}" )
+  (( ${current[(I)$entry]} > 0 ))
+}
+
+clear_events() {
+  builtin emulate -L zsh
+  while (( ${#zsh_scheduled_events} )); do
+    sched -1 || return 1
+  done
+}
+
+typeset -gAH ZI
+ZI[BIN_DIR]=$project_root
+builtin source "$project_root/zi.zsh" >/dev/null || fail 'source Zi'
+zmodload zsh/sched || fail 'load scheduler module'
+clear_events || fail 'clear initial events'
+
+# The test exercises scheduler state, not ZLE descriptor integration.
+zle() { builtin emulate -L zsh; return 0; }
+
+in_hook precmd_functions @zi-scheduler || fail 'source registers the dormant precmd hook'
+@zi-scheduler || fail 'idle precmd check returns success'
+(( ${#zsh_scheduled_events} == 0 )) || fail 'idle precmd check armed a timer'
+[[ -n ${ZI[START_TIME]} ]] || fail 'idle precmd check did not initialize timing'
+in_hook precmd_functions @zi-scheduler || fail 'idle precmd hook was removed'
+in_hook chpwd_functions @zi-scheduler && fail 'idle scheduler registered a chpwd hook'
+pass 'idle scheduler stays dormant'
+
+ZI_TASKS+=( "$(( EPOCHSECONDS + 60 ))+0+1 p 1 _ owner/repo" )
+@zi-scheduler || fail 'pending task activates scheduler'
+(( ${#zsh_scheduled_events} == 1 )) || fail 'pending task did not arm one timer'
+in_hook chpwd_functions @zi-scheduler || fail 'active scheduler did not register chpwd hook'
+in_hook precmd_functions @zi-scheduler && fail 'active scheduler kept the precmd hook'
+pass 'pending work activates scheduler'
+
+clear_events || fail 'clear active event'
+ZI_TASKS=( '<no-data>' )
+@zi-scheduler following || fail 'drained scheduler returns success'
+(( ${#zsh_scheduled_events} == 0 )) || fail 'drained scheduler rearmed a timer'
+in_hook precmd_functions @zi-scheduler || fail 'drained scheduler did not restore precmd hook'
+in_hook chpwd_functions @zi-scheduler && fail 'drained scheduler kept chpwd hook'
+pass 'drained scheduler returns to dormant state'
+
+ZI_TASKS+=( "$(( EPOCHSECONDS + 60 ))+0+1 p 1 _ owner/repo" )
+@zi-scheduler || fail 'later task reactivates scheduler'
+(( ${#zsh_scheduled_events} == 1 )) || fail 'later task did not rearm scheduler'
+pass 'later work reactivates scheduler'
+
+clear_events || fail 'clear final event'

--- a/tests/self-update-reload.zsh
+++ b/tests/self-update-reload.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit pipefail
+setopt err_exit pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset git_bin="${commands[git]}"

--- a/tests/snippet-directory-mirror.zsh
+++ b/tests/snippet-directory-mirror.zsh
@@ -239,6 +239,38 @@ mirror "$github_url" -u legacy || fail "migrate GitHub Subversion working copy"
 [[ $(<"$install_parent/legacy/._zi/mirror-backend") = git-sparse ]] || fail "record migrated backend"
 pass "migrate existing GitHub Subversion directory"
 
+# Nested metadata symlinks are rejected before staging so metadata copying
+# cannot preserve a user-controlled link into a newly activated snapshot.
+command mkdir -p -- "$temp_root/external-metadata" || fail "create nested metadata symlink target"
+command ln -s -- "$temp_root/external-metadata" "$install_parent/installed/._zi/linked-entry" || \
+  fail "create nested metadata symlink fixture"
+if mirror "$github_url" -u installed >/dev/null 2>&1; then
+  fail "nested metadata symlink reports success"
+fi
+[[ -L "$install_parent/installed/._zi/linked-entry" ]] || fail "nested metadata symlink was replaced"
+[[ $(<"$install_parent/installed/example.plugin.zsh") = v2 ]] || fail "replace payload with unsafe metadata"
+command rm -f -- "$install_parent/installed/._zi/linked-entry" || fail "remove nested metadata symlink fixture"
+pass "reject nested metadata symlinks"
+
+# Repository-controlled symlinks are rejected before activation because a
+# sourced or executed link could escape the selected directory snapshot.
+command ln -s -- ../../modules/utility/init.zsh "$source_repo/plugins/example/unsafe-link" || \
+  fail "create source symlink fixture"
+"$real_git" -C "$source_repo" add plugins/example/unsafe-link
+"$real_git" -C "$source_repo" commit -qm "test: add unsafe directory symlink" || fail "commit source symlink fixture"
+"$real_git" -C "$source_repo" push -q "$remote_repo" main || fail "publish source symlink fixture"
+
+typeset migration_revision="$(<"$install_parent/legacy/._zi/mirror-revision")"
+if mirror "$github_url" -u legacy >/dev/null 2>&1; then
+  fail "source symlink reports success"
+fi
+[[ $(<"$install_parent/legacy/example.plugin.zsh") = v3 ]] || fail "preserve payload after source symlink rejection"
+[[ ! -e "$install_parent/legacy/unsafe-link" && ! -L "$install_parent/legacy/unsafe-link" ]] || \
+  fail "activate repository-controlled symlink"
+[[ $(<"$install_parent/legacy/._zi/mirror-revision") = $migration_revision ]] || \
+  fail "preserve revision after source symlink rejection"
+pass "reject repository-controlled symlinks"
+
 # GitHub URLs outside the supported legacy trunk shape fail closed instead of
 # falling through to Subversion, while other hosts retain Subversion behavior.
 if mirror https://github.com/example/project/tree/main/plugins/example "" unsupported >/dev/null 2>&1; then

--- a/tests/version-reporting.zsh
+++ b/tests/version-reporting.zsh
@@ -3,7 +3,7 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 builtin emulate -LR zsh
-setopt errexit nounset pipefail
+setopt err_exit no_unset pipe_fail
 
 typeset project_root="${0:A:h:h}"
 typeset temp_root
@@ -35,7 +35,7 @@ run_case() {
     ZI_TEST_EXPECTED="$expected" \
     zsh -f <<'ZSH' || fail "$label"
 builtin emulate -LR zsh
-setopt pipefail
+setopt pipe_fail
 
 typeset -gAH ZI
 ZI[BIN_DIR]="$ZI_TEST_CHECKOUT"

--- a/zi.zsh
+++ b/zi.zsh
@@ -1151,18 +1151,43 @@ builtin setopt noaliases
   ZI_EXTS2[$key${${(M)type#hook:}:+ ${ZI_EXTS2[seqno]}}]="${ZI_EXTS2[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} '' ${(q)icemods}"
   ZI_EXTS2[ice-mods]="${ZI_EXTS2[ice-mods]}${icemods:+|}$icemods"
 } # ]]]
-# FUNCTION: @zsh-plugin-run-on-update. [[[
+# FUNCTION: .zi-run-plugin-standard-unload-callback. [[[
+# Runs a persisted Plugin Standard unload callback in the current shell while
+# containing `return` to the callback frame and restoring the caller's cwd.
+.zi-run-plugin-standard-unload-callback() {
+  local callback="$1" callback_dir="$2" callback_oldcd="$PWD"
+  integer callback_rc
+  shift 2
+  () { builtin setopt local_options no_auto_pushd; builtin cd -q "$callback_dir"; } || return 1
+  () { eval "$callback"; } "$@"
+  callback_rc=$?
+  () { builtin setopt local_options no_auto_pushd; builtin cd -q "$callback_oldcd"; }
+  return "$callback_rc"
+} # ]]]
+# FUNCTION: @zsh-plugin-run-on-unload. [[[
 # The Plugin Standard required mechanism, see:
 # https://wiki.zshell.dev/community/zsh_plugin_standard
 @zsh-plugin-run-on-unload() {
+  builtin emulate -L zsh
+  local current_id="${ZI[CUR_USPL2]}"
+  if [[ -z $current_id ]]; then
+    builtin print -u2 -r -- "@zsh-plugin-run-on-unload: no plugin or snippet load is active"
+    return 1
+  fi
   ICE[ps-on-unload]="${(j.; .)@}"
-  .zi-pack-ice "$id_as" ""
+  .zi-pack-ice "$current_id" ""
 } # ]]]
 # FUNCTION: @zsh-plugin-run-on-update. [[[
 # The Plugin Standard required mechanism
 @zsh-plugin-run-on-update() {
+  builtin emulate -L zsh
+  local current_id="${ZI[CUR_USPL2]}"
+  if [[ -z $current_id ]]; then
+    builtin print -u2 -r -- "@zsh-plugin-run-on-update: no plugin or snippet load is active"
+    return 1
+  fi
   ICE[ps-on-update]="${(j.; .)@}"
-  .zi-pack-ice "$id_as" ""
+  .zi-pack-ice "$current_id" ""
 } # ]]]
 
 # Remaining functions.

--- a/zi.zsh
+++ b/zi.zsh
@@ -188,7 +188,12 @@ XDG_ZI_CONFIG=${~ZI[CONFIG_DIR]}
 
 if [[ -z ${manpath[(re)${ZI[MAN_DIR]}]} ]] && [[ -d ${ZI[MAN_DIR]} ]]; then
   typeset -gxU manpath
-  manpath=( "${ZI[MAN_DIR]}" "${manpath[@]}" )
+  if (( ${#manpath} )); then
+    manpath=( "${ZI[MAN_DIR]}" "${manpath[@]}" )
+  else
+    # An empty component keeps the system default manual paths available.
+    manpath=( "${ZI[MAN_DIR]}" "" )
+  fi
 fi
 
 if [[ -z ${cdpath[(re)${ZI[CDPATH_DIR]}]} ]] && [[ -d ${ZI[CDPATH_DIR]} ]]; then

--- a/zi.zsh
+++ b/zi.zsh
@@ -42,7 +42,7 @@ uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|mod
 [[ ! -e ${ZI[BIN_DIR]}/zi.zsh ]] && ZI[BIN_DIR]=
 ZI[ZERO]="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 
-[[ ! -o functionargzero || ${options[posixargzero]} = on || ${ZI[ZERO]} != */* ]] && ZI[ZERO]="${(%):-%N}"
+[[ ! -o function_argzero || ${options[posix_argzero]} = on || ${ZI[ZERO]} != */* ]] && ZI[ZERO]="${(%):-%N}"
 : ${ZI[BIN_DIR]:="${ZI[ZERO]:h}"}
 
 [[ ${ZI[BIN_DIR]} = \~* ]] && ZI[BIN_DIR]=${~ZI[BIN_DIR]}
@@ -313,7 +313,7 @@ ZI_ZLE_HOOKS_LIST=(
   paste-insert 1
 )
 
-builtin setopt noaliases
+builtin setopt no_aliases
 
 # ]]]
 
@@ -354,7 +354,7 @@ builtin setopt noaliases
 # run custom `autoload' function, that doesn't need FPATH.
 :zi-tmp-subst-autoload () {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
+  builtin setopt extended_glob warn_create_global typeset_silent rc_quotes
 
   local -a opts opts2 custom reply
   local func
@@ -401,7 +401,7 @@ builtin setopt noaliases
     # Real autoload doesn't touch function if it already exists.
     # Author of the idea of FPATH-clean autoloading: Bart Schaefer.
     if (( ${+functions[$func]} != 1 )) {
-      builtin setopt noaliases
+      builtin setopt no_aliases
       if [[ $func == /* ]] && is-at-least 5.4; then
         builtin autoload ${opts[@]} $func
         return $?
@@ -434,7 +434,7 @@ builtin setopt noaliases
           } else {
             eval "function ${(q)${custom[++count*2]}:-$func} {
               local body=\"\$(<${(qqq)sel}/${(qqq)func})\" body2
-              () { builtin setopt localoptions extendedglob
+              () { builtin setopt local_options extended_glob
                 body2=\"\${body##[[:space:]]#${func}[[:blank:]]#\(\)[[:space:]]#\{}\"
                 [[ \$body2 != \$body ]] && body2=\"\${body2%\}[[:space:]]#([$nl]#([[:blank:]]#\#[^$nl]#((#e)|[$nl]))#)#}\"
               }
@@ -473,7 +473,7 @@ builtin setopt noaliases
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-bindkey() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
 
   is-at-least 5.3 && .zi-add-report "${ZI[CUR_USPL2]}" "Bindkey ${(j: :)${(q+)@}}" || .zi-add-report "${ZI[CUR_USPL2]}" "Bindkey ${(j: :)${(q)@}}"
 
@@ -564,7 +564,7 @@ builtin setopt noaliases
     [[ ${ZI[DTRACE]} = 1 ]] && ZI[BINDKEYS___dtrace/_dtrace]+="$quoted "
   else
     # bindkey -A newkeymap main?
-    # Negative indices for KSH_ARRAYS immunity.
+    # Negative indices for ksh_arrays immunity.
     if [[ ${#opts} -eq 1 && ${+opts[-A]} = 1 && ${#pos} = 3 && ${pos[-1]} = main && ${pos[-2]} != -A ]]; then
       # Save a copy of main keymap.
       (( ZI[BINDKEY_MAIN_IDX] = ${ZI[BINDKEY_MAIN_IDX]:-0} + 1 ))
@@ -602,7 +602,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-zstyle() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob nowarncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob no_warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Zstyle $*"
   # Remember in order to perform the actual zstyle call.
   typeset -a pos
@@ -633,7 +633,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-alias() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Alias $*"
   # Remember to perform the actual alias call.
   typeset -a pos
@@ -674,7 +674,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zi-tmp-subst-zle() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Zle $*"
   # Remember to perform the actual zle call.
   typeset -a pos
@@ -727,7 +727,7 @@ builtin setopt noaliases
 # The hijacking is not only for reporting, but also to save compdef
 # calls so that `compinit' can be called after loading plugins.
 :zi-tmp-subst-compdef() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset
   .zi-add-report "${ZI[CUR_USPL2]}" "Saving \`compdef $*' for replay"
   ZI_COMPDEF_REPLAY+=( "${(j: :)${(q)@}}" )
 
@@ -792,7 +792,7 @@ builtin setopt noaliases
 # Turn off temporary substituting of functions completely for a given mode ("load", "light",
 # "light-b" (i.e. the `trackbinds' mode) or "compdef").
 .zi-tmp-subst-off() {
-  builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal typesetsilent noshortloops unset noaliases
+  builtin setopt local_options no_err_return no_err_exit extended_glob warn_create_global typeset_silent no_short_loops unset no_aliases
   local mode="$1"
   # Disable temporary substituting of functions only once.
   # Disable temporary substituting of functions only the way it was enabled first.
@@ -934,7 +934,7 @@ builtin setopt noaliases
 #
 .zi-any-to-user-plugin() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+reply}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+reply}:#0}:+warn_create_global}
   # Two components given?
   # That's a pretty fast track to call this function this way.
   if [[ -n $2 ]]; then
@@ -968,7 +968,7 @@ builtin setopt noaliases
 # FUNCTION: .zi-any-to-pid. [[[
 .zi-any-to-pid() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+REPLY}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+REPLY}:#0}:+warn_create_global}
 
   1=${~1} 2=${~2}
 
@@ -997,7 +997,7 @@ builtin setopt noaliases
 # Replaces parts of path with %HOME, etc.
 .zi-util-shands-path() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob typesetsilent noshortloops rcquotes ${${${+REPLY}:#0}:+warncreateglobal}
+  builtin setopt extended_glob typeset_silent no_short_loops rc_quotes ${${${+REPLY}:#0}:+warn_create_global}
 
   local -A map
   map=( \~ %HOME $HOME %HOME $ZI[SNIPPETS_DIR] %SNIPPETS $ZI[PLUGINS_DIR] %PLUGINS
@@ -1091,7 +1091,7 @@ builtin setopt noaliases
 # FUNCTION: @zi-substitute. [[[
 @zi-substitute() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops
   local -A ___subst_map
   ___subst_map=(
     "%ID%"   "${id_as_clean:-$id_as}"
@@ -1136,7 +1136,7 @@ builtin setopt noaliases
   ZI_EXTS[seqno]=$(( ${ZI_EXTS[seqno]:-0} + 1 ))
   ZI_EXTS[$key${${(M)type#hook:}:+ ${ZI_EXTS[seqno]}}]="${ZI_EXTS[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} ${(q)helphandler} ${(q)icemods}"
   () {
-    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
     integer index="${type##[%a-zA-Z:_!-]##}"
     ZI_EXTS[ice-mods]="${ZI_EXTS[ice-mods]}${icemods:+|}${(j:|:)${(@)${(@s:|:)icemods}/(#b)(#s)(?)/$index-$match[1]}}"
   }
@@ -1145,7 +1145,7 @@ builtin setopt noaliases
 # Registers the z-annex inside Zi.
 @zi-register-hook() {
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-    builtin setopt extendedglob nobanghist noshortloops typesetsilent warncreateglobal
+    builtin setopt extended_glob no_bang_hist no_short_loops typeset_silent warn_create_global
   local name="$1" type="$2" handler="$3" icemods="$4" key="zi ${(q)2}"
   ZI_EXTS2[seqno]=$(( ${ZI_EXTS2[seqno]:-0} + 1 ))
   ZI_EXTS2[$key${${(M)type#hook:}:+ ${ZI_EXTS2[seqno]}}]="${ZI_EXTS2[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} '' ${(q)icemods}"
@@ -1277,12 +1277,12 @@ builtin setopt noaliases
 .zi-set-m-func() {
   if [[ $1 == set ]]; then
     ZI[___m_bkp]="${functions[m]}"
-    builtin setopt noaliases
+    builtin setopt no_aliases
     functions[m]="${functions[+zi-message]}"
     builtin setopt aliases
   elif [[ $1 == unset ]]; then
     if [[ -n ${ZI[___m_bkp]} ]]; then
-      builtin setopt noaliases
+      builtin setopt no_aliases
       functions[m]="${ZI[___m_bkp]}"
       builtin setopt aliases
     else
@@ -1306,14 +1306,14 @@ builtin setopt noaliases
   # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@" within scripts that we `source`.
   builtin set --
   integer correct retval exists
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
   [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
     local -a precm
     precm=(
       builtin emulate
       ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
       ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
-      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
+      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o no_sh_glob -o brace_expand -o ksh_glob}}
       ${(s: :):-${${:-${(@s: :):--o}" "${(s: :)^ICE[opts]}}:#-o }}
       -c
     )
@@ -1364,7 +1364,7 @@ builtin setopt noaliases
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
     "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" \!atinit || return $(( 10 - $? ))
   done
-  (( ${+ICE[atinit]} )) && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  (( ${+ICE[atinit]} )) && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atinit-<-> <->]} )
   for key in "${reply[@]}"; do
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
@@ -1410,7 +1410,7 @@ builtin setopt noaliases
       (( 0 == retval )) && [[ $url = PZT::* || $url = https://github.com/sorin-ionescu/prezto/* ]] && zstyle ":prezto:module:${${id_as%/init.zsh}:t}" loaded 'yes'
     } else { [[ ${+ICE[silent]} -eq 1 || ${+ICE[pick]} -eq 1 && -z ${ICE[pick]} || ${ICE[pick]} = /dev/null ]] || { +zi-message "Snippet not loaded ({url}${id_as}{rst})"; retval=1; } }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for key in "${reply[@]}"; do
@@ -1422,8 +1422,8 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$save_url" "" "$id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
-    (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
+    (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
   elif [[ -n ${opts[(r)--command]} || ${ICE[as]} = command ]]; then
     [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]] && ICE[pick]="${id_as:t}"
     # Directory snippet - a directory and multiple files are possible.
@@ -1458,7 +1458,7 @@ builtin setopt noaliases
       ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"
       (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }
     fi
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for key in "${reply[@]}"; do
@@ -1470,14 +1470,14 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$save_url" "" "$id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
   fi
-  (( ${+ICE[atload]} )) && [[ ${ICE[atload][1]} != "!" ]] && { ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  (( ${+ICE[atload]} )) && [[ ${ICE[atload][1]} != "!" ]] && { ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atload-<-> <->]} )
   for key in "${reply[@]}"; do
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
@@ -1562,7 +1562,7 @@ builtin setopt noaliases
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
     "${___arr[5]}" plugin "$___user" "$___plugin" "$___id_as" "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}" \!atinit || return $(( 10 - $? ))
   done
-  [[ ${+ICE[atinit]} = 1 && $ICE[atinit] != '!'*   ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  [[ ${+ICE[atinit]} = 1 && $ICE[atinit] != '!'*   ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]}"; ((1)); } || eval "${ICE[atinit]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atinit-<-> <->]} )
   for ___key in "${reply[@]}"; do
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
@@ -1591,14 +1591,14 @@ builtin setopt noaliases
   local ___pbase="${${___plugin:t}%(.plugin.zsh|.zsh|.git)}" ___key
   # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@" within scripts that we `source`.
   builtin set --
-  [[ -o ksharrays ]] && ___correct=1
+  [[ -o ksh_arrays ]] && ___correct=1
   [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
     local -a ___precm
     ___precm=(
       builtin emulate
       ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
       ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
-      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
+      ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o no_sh_glob -o brace_expand -o ksh_glob}}
       ${(s: :):-${${:-${(@s: :):--o}" "${(s: :)^ICE[opts]}}:#-o }}
       -c
     )
@@ -1635,9 +1635,9 @@ builtin setopt noaliases
       fi
     }
     local ZERO
-    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit#!]}"; ((1)); } || eval "${ICE[atinit]#!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit#!]}"; ((1)); } || eval "${ICE[atinit]#!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$___pdir_orig/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local ___fname; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; local ___fname; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for ___key in "${reply[@]}"; do
@@ -1649,9 +1649,9 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$___user" "$___plugin" "$___id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt noaliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
@@ -1674,11 +1674,11 @@ builtin setopt noaliases
     # We need some state, but ___user wants his for his plugins.
     (( ${+ICE[blockf]} )) && { local -a fpath_bkp; fpath_bkp=( "${fpath[@]}" ); }
     local ZERO="$___pdir_path/$___fname"
-    (( ${+ICE[aliases]} )) || builtin setopt noaliases
-    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]#!}"; ((1)); } || eval "${ICE[atinit]#1}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    (( ${+ICE[aliases]} )) || builtin setopt no_aliases
+    [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit]#!}"; ((1)); } || eval "${ICE[atinit]#1}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }
     [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$___pdir_orig/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; }
-    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); } done; }
+    [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); } done; }
     # Run the atload hooks right before atload ice.
     reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
     for ___key in "${reply[@]}"; do
@@ -1690,13 +1690,13 @@ builtin setopt noaliases
       (( ${+functions[.zi-service]} )) || builtin source "${ZI[BIN_DIR]}/lib/zsh/additional.zsh"
       .zi-wrap-functions "$___user" "$___plugin" "$___id_as"
     }
-    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+    [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     (( ZI[ALIASES_OPT] )) && builtin setopt aliases
     (( ${+ICE[blockf]} )) && { fpath=( "${fpath_bkp[@]}" ); }
     .zi-tmp-subst-off "${___mode:-load}"
     [[ $___mode != light(|-b) ]] && .zi-diff "${ZI[CUR_USPL2]}" end
   fi
-  [[ ${+ICE[atload]} = 1 && ${ICE[atload][1]} != "!" ]] && { ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; }
+  [[ ${+ICE[atload]} = 1 && ${ICE[atload][1]} != "!" ]] && { ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]}"; ((1)); } || eval "${ICE[atload]}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:atload-<-> <->]} )
   for ___key in "${reply[@]}"; do
     ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
@@ -1783,7 +1783,7 @@ builtin setopt noaliases
     (( ___nolast )) && { builtin print -r "$1" >! ${ZI[BIN_DIR]}/last-run-object.txt; }
     ZI[last-run-plugin]="$1"
     eval "${@[2-correct,-1]}"
-    () { builtin setopt localoptions noautopushd; builtin cd -q "$___oldpwd"; }
+    () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldpwd"; }
   else
     +zi-message "{u-warn}Error{b-warn}:{rst} no such plugin or snippet."
   fi
@@ -1865,7 +1865,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: .zi-formatter-pid. [[[
 .zi-formatter-pid() {
-  builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   # Save whitespace location
   local pbz=${(M)1##(#s)[[:space:]]##}
   local kbz=${(M)1%%[[:space:]]##(#e)}
@@ -1900,7 +1900,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: .zi-formatter-url. [[[
 .zi-formatter-url() {
-  builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   #              1:proto        3:domain/5:start      6:end-of-it         7:no-dot-domain        9:file-path
   if [[ $1 = (#b)([^:]#)(://|::)((([[:alnum:]._+-]##).([[:alnum:]_+-]##))|([[:alnum:].+_-]##))(|/(*)) ]] {
     # The advanced coloring if recognized the format…
@@ -2032,7 +2032,7 @@ builtin setopt noaliases
 # Parses ICE specification, puts the result into ICE global hash. The ice-spec is valid for
 # next command only (i.e. it "melts"), but it can then stick to plugin and activate e.g. at update.
 .zi-ice() {
-  builtin setopt localoptions noksharrays extendedglob warncreateglobal typesetsilent noshortloops
+  builtin setopt local_options no_ksh_arrays extended_glob warn_create_global typeset_silent no_short_loops
   integer retval
   local bit exts="${(j:|:)${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}}"
   for bit; do
@@ -2082,7 +2082,7 @@ return retval
 } # ]]]
 # FUNCTION: .zi-setup-params. [[[
 .zi-setup-params() {
-  builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
   reply=( ${(@)${(@s.;.)ICE[param]}/(#m)*/${${MATCH%%(-\>|→|=\>)*}//((#s)[[:space:]]##|[[:space:]]##(#e))}${${(M)MATCH#*(-\>|→|=\>)}:+\=${${MATCH#*(-\>|→|=\>)}//((#s)[[:space:]]##|[[:space:]]##(#e))}}} )
   (( ${#reply} )) && return 0 || return 1
 } # ]]]
@@ -2207,7 +2207,7 @@ return retval
 @zi-scheduler() {
   integer ___ret="${${ZI[lro-data]%:*}##*:}"
   # lro stands for lastarg-retval-option.
-  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[printexitvalue]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
+  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
   [[ -n $1 && $1 != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
   [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
   ZI[START_TIME]="${ZI[START_TIME]:-$EPOCHREALTIME}"
@@ -2216,12 +2216,12 @@ return retval
   local -a match mbegin mend reply
   local MATCH REPLY AFD; integer MBEGIN MEND
 
-  [[ -o ksharrays ]] && correct=1
+  [[ -o ksh_arrays ]] && correct=1
 
   if [[ -n $1 ]] {
     if [[ ${#ZI_RUN} -le 1 || $1 = following ]]  {
       () {
-        builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+        builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
         # Example entry:
         # 1531252764+2+1 p 18 light z-shell/zsh-diff-so-fancy
         #
@@ -2262,13 +2262,13 @@ return retval
     add-zsh-hook -d -- precmd @zi-scheduler
     add-zsh-hook -- chpwd @zi-scheduler
     () {
-      builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+      builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
       # No "+" in this pattern, it will match only "1531252764" in "1531252764+2" and replace it with current time.
       ZI_TASKS=( ${ZI_TASKS[@]/(#b)([0-9]##)(*)/$(( ${match[1]} <= 1 ? ${match[1]} : ___t ))${match[2]}} )
     }
     # There's a bug in Zsh: first sched call would not be issued until a key-press,
     # if "sched +1 ..." would be called inside zle -F handler. So it's done here, in precmd-handle code.
-    sched +1 'ZI[lro-data]="$_:$?:${options[printexitvalue]}"; @zi-scheduler following ${ZI[lro-data]%:*:*}'
+    sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following ${ZI[lro-data]%:*:*}'
 
     AFD=13371337 # for older Zsh + noclobber option
     exec {AFD}< <(LANG=C command sleep 0.002; builtin print run;)
@@ -2324,7 +2324,7 @@ zi() {
     local -a reply; local REPLY
   }
 
-  [[ -o ksharrays ]] && ___correct=1
+  [[ -o ksh_arrays ]] && ___correct=1
 
   local -A ___opt_map OPTS
   ___opt_map=(
@@ -2406,7 +2406,7 @@ zi() {
       integer  ___is_snippet
       # Classic syntax -> simulate a call through the for-syntax.
       () {
-        builtin setopt localoptions extendedglob
+        builtin setopt local_options extended_glob
         : ${@[@]//(#b)([ $'\t']##|(#s))(-b|--command|-f|--force)([ $'\t']##|(#e))/${OPTS[${match[2]}]::=1}}
       } "$@"
       builtin set -- "${@[@]:#(-b|--command|-f|--force)}"
@@ -2471,7 +2471,7 @@ zi() {
           [[ ${ICE[id-as]} = (auto|) && ${+ICE[id-as]} == 1 ]] && ICE[id-as]="${___etid:t}"
           integer  ___is_snippet=${${(M)___is_snippet:#-1}:-0}
           () {
-            builtin setopt localoptions extendedglob
+            builtin setopt local_options extended_glob
             if [[ $___is_snippet -ge 0 && ( -n ${ICE[is-snippet]+1} || $___etid = ((#i)(http(s|)|ftp(s|)):/|(${(~kj.|.)ZI_1MAP}))* ) ]] {
               ___is_snippet=1
             }
@@ -2536,7 +2536,7 @@ zi() {
 
           if [[ ${reply[-1]} -eq 1 && -n ${ICE[trigger-load]} ]] {
             () {
-              builtin setopt localoptions extendedglob
+              builtin setopt local_options extended_glob
               local ___mode
               (( ___is_snippet > 0 )) && ___mode=snippet || ___mode="${${${ICE[light-mode]+light}}:-load}"
               for MATCH ( ${(s.;.)ICE[trigger-load]} ) {
@@ -2607,7 +2607,7 @@ zi() {
 
     if (( ___error )) {
       () {
-        builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+        builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
         +zi-message -n "{u-warn}Error{b-warn}:{rst} No plugin or snippet ID given"
         if [[ -n $___last_ice ]] {
           +zi-message -n " (the last recognized ice was: {ice}"\
@@ -2866,7 +2866,7 @@ zi() {
           .zi-ls "$@"
           ;;
         (srv)
-          () { builtin setopt localoptions extendedglob warncreateglobal
+          () { builtin setopt local_options extended_glob warn_create_global
           [[ ! -e ${ZI[SERVICES_DIR]}/"$2".fifo ]] && { builtin print "No such service: $2"; } ||
             { [[ $3 = (#i)(next|stop|quit|restart) ]] &&
               { builtin print "${(U)3}" >>! ${ZI[SERVICES_DIR]}/"$2".fifo || builtin print "Service $2 inactive"; ___retval=1; } ||

--- a/zi.zsh
+++ b/zi.zsh
@@ -345,6 +345,20 @@ fi
   fi
 }
 
+# List of standard add-zsh-hook arrays whose entries are tracked per plugin.
+# Ownership is a property of the registration, not of who defined the function,
+# so these are diffed across a load rather than inferred from function deletion.
+typeset -gaH ZI_ZSH_HOOKS_LIST
+ZI_ZSH_HOOKS_LIST=(
+  chpwd_functions
+  precmd_functions
+  preexec_functions
+  periodic_functions
+  zshaddhistory_functions
+  zshexit_functions
+  zsh_directory_name_functions
+)
+
 # List of hooks.
 typeset -gAH ZI_ZLE_HOOKS_LIST
 ZI_ZLE_HOOKS_LIST=(
@@ -946,6 +960,38 @@ builtin setopt no_aliases
     ZI[PARAMETERS_AFTER__$1]+=" ${(j: :)${(qkv)parameters[@]}}"
   }
 } # ]]]
+# FUNCTION: .zi-diff-hooks. [[[
+# Implements detection of changes to the standard add-zsh-hook arrays.
+# Performs data gathering, computation is done in *-compute().
+#
+# Each snapshot records every tracked array as "array:entry" pairs, so a
+# registration is attributed to the plugin that made it regardless of which
+# actor defined the underlying function.
+#
+# $1 - user/plugin (i.e. uspl2 format)
+# $2 - command, can be "begin" or "end"
+.zi-diff-hooks() {
+  builtin emulate -L zsh -o no_ksh_arrays
+  local hook_array entry
+  typeset -a snapshot
+  for hook_array in "${ZI_ZSH_HOOKS_LIST[@]}"; do
+    (( ${(P)+hook_array} )) || continue
+    for entry in "${(@P)hook_array}"; do
+      snapshot+=( "${(q)hook_array}:${(q)entry}" )
+    done
+  done
+  if [[ $2 = begin ]]; then
+    # Snapshot presence is tracked separately because an empty hook set is a
+    # valid baseline. Keep the first baseline across overwrite-loads so one
+    # unload still owns entries added by the first load.
+    if [[ -z ${ZI[ZSH_HOOKS_DIFFED__$1]} ]]; then
+      ZI[ZSH_HOOKS_BEFORE__$1]="${snapshot[*]}"
+      ZI[ZSH_HOOKS_DIFFED__$1]=1
+    fi
+  else
+    ZI[ZSH_HOOKS_AFTER__$1]="${snapshot[*]}"
+  fi
+} # ]]]
 # FUNCTION: .zi-diff. [[[
 # Performs diff actions of all types
 .zi-diff() {
@@ -953,6 +999,7 @@ builtin setopt no_aliases
   .zi-diff-options "$1" "$2"
   .zi-diff-env "$1" "$2"
   .zi-diff-parameter "$1" "$2"
+  .zi-diff-hooks "$1" "$2"
 } # ]]]
 
 #

--- a/zi.zsh
+++ b/zi.zsh
@@ -2489,10 +2489,18 @@ return retval
 @zi-scheduler() {
   integer ___ret="${${ZI[lro-data]%:*}##*:}"
   # lro stands for lastarg-retval-option.
-  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
   [[ -n $1 && $1 != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
   [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
   ZI[START_TIME]="${ZI[START_TIME]:-$EPOCHREALTIME}"
+  if (( ${#ZI_TASKS} <= 1 && ${#ZI_RUN} == 0 )); then
+    # Keep the prompt hook dormant so a later Zi command can reactivate the scheduler.
+    if [[ -n $1 ]]; then
+      add-zsh-hook -d -- chpwd @zi-scheduler
+      add-zsh-hook -- precmd @zi-scheduler
+    fi
+    [[ ${ZI[lro-data]##*:} = on ]] && return 0 || return ___ret
+  fi
+  [[ $1 = following ]] && sched +1 'ZI[lro-data]="$_:$?:${options[print_exit_value]}"; @zi-scheduler following "${ZI[lro-data]%:*:*}"'
 
   integer ___t=EPOCHSECONDS ___i correct
   local -a match mbegin mend reply

--- a/zi.zsh
+++ b/zi.zsh
@@ -258,18 +258,32 @@ ZI_2MAP=(
 # Initiate. [[[
 zmodload zsh/zutil || { builtin print -P "%F{196}zsh/zutil module is required, aborting ❮ Zi ❯ set up.%f"; return 1; }
 zmodload zsh/parameter || { builtin print -P "%F{196}zsh/parameter module is required, aborting ❮ Zi ❯ set up.%f"; return 1; }
-zmodload zsh/terminfo 2>/dev/null
-zmodload zsh/termcap 2>/dev/null
+zmodload zsh/terminfo 2>/dev/null || builtin true
+zmodload zsh/termcap 2>/dev/null || builtin true
 
-# Terminal color codes.
-if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+termcap} -eq 1 && -n ${termcap[Co]} ) ]] {
-  ZI+=(
+# Terminal color codes. Keep a complete private palette so an explicit
+# --color=always request works even when Zi was sourced from a non-terminal.
+# The public ZI palette retains the legacy SOURCED suppression used by direct
+# consumers; +zi-message overlays missing entries only for its dynamic scope.
+typeset -gAH ZI_MESSAGE_PALETTE
+typeset -g ZI_MESSAGE_PUBLIC_PALETTE_READY
+if [[ ${ZI[term-colors]} != <-> ]]; then
+  ZI[term-colors]=0
+  [[ ${terminfo[colors]} == <-> ]] && ZI[term-colors]=${terminfo[colors]}
+  [[ ${termcap[Co]} == <-> && ${termcap[Co]} -gt ${ZI[term-colors]} ]] && ZI[term-colors]=${termcap[Co]}
+fi
+() {
+  builtin emulate -L zsh
+  local key
+  local -A palette
+
+  palette=(
   col-annex   $'\e[38;5;165m'      col-info    $'\e[38;5;82m'       col-p       $'\e[38;5;81m'
   col-apo     $'\e[1;38;5;220m'    col-info2   $'\e[38;5;220m'      col-pkg     $'\e[1;3;38;5;27m'
   col-b       $'\e[1m'             col-info3   $'\e[1m\e[38;5;220m' col-pname   $'\e[1;4m\e[32m'
   col-aps     $'\e[38;5;117m'      col-baps    $'\e[1;38;5;82m'     col-pre     $'\e[38;5;93m'
   col-bar     $'\e[38;5;82m'       col-bcmd    $'\e[38;5;220m'      col-profile $'\e[38;5;201m'
-  col-bspc    $'\b'                col-bapo    $'\e[1;39;5;220m'    col-keyword $'\e[32m'
+  col-bspc    $'\b'                col-bapo    $'\e[1;38;5;220m'    col-keyword $'\e[32m'
   col-b-lhi   $'\e[1m\e[38;5;27m'  col-lhi     $'\e[38;5;33m'       col-slight  $'\e[38;5;230m'
   col-b-warn  $'\e[1;38;5;214m'    col-msg     $'\e[0m'             col-st      $'\e[9m'
   col-cmd     $'\e[38;5;82m'       col-msg2    $'\e[38;5;172m'      col-tab     $' \t '
@@ -295,9 +309,40 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
   col-…     "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
   col--…    "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
   )
-  if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 ) ]] {
-    ZI+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
-  }
+  if (( ${ZI[term-colors]} < 256 )); then
+    palette+=(
+    col-annex   $'\e[35m'      col-info    $'\e[32m'      col-p       $'\e[36m'
+    col-apo     $'\e[1;33m'    col-info2   $'\e[33m'      col-pkg     $'\e[1;3;34m'
+    col-aps     $'\e[36m'      col-bapo    $'\e[1;33m'    col-baps    $'\e[1;32m'
+    col-bar     $'\e[32m'      col-bcmd    $'\e[33m'      col-info3   $'\e[1;33m'
+    col-msg2    $'\e[33m'      col-msg3    $'\e[90m'      col-pre     $'\e[35m'
+    col-profile $'\e[35m'      col-term    $'\e[33m'
+    col-b-lhi   $'\e[1;34m'    col-lhi     $'\e[34m'      col-slight  $'\e[37m'
+    col-b-warn  $'\e[1;33m'    col-cmd     $'\e[32m'      col-data    $'\e[32m'
+    col-data2   $'\e[36m'      col-meta    $'\e[36m'      col-th-bar  $'\e[32m'
+    col-dir     $'\e[3;35m'    col-meta2   $'\e[35m'      col-txt     $'\e[37m'
+    col-ehi     $'\e[1;31m'    col-error   $'\e[1;31m'    col-failure $'\e[31m'
+    col-faint   $'\e[90m'      col-note    $'\e[33m'      col-url     $'\e[34m'
+    col-file    $'\e[3;36m'    col-u-warn  $'\e[4;33m'    col-func    $'\e[35m'
+    col-uname   $'\e[1;4;35m'  col-uninst  $'\e[32m'      col-var     $'\e[36m'
+    col-flag    $'\e[1;3;32m'  col-quo     $'\e[1;34m'    col-glob    $'\e[33m'
+    col-num     $'\e[3;32m'    col-version $'\e[3;32m'    col-happy   $'\e[1;32m'
+    col-obj     $'\e[36m'      col-hi      $'\e[1;35m'    col-obj2    $'\e[32m'
+    col-warn    $'\e[33m'      col-ice     $'\e[36m'      col-ok      $'\e[33m'
+    col-id-as   $'\e[4;33m'    col-opt     $'\e[32m'      col-time    $'\e[33m'
+    col-quos    $'\e[1;31m'    col-pname   $'\e[1;4;36m'
+    col-mdsh    $'\e[1;33m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh   $'\e[1;33m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+    col-↔       ${${${(M)LANG:#*UTF-8*}:+$'\e[32m↔\e[0m'}:-$'\e[32m«-»\e[0m'}
+    )
+  fi
+  ZI_MESSAGE_PALETTE=( "${(@kv)palette}" )
+  if [[ -z $SOURCED ]] && (( ${ZI[term-colors]} > 0 )); then
+    for key in ${(k)palette}; do
+      (( ${+ZI[$key]} )) || ZI[$key]=${palette[$key]}
+    done
+    ZI_MESSAGE_PUBLIC_PALETTE_READY=1
+  fi
 }
 
 # List of hooks.
@@ -1807,174 +1852,359 @@ builtin setopt no_aliases
   command true # workaround a Zsh bug, see: http://www.zsh.org/mla/workers/2018/msg00966.html
   builtin zle -F "$THEFD" +zi-deploy-message
 } # ]]]
-# FUNCTION: .zi-formatter-auto[[[
-# The automatic message formatting tool automatically detects,
-# formats, and colorizes the following pieces of text:
-# [URLs], [plugin IDs (user/repo) if exists on the disk], [numbers], [time], [single-word id-as plugins],
-# [single word commands], [single word functions], [zi commands], [ice modifiers (e.g: mv'a -> b')],
-# [single-char bits and quoted strings (`...`, ,'...', "...")].
-.zi-formatter-auto() {
+# FUNCTION: .zi-message-auto-format. [[[
+# Applies byte-preserving automatic formatting to one unstyled message span.
+# Safe mode recognizes only deterministic Zi and lexical forms. Contextual mode
+# additionally consults the current shell and filesystem.
+.zi-message-auto-format() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+  builtin setopt extended_glob no_short_loops
 
-  local MATCH in=$1 out rwmsg spaces rest; integer MBEGIN MEND
-  local -a match mbegin mend ice_order ecmds
+  local rest=$1 mode=${2:-safe} resume=$3 output chunk core prefix suffix style quote ice_name
+  local MATCH
+  local -a match mbegin mend command_names ice_names extension_commands extension_ices
+  integer MBEGIN MEND color_enabled=${4:-1} index quote_end styled=0
 
-  ice_order=( ${(As:|:)ZI[ice-list]} ${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/} )
-  ecmds=( ${ZI_EXTS[(I)z-annex subcommand:*]#z-annex subcommand:} )
-  in=${(j: :)${${(Z+Cn+)in}//[$'\t ']/$'\u00a0'}}
-  rwmsg=$in
-
-  while [[ $in == (#b)([[:space:]]#)([^[:space:]]##)(*) ]]; do
-    spaces=$match[1]
-    rest=$match[3]
-    rwmsg=${match[2]//---//}
-    REPLY=$rwmsg
-    if [[ $rwmsg == ([[:space:]]##|(#s))[0-9.]##([[:space:]]##|(#e)) && \
-      $rest == ([[:space:]]#|(#s))[sm]([[:space:]]##*|(#e)) || $rwmsg == ([[:space:]]##|(#s))[0-9.]##[sm]([[:space:]]##|(#e)) ]]; then
-      REPLY=${ZI[col-time]}$rwmsg${ZI[col-rst]}
-      [[ $rwmsg != *[sm]* ]] && rest=$ZI[col-time]${(M)rest##[[:space:]]#[sm]}$ZI[col-rst]${rest##[[:space:]]#[sm]}
-    elif [[ $rwmsg == ([[:space:]]##|(#s))[0-9.]##([[:space:]]##|(#e)) ]]; then
-      REPLY=${ZI[col-num]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (#b)(--|)(${(~j:|:)ice_order})([:=\"\'\!a-zA-Z0-9-][^\"\']##[^a-zA-Z0-9]##) ]]; then
-      REPLY=${ZI[col-ice]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (${~ZI[cmd-list]}|${(~j:|:)ecmds}) ]]; then
-      REPLY=${ZI[col-cmd]}$rwmsg${ZI[col-rst]}
-    elif (( $+commands[$rwmsg] )); then
-      REPLY=${ZI[col-bcmd]}$rwmsg${ZI[col-rst]}
-    elif (( $+functions[$rwmsg] )); then
-      REPLY=${ZI[col-func]}$rwmsg${ZI[col-rst]}
-    elif [[ $rwmsg == (#b)((http(s|)|ftp(s|)|rsync|ssh|scp|ntp|file)://[[:alnum:].:+/]##) ]]; then
-      .zi-formatter-url $rwmsg
-    elif [[ $rwmsg == (OMZ|PZT|PZTM|OMZP|OMZT|OMZL)::* || $rwmsg == [^/]##/[^/]## || -d ${ZI[PLUGINS_DIR]}/${rwmsg//\//---} ]]; then
-      .zi-formatter-pid $rwmsg
-    elif [[ $rwmsg == (#b)(*)(...|'<->'|'<–>'|'<—>')(*) || $rwmsg == (#b)(*)(…|–|—|――|↔|...)(*) ]]; then
-      local -A map=( … … - dsh – ndsh — mdsh ―― mmdsh '<->' ↔ '<–>' ↔ '<—>' ↔ ↔ ↔ ... … )
-      local openq=$match[2] str=$match[3] closeq=$match[4] RST=$ZI[col-rst]
-      REPLY=$match[1]$ZI[col-${map[$openq]}]$str$RST$ZI[col-${map[$closeq]}]$match[5]$ZI[col-rst]
-    # \1 - preceding \2 - open, \3 - string, \4 - close, \5 - following
-    elif [[ $rwmsg == (#b)(*)([\'\`\"])([^\'\`\"]##)([\'\`\"])(*) ]]; then
-      local -A map=( \` bapo \' apo \" quo x\` baps x\' aps x\" quos )
-      local openq=$match[2] str=$match[3] closeq=$match[4] RST=$ZI[col-rst]
-      REPLY=$match[1]$ZI[col-${map[$openq]}]$openq$RST$ZI[col-${map[x$openq]}]$str$RST$ZI[col-${map[$closeq]}]$closeq$RST$match[5]$ZI[col-rst]
-    fi
-    in=$rest
-    out+=${spaces//$'\n'/$'\013\015'}$REPLY
-  done
-  REPLY=${out//$'\u00a0'/ }
-} # ]]]
-# FUNCTION: .zi-formatter-pid. [[[
-.zi-formatter-pid() {
-  builtin emulate -L zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
-  # Save whitespace location
-  local pbz=${(M)1##(#s)[[:space:]]##}
-  local kbz=${(M)1%%[[:space:]]##(#e)}
-  # Trim leading/trailing whitespace
-  1=${1//((#s)[[:space:]]##|[[:space:]]##(#e))/}
-  ((${+functions[.zi-first]})) || source ${ZI[BIN_DIR]}/lib/zsh/side.zsh
-  .zi-any-colorify-as-uspl2 "$1";
-  # Replace at least one character with an unbreakable space,
-  # because extreme whitespace is lost due to implementation problems ...
-  pbz=${pbz/[[:blank:]]/ }
-  local kbz_rev="${(j::)${(@Oas::)kbz}}"
-  kbz="${(j::)${(@Oas::)${kbz_rev/[[:blank:]]/ }}}"
-  # Restore whitespace location
-  REPLY=$pbz$REPLY$kbz
-} # ]]]
-# FUNCTION: .zi-formatter-bar. [[[
-.zi-formatter-bar() {
-  .zi-formatter-bar-util ─ bar
-} # ]]]
-# FUNCTION: .zi-formatter-th-bar. [[[
-.zi-formatter-th-bar() {
-  .zi-formatter-bar-util ━ th-bar
-}
-# FUNCTION: .zi-formatter-bar-util. [[[
-.zi-formatter-bar-util() {
-  if [[ $LANG == (#i)*utf-8* ]]; then
-    ch=$1
-  else
-    ch=-
+  if (( ! color_enabled )); then
+    REPLY=$1
+    return 1
   fi
-  REPLY=$ZI[col-$2]${(pl:COLUMNS-1::$ch:):-}$ZI[col-rst]
-} # ]]]
-# FUNCTION: .zi-formatter-url. [[[
-.zi-formatter-url() {
-  builtin emulate -LR zsh -o extended_glob ${=${options[xtrace]:#off}:+-o xtrace}
-  #              1:proto        3:domain/5:start      6:end-of-it         7:no-dot-domain        9:file-path
-  if [[ $1 = (#b)([^:]#)(://|::)((([[:alnum:]._+-]##).([[:alnum:]_+-]##))|([[:alnum:].+_-]##))(|/(*)) ]] {
-    # The advanced coloring if recognized the format…
-    match[9]=${match[9]//\//"%F{227}%B"/"%F{81}%b"}
-    if [[ -n $match[4] ]]; then
-      # … this ·case· ends at: trailing component of the with-dot domain …
-      REPLY="$(builtin print -Pr -- %F{220}$match[1]%F{227}$match[2]%B%F{82}$match[5]%B%F{227}.%B%F{183}$match[6]%f%b)"
+
+  command_names=( ${(s:|:)ZI[cmd-list]} )
+  ice_names=( ${(s:|:)ZI[ice-list]} )
+  if [[ $mode == contextual ]]; then
+    extension_commands=( ${ZI_EXTS[(I)z-annex subcommand:*]#z-annex subcommand:} )
+    extension_ices=( ${(@)${(@Akons:|:u)${ZI_EXTS[ice-mods]//\'\'/}}/(#s)<->-/} )
+  fi
+
+  while [[ -n $rest ]]; do
+    if [[ $rest == (#b)([[:space:]]##)(*) ]]; then
+      output+=$match[1]
+      rest=$match[2]
+      continue
+    fi
+
+    # Quotes may contain whitespace, so recognize a balanced span before the
+    # ordinary non-whitespace token path.
+    quote=$rest[1]
+    if [[ $quote == [\'\"\`] ]]; then
+      quote_end=0
+      for (( index = 2; index <= ${#rest}; ++index )); do
+        if [[ $rest[index] == "$quote" ]]; then
+          quote_end=$index
+          break
+        fi
+      done
+      if (( quote_end )); then
+        chunk=$rest[1,quote_end]
+        rest=$rest[quote_end+1,-1]
+        output+=${ZI[col-quo]}$chunk${ZI[col-rst]}$resume
+        styled=1
+        continue
+      fi
+    fi
+
+    [[ $rest == (#b)([^[:space:]]##)(*) ]] || {
+      REPLY=$output$rest
+      return $(( styled ? 0 : 1 ))
+    }
+    chunk=$match[1]
+    rest=$match[2]
+    core=$chunk
+    prefix=${(M)core##[(\[\{<]#}
+    core=${core#$prefix}
+    suffix=${(M)core%%[.,:;!?\)\]\}>]#}
+    core=${core%$suffix}
+    style=
+
+    if [[ $core == [[:alpha:]][[:alnum:]+.-]#://[^[:space:][:cntrl:]]## ]]; then
+      style=url
+    elif (( ${command_names[(Ie)$core]} )); then
+      style=cmd
     else
-      # … this ·case· ends at: no-dot domain …
-      REPLY="$(builtin print -Pr -- %F{220}$match[1]%F{227}$match[2]%B%F{82}$match[7]%f%b)"
+      ice_name=${core#--}
+      [[ $ice_name == "$core" ]] && ice_name=${core#-}
+      ice_name=${ice_name%%[=:\'\"]*}
+      if [[ $ice_name != "$core" ]] && (( ${ice_names[(Ie)$ice_name]} )); then
+        style=ice
+      elif [[ $core == (0|[1-9][0-9]#)(.[0-9]##|)(ms|s|m|h|d) ]]; then
+        style=time
+      elif [[ $core == (|[-+])(0|[1-9][0-9]#)(.[0-9]##|) ]]; then
+        style=num
+      elif [[ $mode == contextual ]]; then
+        if (( ${extension_commands[(Ie)$core]} )); then
+          style=cmd
+        elif (( ${extension_ices[(Ie)$ice_name]} )); then
+          style=ice
+        elif [[ -n ${builtins[(Ie)$core]} || -n ${commands[(Ie)$core]} || -n ${aliases[(Ie)$core]} ]] || (( ${reswords[(Ie)$core]} )); then
+          style=bcmd
+        elif [[ -n ${functions[(Ie)$core]} ]]; then
+          style=func
+        elif [[ $core == (OMZ|PZT|PZTM|OMZP|OMZT|OMZL)::* || -d "${ZI[PLUGINS_DIR]}/${core//\//---}" ]]; then
+          style=pname
+        elif [[ -e $core ]]; then
+          style=file
+        fi
+      fi
     fi
-    # Is there any file-path part in the URL?
-    if [[ -n $match[9] ]]; then
-      # … append it. This ends the URL.
-      REPLY+="$(print -Pr -- %F{227}%B/%F{81}%b$match[9]%f%b)"
+
+    if [[ -n $style ]]; then
+      output+=$prefix${ZI[col-$style]}$core${ZI[col-rst]}$resume$suffix
+      styled=1
+    else
+      output+=$chunk
     fi
-  #endif
-  } else {
-    # …revert to the basic if not…
-    REPLY=$ZI[col-url]$1$ZI[col-rst]
-  }
+  done
+
+  REPLY=$output
+  return $(( styled ? 0 : 1 ))
 } # ]]]
-# FUNCTION: +zi-message-formatter [[[
-.zi-main-message-formatter() {
-  if [[ -z $1 && -z $2 && -z $3 ]]; then
-    REPLY=""
-    return
+# FUNCTION: .zi-message-color-enabled. [[[
+.zi-message-color-enabled() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  local policy=$1 output_fd=$2
+
+  case $policy in
+    always) return 0 ;;
+    never) return 1 ;;
+    auto)
+      [[ -z $NO_COLOR && $TERM != dumb ]] || return 1
+      (( ${ZI[term-colors]:-0} > 0 )) || return 1
+      [[ -t $output_fd ]]
+      ;;
+    *) return 1 ;;
+  esac
+} # ]]]
+# FUNCTION: .zi-message-render. [[[
+.zi-message-render() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin setopt extended_glob no_short_loops
+
+  local input=$1 default_auto=$2 level=$4 rest segment tag output special special_style active_code base_code color_key style_tag
+  local current_auto=$default_auto
+  local MATCH
+  local -a match mbegin mend
+  local -A level_styles=( plain '' debug dbg info info warn warn error error success happy )
+  local -A style_aliases=( pid pname )
+  integer MBEGIN MEND color_enabled=$3 literal_mode=$5 explicit_style=0 styled=0 needs_reset=0 formatter_status width
+
+  style_tag=$level_styles[$level]
+  base_code=${style_tag:+${ZI[col-$style_tag]}}
+  active_code=$base_code
+  if (( color_enabled )) && [[ -n $base_code ]]; then
+    output+=$base_code
+    styled=1
+    needs_reset=1
   fi
-  local append influx in_prepend
-  if [[ $2 == (b|u|it|st|nb|nu|nit|nst) ]]; then
-    # Code repetition to preserve any leading/trailing whitespace and to allow accumulation of this code with others.
-    append=$ZI[col-$2]
-  elif [[ $2 == (…|ndsh|mdsh|mmdsh|-…|lr|) || -z $2 || -z $ZI[col-$2] ]]; then
-    # Resume previous escape code, if stored.
-    if [[ $ZI[__last-formatter-code] != (…|ndsh|mdsh|mmdsh|-…|lr|rst|nl|) ]]; then
-      in_prepend=$ZI[col-$ZI[__last-formatter-code]]
-      influx=$ZI[col-$ZI[__last-formatter-code]]
+
+  if (( literal_mode )); then
+    output+=$input
+    (( styled )) && output+=${ZI[col-rst]}
+    REPLY=$output
+    return $(( styled ? 0 : 1 ))
+  fi
+
+  rest=$input
+  while [[ -n $rest ]]; do
+    if [[ $rest == (#b)([^\{]#)(\{([^\{\}]##)\})(*) ]]; then
+      segment=$match[1]
+      tag=$match[3]
+      rest=$match[4]
+    else
+      segment=$rest
+      tag=
+      rest=
     fi
-  else
-    # End of escaping logic
-    append=$ZI[col-rst]
+
+    if [[ -n $segment ]]; then
+      if (( color_enabled && ! explicit_style )) && [[ $current_auto != off ]]; then
+        .zi-message-auto-format "$segment" "$current_auto" "$base_code" 1
+        formatter_status=$?
+        output+=$REPLY
+        if (( formatter_status == 0 )); then
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+      else
+        output+=$segment
+      fi
+    fi
+
+    [[ -n $tag ]] || continue
+    special=
+    special_style=
+    case $tag in
+      nl) special=$'\n' ;;
+      tab) special=$' \t ' ;;
+      bspc) special=$'\b' ;;
+      …) special=${${${(M)LANG:#*UTF-8*}:+…}:-...} ;;
+      ndsh) [[ $LANG == (#i)*utf-8* ]] && special=– || special=- ;;
+      mdsh) [[ $LANG == (#i)*utf-8* ]] && special=$'\u2014' || special=-; special_style=warn ;;
+      mmdsh) [[ $LANG == (#i)*utf-8* ]] && special=―― || special=--; special_style=warn ;;
+      -…) special=${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-...} ;;
+      lr|↔)
+        special=${${${(M)LANG:#*UTF-8*}:+↔}:-«-»}
+        [[ $tag == ↔ ]] && special_style=bar
+        ;;
+      bar|th-bar)
+        width=$(( COLUMNS > 1 ? COLUMNS - 1 : 0 ))
+        if [[ $LANG == (#i)*utf-8* ]]; then
+          [[ $tag == th-bar ]] && special=━ || special=─
+        else
+          special=-
+        fi
+        special=${(pl:$width::$special:):-}
+        special_style=$tag
+        ;;
+      rst)
+        explicit_style=0
+        current_auto=$default_auto
+        active_code=$base_code
+        if (( color_enabled )); then
+          output+=${ZI[col-rst]}$base_code
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+        continue
+        ;;
+      auto|contextual|no-auto)
+        explicit_style=0
+        [[ $tag == no-auto ]] && current_auto=off || current_auto=$tag
+        [[ $current_auto == auto ]] && current_auto=safe
+        active_code=$base_code
+        if (( color_enabled )); then
+          output+=${ZI[col-rst]}$base_code
+          styled=1
+          [[ -n $base_code ]] && needs_reset=1 || needs_reset=0
+        fi
+        continue
+        ;;
+    esac
+
+    if [[ $tag == (nl|tab|bspc|…|ndsh|mdsh|mmdsh|-…|lr|↔|bar|th-bar) ]]; then
+      if (( color_enabled )) && [[ -n $special_style ]]; then
+        output+=${ZI[col-$special_style]}$special${ZI[col-rst]}$active_code
+        styled=1
+        [[ -n $active_code ]] && needs_reset=1 || needs_reset=0
+      else
+        output+=$special
+      fi
+      continue
+    fi
+
+    style_tag=${style_aliases[$tag]:-$tag}
+    color_key=col-$style_tag
+    if (( ${+ZI[$color_key]} )); then
+      explicit_style=1
+      current_auto=off
+      active_code=${ZI[$color_key]}
+      if (( color_enabled )); then
+        output+=$active_code
+        styled=1
+        needs_reset=1
+      fi
+    else
+      output+="{$tag}"
+    fi
+  done
+
+  (( needs_reset )) && output+=${ZI[col-rst]}
+  REPLY=$output
+  return $(( styled ? 0 : 1 ))
+} # ]]]
+# FUNCTION: .zi-message-emit. [[[
+.zi-message-emit() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+
+  local message_kind=$1 auto_mode=default color_mode=default level=plain message REPLY
+  integer output_fd=1 newline=1 line_mode=0 literal_mode=0 color_enabled=0 render_status
+  shift
+
+  if [[ $ZI_MESSAGE_PUBLIC_PALETTE_READY != 1 ]]; then
+    local -A message_zi=( "${(@kv)ZI}" )
+    local -A ZI=( "${(@kv)message_zi}" )
+    local palette_key
+    for palette_key in ${(k)ZI_MESSAGE_PALETTE}; do
+      (( ${+ZI[$palette_key]} )) || ZI[$palette_key]=${ZI_MESSAGE_PALETTE[$palette_key]}
+    done
   fi
-  # Construct the text.
-  REPLY=$in_prepend${ZI[col-$2]:-$1}$influx$3$append
-  # Replace new lines with characters that work the same but are not deleted in the substitution
-  # $ (...) - vertical tab 0xB ↔ 13 in the system octagonal connected back carriage (015).
-  local nl=$'\n' vertical=$'\013' carriager=$'\015'
-  REPLY=${REPLY//$nl/$vertical$carriager}
+
+  while (( $# )); do
+    case $1 in
+      --) shift; break ;;
+      -n) newline=0; shift ;;
+      -l) line_mode=1; shift ;;
+      -r) shift ;;
+      -u)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: -u requires a descriptor'; return 2; }
+        output_fd=$2
+        shift 2
+        ;;
+      -u<->) output_fd=${1#-u}; shift ;;
+      --auto)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --auto requires a mode'; return 2; }
+        auto_mode=$2
+        shift 2
+        ;;
+      --auto=*) auto_mode=${1#--auto=}; shift ;;
+      --color)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --color requires a mode'; return 2; }
+        color_mode=$2
+        shift 2
+        ;;
+      --color=*) color_mode=${1#--color=}; shift ;;
+      --level)
+        (( $# >= 2 )) || { builtin print -ru2 -- '+zi-message: --level requires a level'; return 2; }
+        level=$2
+        shift 2
+        ;;
+      --level=*) level=${1#--level=}; shift ;;
+      --literal) literal_mode=1; shift ;;
+      -*) builtin print -ru2 -- "+zi-message: invalid option: $1"; return 2 ;;
+      *) break ;;
+    esac
+  done
+
+  [[ $output_fd == <-> ]] || { builtin print -ru2 -- "+zi-message: invalid descriptor: $output_fd"; return 2; }
+  if [[ $auto_mode == default ]]; then
+    zstyle -s ':zi:message' auto auto_mode || auto_mode=safe
+  fi
+  if [[ $color_mode == default ]]; then
+    zstyle -s ':zi:message' color color_mode || color_mode=auto
+  fi
+  [[ $auto_mode == (off|safe|contextual) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid auto mode: $auto_mode"
+    return 2
+  }
+  [[ $color_mode == (default|auto|always|never) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid color mode: $color_mode"
+    return 2
+  }
+  [[ $level == (plain|debug|info|warn|error|success) ]] || {
+    builtin print -ru2 -- "+zi-message: invalid level: $level"
+    return 2
+  }
+
+  (( line_mode )) && message="${(F)@}" || message="${(j: :)@}"
+  .zi-message-color-enabled "$color_mode" "$output_fd" && color_enabled=1
+  .zi-message-render "$message" "$auto_mode" "$color_enabled" "$level" "$literal_mode"
+  render_status=$?
+  (( render_status <= 1 )) || return $render_status
+
+  builtin print -rn -u "$output_fd" -- "$REPLY" || return $?
+  if [[ $message_kind == progress ]]; then
+    builtin print -rn -u "$output_fd" -- $'\r'
+  elif (( newline )); then
+    builtin print -rn -u "$output_fd" -- $'\n'
+  fi
 } # ]]]
 # FUNCTION: +zi-message. [[[
 +zi-message() {
-  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
-
-  local MATCH opt msg; integer MBEGIN MEND
-  local -a match mbegin mend
-
-  [[ $1 = -* ]] && { local opt=$1; shift; }
-
-  ZI[__last-formatter-code]=
-  msg=${${(j: :)${@:#--}}//\%/%%}
-
-  # First try a dedicated formatter, marking its empty output with ←→, then
-  # the general formatter and in the end filter-out the ←→ from the message.
-  msg=${${msg//(#b)(([\\]|(%F))([\{]([^\}]##)[\}])|([\{]([^\}]##)[\}])([^\%\{\\]#))/${match[4]:+${${match[3]:-$ZI[col-${ZI[__last-formatter-code]}]}:#%F}}$match[3]$match[4]${${functions[.zi-formatter-$match[7]]:+${$(.zi-formatter-$match[7] "$match[8]"; builtin print -rn -- $REPLY):-←→}}:-$(.zi-main-message-formatter "$match[6]" "$match[7]" "$match[8]"; builtin print -rn -- "$REPLY")${${ZI[__last-formatter-code]::=${${${match[7]:#(…|ndsh|mdsh|mmdsh|-…|lr)}:+$match[7]}:-${ZI[__last-formatter-code]}}}:+}}}//←→}
-  # Reset color attributes at the end of the message.
-  msg=$msg$ZI[col-rst]
-  # Output the processed message:
-  builtin print -Pr ${opt:#--} -- $msg
-
-  # Needed to properly end a message with {nl}.
-  if [[ -n ${opt:#*n*} || -z $opt ]]; then
-    print -n $'\015'
-  fi
+  .zi-message-emit message "$@"
+} # ]]]
+# FUNCTION: +zi-progress. [[[
++zi-progress() {
+  .zi-message-emit progress "$@"
 } # ]]]
 # FUNCTION: +zi-prehelp-usage-message. [[[
 # Prints the usage message.
@@ -1997,7 +2227,7 @@ builtin setopt no_aliases
         msg=${msg#($cmd|\*):\[}
       }
       local pre_msg=`+zi-message -n {opt}${(r:14:)${txt#opt_}}`
-      +zi-message ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
+      +zi-message -- ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
     }
   } elif [[ -n $allowed ]] {
     shift 2


### PR DESCRIPTION
# Promotion readiness record

## Candidate identity

- Prior `main` SHA: `4574ced008f18a13bcb738bba07fc3dc8a5e011f`
- Candidate `next` SHA: `e8b5b57d8b231772f183c7c1cc9ffaaedbedd728`
- Candidate tree SHA: `ebdbf9908dd32764edd0a87fbd1787469933ec49`
- Complete compare:
  [`main...next`](https://github.com/z-shell/zi/compare/4574ced008f18a13bcb738bba07fc3dc8a5e011f...e8b5b57d8b231772f183c7c1cc9ffaaedbedd728)

- [x] `git diff --name-only <candidate-next>...<prior-main>` produces no output.
- [x] The candidate tree equals the recorded tree SHA.

## Required validation

The `Promotion gate` check directly depends on every constituent below and
fails if any constituent fails, is cancelled, or is skipped.

| Validation                                | Stable job name             | Result  |
| ----------------------------------------- | --------------------------- | ------- |
| Zsh syntax and compile                    | `Zsh syntax and compile`    | Passed |
| ZD ZUnit integration                      | `ZD integration`            | Passed |
| Trunk                                     | `Trunk`                     | Passed |
| CodeQL                                    | `CodeQL`                    | Passed |
| Exact-candidate clean install and startup | `Clean install and startup` | Passed |
| Aggregate                                 | `Promotion gate`            | Passed |

- [x] The candidate SHA has not changed since every required check completed.
- [x] The `Guard main branch source` and `Promotion gate` required contexts pass.
- [x] The complete file and commit compare contains only reviewed work.

Before this pull request, the exact candidate had 58 retained successful check
runs, including the complete Zsh behavior suite, five ZD integration suites,
Trunk, and CodeQL. Local verification also passed all 12 focused behavior
tests, syntax and isolated compilation of all 39 tracked Zsh sources, clean
install and startup, `actionlint`, YAML parsing, and `git diff --check`.

## Readiness review

### Unresolved issues

No unresolved issue blocks promotion.

Issues #113, #386-#388, #429-#430, and #445-#449 remain independently
tracked. The high-priority defects #445 and #446 predate the current stable
`main` branch and are not regressions introduced by this candidate.

### User-facing and migration notes

- Harden archive extraction against traversal and unsafe symlinks.
- Harden GitHub directory snippets against unsafe symlinks.
- Add GitHub `/trunk/` directory support through transactional sparse Git.
- Make parallel updates deterministic.
- Correct Plugin Standard callback handling for effective plugin IDs.
- Rebuild message output behavior:
  - safe auto output is the default
  - normal messages use line feeds unless `-n` is requested
  - progress output owns carriage returns
  - dynamic text uses literal mode
  - invalid options and descriptors return status 2
- Correct hook ownership, `MANPATH` handling, and scheduler idle behavior.
- Add promotion ancestry and public-contract evidence checks.

The message-output change is intentionally breaking. The canonical wiki
documentation is already merged, and checked runtime consumers require no
pre-promotion adaptation.

### Public-contract follow-ups

The canonical message-output documentation is current and the complete known
consumer inventory was manually verified. Stale or moved evidence pins in
generated documentation and historical consumer paths are follow-up
maintenance, not runtime blockers.

- [x] Newly monitored message-output consumers were manually inventoried across
      the complete compare.

## Resolved issues

Closes #431
Closes #438
Closes #440
Closes #442
Closes #456
Closes #458
Closes #461
Closes #463
Closes #465

## Merge contract

Promotion must use **Create a merge commit**. Never squash or rebase the
persistent `next` branch into `main`.

- [ ] The resulting commit message has no bot, AI-agent, or automation
      `Co-authored-by` trailer.
- [x] `delete_branch_on_merge` is `false` and remote `next` exists.
- [x] The `main` ruleset allows merge commits and does not require linear
      history.
- [x] The `next` ruleset does not require linear history.

## Rollback readiness

- Rollback owner: `@ss-o`
- Observable rollback criteria:
  - clean installation or startup failure
  - a regression in the ZD integration suites
  - message byte, newline, or file-descriptor regressions
  - archive or directory-snippet containment regressions
  - a scheduler idle-loop regression
- [x] The owner can open a same-repository `hotfix-*` pull request that reverts
      the promotion merge through protected `main`.
- [x] The revert pull request will run `Guard main branch source` and
      `Promotion gate`.
- [x] After a revert, clean install and startup will be confirmed at the new
      `main` head, then the hotfix will be merged forward into `next`.

Never force-push either persistent branch. Roll back with a reviewed revert
commit so the incident and recovery remain auditable.

## Stable consumption boundary

Merging this promotion updates the Git-consumed stable `main` ref. After exact
merge-result verification, the separately approved `v2.0.0` signed tag and
GitHub release will publish the breaking milestone with reviewed release notes.
