### PR TITLE
feat(release): automate approved milestone publication

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,21 @@
+---
+name: Release Prepare
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  propose:
+    uses: z-shell/.github/.github/workflows/release-prepare.yml@6f3d88335ca0ae77b795ec2883b4402b51f15c6a # main
+    with:
+      signed_tag: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+---
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Verify and publish
+    if: github.repository == 'z-shell/zi'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Verify release authorization
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zsh -f scripts/verify-release-tag.zsh
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "Zi $TAG" \
+            --generate-notes \
+            --latest

--- a/scripts/verify-release-tag.zsh
+++ b/scripts/verify-release-tag.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+
+emulate -L zsh
+setopt err_return no_unset pipe_fail
+
+fail() {
+    print -u2 -- "release verification: $*"
+    return 1
+}
+
+tag=${GITHUB_REF_NAME:-}
+repository=${GITHUB_REPOSITORY:-}
+
+[[ $repository == z-shell/zi ]] || fail "unexpected repository: ${repository:-unset}"
+[[ $tag =~ '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' ]] ||
+    fail "tag must match vX.Y.Z: ${tag:-unset}"
+
+tag_ref="refs/tags/${tag}"
+[[ $(git cat-file -t "$tag_ref" 2>/dev/null) == tag ]] ||
+    fail "tag must be annotated: $tag"
+
+git fetch --quiet --force --no-tags origin \
+    refs/heads/main:refs/remotes/origin/main ||
+    fail "could not fetch origin/main"
+
+target=$(git rev-parse "${tag_ref}^{}") || fail "could not resolve tag target"
+main=$(git rev-parse refs/remotes/origin/main) || fail "could not resolve origin/main"
+[[ $target == $main ]] || fail "tag target is not the current origin/main"
+
+tag_object=$(git rev-parse "$tag_ref") || fail "could not resolve tag object"
+tag_json=$(gh api "repos/${repository}/git/tags/${tag_object}") ||
+    fail "could not read tag verification"
+jq -e --arg target "$target" \
+    '.verification.verified == true and
+     .object.type == "commit" and
+     .object.sha == $target' <<<"$tag_json" >/dev/null ||
+    fail "GitHub did not verify the signed tag and target"
+
+runs_json=$(gh api --method GET "repos/${repository}/actions/runs" \
+    -f branch=main -f head_sha="$target" -f per_page=100) ||
+    fail "could not read workflow runs"
+
+for workflow in Zsh 'ZD Integration' CodeQL 'Trunk Code Quality'; do
+    jq -e --arg name "$workflow" --arg target "$target" \
+        '.workflow_runs | any(
+            .name == $name and
+            .head_branch == "main" and
+            .head_sha == $target and
+            .status == "completed" and
+            .conclusion == "success"
+        )' <<<"$runs_json" >/dev/null ||
+        fail "required workflow did not succeed: $workflow"
+done
+
+print -- "Release authorization verified for ${tag} at ${target}."

--- a/tests/release-tag-verification.zsh
+++ b/tests/release-tag-verification.zsh
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+
+emulate -L zsh
+setopt err_exit no_unset pipe_fail
+
+root=${0:A:h:h}
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/zi-release-test.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT HUP INT TERM
+
+git init --bare "$tmp/origin.git" >/dev/null
+git clone "$tmp/origin.git" "$tmp/repository" >/dev/null 2>&1
+git -C "$tmp/repository" config user.email release-test@example.invalid
+git -C "$tmp/repository" config user.name 'Release Test'
+print test >"$tmp/repository/file"
+git -C "$tmp/repository" add file
+git -C "$tmp/repository" commit -m 'test: initial commit' >/dev/null
+git -C "$tmp/repository" branch -M main
+git -C "$tmp/repository" push -u origin main >/dev/null 2>&1
+
+target=$(git -C "$tmp/repository" rev-parse HEAD)
+git -C "$tmp/repository" tag -a v2.1.0 -m v2.1.0
+git -C "$tmp/repository" tag v2.1.1
+
+print stale >>"$tmp/repository/file"
+git -C "$tmp/repository" commit -am 'test: advance main' >/dev/null
+git -C "$tmp/repository" push origin main >/dev/null 2>&1
+current=$(git -C "$tmp/repository" rev-parse HEAD)
+git -C "$tmp/repository" tag -a v2.2.0 -m v2.2.0
+
+mkdir "$tmp/bin"
+cat >"$tmp/bin/gh" <<'FAKE_GH'
+#!/usr/bin/env zsh
+if [[ $* == *'/git/tags/'* ]]; then
+    print -r -- "{\"verification\":{\"verified\":${FAKE_TAG_VERIFIED}},\"object\":{\"type\":\"commit\",\"sha\":\"${FAKE_TAG_TARGET}\"}}"
+    exit 0
+fi
+conclusion=success
+[[ ${FAKE_WORKFLOW_FAILURE:-false} == true ]] && conclusion=failure
+print -r -- "{\"workflow_runs\":[
+{\"name\":\"Zsh\",\"head_branch\":\"main\",\"head_sha\":\"${FAKE_TAG_TARGET}\",\"status\":\"completed\",\"conclusion\":\"${conclusion}\"},
+{\"name\":\"ZD Integration\",\"head_branch\":\"main\",\"head_sha\":\"${FAKE_TAG_TARGET}\",\"status\":\"completed\",\"conclusion\":\"success\"},
+{\"name\":\"CodeQL\",\"head_branch\":\"main\",\"head_sha\":\"${FAKE_TAG_TARGET}\",\"status\":\"completed\",\"conclusion\":\"success\"},
+{\"name\":\"Trunk Code Quality\",\"head_branch\":\"main\",\"head_sha\":\"${FAKE_TAG_TARGET}\",\"status\":\"completed\",\"conclusion\":\"success\"}
+]}"
+FAKE_GH
+chmod +x "$tmp/bin/gh"
+
+run_verifier() {
+    local tag=$1 verified=$2 api_target=$3 workflows_fail=${4:-false}
+    (
+        cd "$tmp/repository"
+        PATH="$tmp/bin:$PATH" \
+            GITHUB_REF_NAME=$tag \
+            GITHUB_REPOSITORY=z-shell/zi \
+            FAKE_TAG_VERIFIED=$verified \
+            FAKE_TAG_TARGET=$api_target \
+            FAKE_WORKFLOW_FAILURE=$workflows_fail \
+            zsh -f "$root/scripts/verify-release-tag.zsh"
+    )
+}
+
+expect_fail() {
+    if run_verifier "$@" >/dev/null 2>&1; then
+        print -u2 -- "expected verification to fail: $1"
+        return 1
+    fi
+}
+
+expect_fail release-2.2.0 true "$current"
+expect_fail v2.1.1 true "$target"
+expect_fail v2.1.0 true "$target"
+expect_fail v2.2.0 false "$current"
+expect_fail v2.2.0 true "$target"
+expect_fail v2.2.0 true "$current" true
+run_verifier v2.2.0 true "$current"
+
+print 'release tag verification tests passed'


### PR DESCRIPTION
## Description

Automate the approved Zi milestone release flow without automating tag creation:

- call the organization semantic-version and release-notes preparation workflow after a promotion reaches `main`
- require a maintainer-pushed signed annotated `vX.Y.Z` tag as publication authorization
- reject malformed, lightweight, unverified, stale/off-`main`, target-mismatched, or insufficiently tested tags
- publish generated GitHub release notes idempotently after verification

The reusable caller is pinned to the exact merged policy commit. No version file or release dependency is added. This becomes active when `next` is next promoted to `main`.

## Related issues

Part of #468
Policy: z-shell/.github#583 and z-shell/.github#584

## Type of change

- [x] `feat` - new feature (non-breaking)
- [x] `ci` - CI/workflow change

## Validation

- `actionlint` on both workflows
- Ruby YAML parse with aliases enabled
- `zsh -n` on the verifier and focused test
- `zsh -f tests/release-tag-verification.zsh`
- safe Trunk check on all four files
- live read-only verification of signed tag `v2.0.0` against its exact `main` commit and successful workflows
- `git diff --check`

## Checklist

- [x] Ordinary work targets `next`; only same-repository hotfixes target `main`
- [x] Commit messages follow Conventional Commits format
- [x] No prohibited `Co-authored-by` trailer is present
- [x] Contribution guidelines reviewed
- [x] Relevant tests pass
- [x] Release policy documentation was updated in z-shell/.github#584

## Migration plan

Not required. This does not change Zi's public shell contract.
