### PR TITLE
fix(autoload): only claim functions owned by the loading plug-in

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -15,6 +15,7 @@ on:
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
@@ -31,6 +32,7 @@ on:
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
       - "tests/fixtures/plugin-standard-callbacks/**"
@@ -116,6 +118,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test parallel update
         run: zsh -f tests/parallel-update.zsh
+
+  plugin-autoload-ownership:
+    name: Plugin Autoload Ownership
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test plugin autoload ownership
+        run: zsh -f tests/plugin-autoload-ownership.zsh
 
   plugin-standard-callbacks:
     name: Plugin Standard Callbacks

--- a/tests/plugin-autoload-ownership.zsh
+++ b/tests/plugin-autoload-ownership.zsh
@@ -24,7 +24,9 @@ command mkdir -p \
   "${temp_root}/zdotdir" \
   "${temp_root}/plugins/registrar" \
   "${temp_root}/plugins/provider/lib" \
-  "${temp_root}/plugins/selfowned" || fail "create isolated environment"
+  "${temp_root}/plugins/selfowned" \
+  "${temp_root}/plugins/multidir/lib" \
+  "${temp_root}/plugins/multidir/funcs" || fail "create isolated environment"
 
 # The registrar stands in for a plug-in that runs compinit, which replays a
 # bulk `autoload -Uz' for every completion function recorded in .zcompdump.
@@ -48,6 +50,17 @@ builtin print -r -- 'autoload -Uz _issue_471_own' \
   > "${temp_root}/plugins/selfowned/selfowned.plugin.zsh" || fail "write self-owned plug-in"
 builtin print -r -- 'builtin print -r -- self-owned-body' \
   > "${temp_root}/plugins/selfowned/_issue_471_own" || fail "write self-owned function"
+
+# A plug-in registering two $fpath subdirectories, autoloading a function from
+# the second one, under blockf'' so that its $fpath additions are reverted once
+# it has loaded. The function has to stay resolvable afterwards.
+builtin print -rl -- \
+  '0=${(%):-%N}' \
+  'fpath+=( ${0:A:h}/lib ${0:A:h}/funcs )' \
+  'autoload -Uz _issue_471_second_dir' \
+  > "${temp_root}/plugins/multidir/multidir.plugin.zsh" || fail "write multidir plug-in"
+builtin print -r -- 'builtin print -r -- second-dir-body' \
+  > "${temp_root}/plugins/multidir/funcs/_issue_471_second_dir" || fail "write second-dir function"
 
 env \
   HOME="${temp_root}/home" \
@@ -95,6 +108,23 @@ result="$(_issue_471_own 2>&1)" || {
 }
 [[ $result == self-owned-body ]] || {
   builtin print -u2 -r -- "unexpected self-owned body resolved: $result"
+  return 1
+}
+
+# Every $fpath subdirectory of the plug-in counts as the plug-in's own, not
+# just the first one.
+zi ice blockf
+zi light "${ZI_TEST_ROOT}/plugins/multidir" >/dev/null || return 1
+[[ -z ${fpath[(r)${ZI_TEST_ROOT}/plugins/multidir/funcs]} ]] || {
+  builtin print -u2 -r -- "blockf did not revert the multidir plug-in's \$fpath additions"
+  return 1
+}
+result="$(_issue_471_second_dir 2>&1)" || {
+  builtin print -u2 -r -- "function in the plug-in's second \$fpath subdirectory failed to autoload: $result"
+  return 1
+}
+[[ $result == second-dir-body ]] || {
+  builtin print -u2 -r -- "unexpected second-dir body resolved: $result"
   return 1
 }
 ZSH

--- a/tests/plugin-autoload-ownership.zsh
+++ b/tests/plugin-autoload-ownership.zsh
@@ -27,7 +27,8 @@ command mkdir -p \
   "${temp_root}/plugins/selfowned" \
   "${temp_root}/plugins/multidir/lib" \
   "${temp_root}/plugins/multidir/funcs" \
-  "${temp_root}/plugins/symlinked/lib" || fail "create isolated environment"
+  "${temp_root}/plugins/symlinked/lib" \
+  "${temp_root}/plugins/digest/functions" || fail "create isolated environment"
 command ln -s -- "${temp_root}/plugins" "${temp_root}/plugins-link" ||
   fail "create plug-in directory symlink"
 
@@ -75,6 +76,20 @@ builtin print -rl -- \
   > "${temp_root}/plugins/symlinked/symlinked.plugin.zsh" || fail "write symlinked plug-in"
 builtin print -r -- 'builtin print -r -- symlinked-body' \
   > "${temp_root}/plugins/symlinked/lib/_issue_471_symlinked" || fail "write symlinked function"
+
+# A plug-in whose $fpath subdirectory is backed by a `<directory>.zwc' digest
+# rather than by plain files. The directory itself is removed after compiling,
+# which is what such a digest allows.
+builtin print -r -- 'builtin print -r -- digest-body' \
+  > "${temp_root}/plugins/digest/functions/_issue_471_digest" || fail "write digest function"
+zsh -fc "zcompile -U -z ${(q)temp_root}/plugins/digest/functions.zwc \
+  ${(q)temp_root}/plugins/digest/functions/_issue_471_digest" || fail "compile function digest"
+command rm -rf -- "${temp_root}/plugins/digest/functions" || fail "remove compiled directory"
+builtin print -rl -- \
+  '0=${(%):-%N}' \
+  'fpath+=( ${0:A:h}/functions )' \
+  'autoload -Uz _issue_471_digest' \
+  > "${temp_root}/plugins/digest/digest.plugin.zsh" || fail "write digest plug-in"
 
 env \
   HOME="${temp_root}/home" \
@@ -157,6 +172,23 @@ result="$(_issue_471_symlinked 2>&1)" || {
 }
 [[ $result == symlinked-body ]] || {
   builtin print -u2 -r -- "unexpected symlinked body resolved: $result"
+  return 1
+}
+
+# An $fpath entry of the plug-in backed by a `<directory>.zwc' digest is the
+# plug-in's own, even though no plain function file exists under it.
+zi ice blockf
+zi light "${ZI_TEST_ROOT}/plugins/digest" >/dev/null || return 1
+[[ -z ${fpath[(r)${ZI_TEST_ROOT:A}/plugins/digest/functions]} ]] || {
+  builtin print -u2 -r -- "blockf did not revert the digest plug-in's \$fpath additions"
+  return 1
+}
+result="$(_issue_471_digest 2>&1)" || {
+  builtin print -u2 -r -- "function backed by a directory digest failed to autoload: $result"
+  return 1
+}
+[[ $result == digest-body ]] || {
+  builtin print -u2 -r -- "unexpected digest body resolved: $result"
   return 1
 }
 ZSH

--- a/tests/plugin-autoload-ownership.zsh
+++ b/tests/plugin-autoload-ownership.zsh
@@ -1,0 +1,102 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-autoload-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/plugins/registrar" \
+  "${temp_root}/plugins/provider/lib" \
+  "${temp_root}/plugins/selfowned" || fail "create isolated environment"
+
+# The registrar stands in for a plug-in that runs compinit, which replays a
+# bulk `autoload -Uz' for every completion function recorded in .zcompdump.
+# None of those functions belong to the registrar.
+builtin print -r -- 'autoload -Uz _issue_471_completion' \
+  > "${temp_root}/plugins/registrar/registrar.plugin.zsh" || fail "write registrar plug-in"
+
+# The provider owns the function and is loaded afterwards.
+builtin print -rl -- \
+  '0=${(%):-%N}' \
+  'fpath+=( ${0:A:h}/lib )' \
+  'autoload -Uz _issue_471_completion' \
+  > "${temp_root}/plugins/provider/provider.plugin.zsh" || fail "write provider plug-in"
+builtin print -r -- 'builtin print -r -- provider-body' \
+  > "${temp_root}/plugins/provider/lib/_issue_471_completion" || fail "write provided function"
+
+# A plug-in autoloading its own function while its directory stays out of
+# $fpath. This is what the autoload substitution exists for and must keep
+# working.
+builtin print -r -- 'autoload -Uz _issue_471_own' \
+  > "${temp_root}/plugins/selfowned/selfowned.plugin.zsh" || fail "write self-owned plug-in"
+builtin print -r -- 'builtin print -r -- self-owned-body' \
+  > "${temp_root}/plugins/selfowned/_issue_471_own" || fail "write self-owned function"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "autoload substitution claims functions the plug-in does not own"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+zi load "${ZI_TEST_ROOT}/plugins/registrar" >/dev/null || return 1
+
+[[ ${functions[_issue_471_completion]} != *'local -a fpath'*registrar* ]] || {
+  builtin print -u2 -r -- "registrar's directory was baked into a function it does not own"
+  return 1
+}
+
+zi light "${ZI_TEST_ROOT}/plugins/provider" >/dev/null || return 1
+
+typeset result
+result="$(_issue_471_completion 2>&1)" || {
+  builtin print -u2 -r -- "function owned by a later plug-in failed to resolve: $result"
+  return 1
+}
+[[ $result == provider-body ]] || {
+  builtin print -u2 -r -- "unexpected body resolved: $result"
+  return 1
+}
+
+# The FPATH-clean autoloading that the substitution exists for must survive.
+zi light "${ZI_TEST_ROOT}/plugins/selfowned" >/dev/null || return 1
+[[ -z ${fpath[(r)${ZI_TEST_ROOT}/plugins/selfowned]} ]] || {
+  builtin print -u2 -r -- "self-owned plug-in directory unexpectedly present in \$fpath"
+  return 1
+}
+result="$(_issue_471_own 2>&1)" || {
+  builtin print -u2 -r -- "plug-in's own function failed to autoload: $result"
+  return 1
+}
+[[ $result == self-owned-body ]] || {
+  builtin print -u2 -r -- "unexpected self-owned body resolved: $result"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - autoload substitution only claims functions the plug-in owns"

--- a/tests/plugin-autoload-ownership.zsh
+++ b/tests/plugin-autoload-ownership.zsh
@@ -26,7 +26,10 @@ command mkdir -p \
   "${temp_root}/plugins/provider/lib" \
   "${temp_root}/plugins/selfowned" \
   "${temp_root}/plugins/multidir/lib" \
-  "${temp_root}/plugins/multidir/funcs" || fail "create isolated environment"
+  "${temp_root}/plugins/multidir/funcs" \
+  "${temp_root}/plugins/symlinked/lib" || fail "create isolated environment"
+command ln -s -- "${temp_root}/plugins" "${temp_root}/plugins-link" ||
+  fail "create plug-in directory symlink"
 
 # The registrar stands in for a plug-in that runs compinit, which replays a
 # bulk `autoload -Uz' for every completion function recorded in .zcompdump.
@@ -61,6 +64,17 @@ builtin print -rl -- \
   > "${temp_root}/plugins/multidir/multidir.plugin.zsh" || fail "write multidir plug-in"
 builtin print -r -- 'builtin print -r -- second-dir-body' \
   > "${temp_root}/plugins/multidir/funcs/_issue_471_second_dir" || fail "write second-dir function"
+
+# The same plug-in shape reached through a symlinked plug-in directory. The
+# Plug Standard idiom resolves symlinks, so the registered $fpath entry does not
+# share a prefix with the path zi was given. The plug-in still owns it.
+builtin print -rl -- \
+  '0=${(%):-%N}' \
+  'fpath+=( ${0:A:h}/lib )' \
+  'autoload -Uz _issue_471_symlinked' \
+  > "${temp_root}/plugins/symlinked/symlinked.plugin.zsh" || fail "write symlinked plug-in"
+builtin print -r -- 'builtin print -r -- symlinked-body' \
+  > "${temp_root}/plugins/symlinked/lib/_issue_471_symlinked" || fail "write symlinked function"
 
 env \
   HOME="${temp_root}/home" \
@@ -125,6 +139,24 @@ result="$(_issue_471_second_dir 2>&1)" || {
 }
 [[ $result == second-dir-body ]] || {
   builtin print -u2 -r -- "unexpected second-dir body resolved: $result"
+  return 1
+}
+
+# A plug-in loaded through a symlinked directory owns the $fpath entries it
+# registers, even though `fpath+=( ${0:A:h}/lib )' resolves the symlink and the
+# resulting path shares no prefix with the path zi was given.
+zi ice blockf
+zi light "${ZI_TEST_ROOT}/plugins-link/symlinked" >/dev/null || return 1
+[[ -z ${fpath[(r)${ZI_TEST_ROOT:A}/plugins/symlinked/lib]} ]] || {
+  builtin print -u2 -r -- "blockf did not revert the symlinked plug-in's \$fpath additions"
+  return 1
+}
+result="$(_issue_471_symlinked 2>&1)" || {
+  builtin print -u2 -r -- "function of a plug-in loaded through a symlink failed to autoload: $result"
+  return 1
+}
+[[ $result == symlinked-body ]] || {
+  builtin print -u2 -r -- "unexpected symlinked body resolved: $result"
   return 1
 }
 ZSH

--- a/zi.zsh
+++ b/zi.zsh
@@ -436,7 +436,13 @@ builtin setopt no_aliases
   local -a fpath_elements
   # (R), not (r): (r) yields only the first match, which would hide every
   # $fpath entry of a plug-in that registers more than one subdirectory.
-  fpath_elements=( ${fpath[(R)$PLUGIN_DIR/*]} )
+  # ${PLUGIN_DIR:A} is matched as well: the Plug Standard idiom
+  # `fpath+=( ${0:A:h}/lib )' resolves symlinks, while $PLUGIN_DIR keeps the
+  # path zi was given, so a plug-in reached through a symlinked directory would
+  # otherwise have all of its own $fpath entries judged foreign. Entries
+  # duplicated between the two matches are harmless; the array is only searched
+  # and prepended to the stub's own $fpath.
+  fpath_elements=( ${fpath[(R)$PLUGIN_DIR/*]} ${fpath[(R)${PLUGIN_DIR:A}/*]} )
   # Add a function subdirectory to items, if any (this action is according to the Plug Standard version 1.07 and later).
   [[ -d $PLUGIN_DIR/functions ]] && fpath_elements+=( "$PLUGIN_DIR"/functions )
   if (( ${+opts[(r)-X]} )); then

--- a/zi.zsh
+++ b/zi.zsh
@@ -482,7 +482,21 @@ builtin setopt no_aliases
         # Apply workaround
         func=$func:t
       fi
-      if [[ ${ZI[NEW_AUTOLOAD]} = 2 ]]; then
+      # Only functions that live in the plug-in's own directory may get the
+      # FPATH-clean stub, which bakes $PLUGIN_DIR into the function body. Any
+      # other `autoload' issued while this plug-in is loading (most commonly
+      # the bulk `autoload -Uz' that a compinit run replays from .zcompdump)
+      # belongs to some other provider and must keep the normal, lazy $fpath
+      # resolution. The -C (custom name) form is requested explicitly through
+      # the autoload'' ice, so it keeps its own search and is left alone.
+      local apth aowner=
+      for apth ( $PLUGIN_DIR $fpath_elements ) {
+        [[ -f $apth/$func ]] && { aowner=$apth; break; }
+      }
+      if [[ -z $aowner ]] && (( ! ${+opts[(r)-C]} )); then
+        builtin autoload ${opts[@]} -- $func
+        retval=$?
+      elif [[ ${ZI[NEW_AUTOLOAD]} = 2 ]]; then
         builtin autoload ${opts[@]} "$PLUGIN_DIR/$func"
         retval=$?
       elif [[ ${ZI[NEW_AUTOLOAD]} = 1 ]]; then

--- a/zi.zsh
+++ b/zi.zsh
@@ -497,15 +497,22 @@ builtin setopt no_aliases
       # belongs to some other provider and must keep the normal, lazy $fpath
       # resolution. The -C (custom name) form is requested explicitly through
       # the autoload'' ice, so it keeps its own search and is left alone.
+      # A directory in $fpath may be backed by a `<directory>.zwc' digest
+      # instead of by plain files, in which case the directory itself need not
+      # exist; such an entry is still the plug-in's own.
       local apth aowner=
       for apth ( $PLUGIN_DIR $fpath_elements ) {
-        [[ -f $apth/$func ]] && { aowner=$apth; break; }
+        [[ -f $apth/$func || -f $apth.zwc ]] && { aowner=$apth; break; }
       }
       if [[ -z $aowner ]] && (( ! ${+opts[(r)-C]} )); then
         builtin autoload ${opts[@]} -- $func
         retval=$?
       elif [[ ${ZI[NEW_AUTOLOAD]} = 2 ]]; then
-        builtin autoload ${opts[@]} "$PLUGIN_DIR/$func"
+        # Unreachable while line 239 stays commented out. $aowner, not
+        # $PLUGIN_DIR: the owning directory can be an $fpath subdirectory of
+        # the plug-in. The ${aowner:-$PLUGIN_DIR} fallback keeps the -C form,
+        # which reaches this branch without an ownership match, unchanged.
+        builtin autoload ${opts[@]} "${aowner:-$PLUGIN_DIR}/$func"
         retval=$?
       elif [[ ${ZI[NEW_AUTOLOAD]} = 1 ]]; then
         if (( ${+opts[(r)-C]} )) {

--- a/zi.zsh
+++ b/zi.zsh
@@ -434,7 +434,9 @@ builtin setopt no_aliases
   # "Fpath elements" - ie those elements that are inside the plug-in directory.
   # The name comes from the fact that they are the selected fpath elements → so just "items".
   local -a fpath_elements
-  fpath_elements=( ${fpath[(r)$PLUGIN_DIR/*]} )
+  # (R), not (r): (r) yields only the first match, which would hide every
+  # $fpath entry of a plug-in that registers more than one subdirectory.
+  fpath_elements=( ${fpath[(R)$PLUGIN_DIR/*]} )
   # Add a function subdirectory to items, if any (this action is according to the Plug Standard version 1.07 and later).
   [[ -d $PLUGIN_DIR/functions ]] && fpath_elements+=( "$PLUGIN_DIR"/functions )
   if (( ${+opts[(r)-X]} )); then


### PR DESCRIPTION
Fixes [#471](https://github.com/z-shell/zi/issues/471). Diagnosis and evidence are in [this comment](https://github.com/z-shell/zi/issues/471#issuecomment-5498929535); the issue's own title and root-cause analysis are both incorrect, so it is worth reading that before this diff.

## Problem

`.zi-tmp-subst-on` replaces the `autoload` builtin with `:zi-tmp-subst-autoload` for the whole duration of a plug-in's load (`zi.zsh:804-823`). That exists for FPATH-clean autoloading, so a plug-in can call `autoload -Uz myfunc` without its own directory being in `$fpath`. It implemented that by writing a stub with `$PLUGIN_DIR` baked into the body (`zi.zsh:511-515`), and never checked that the function actually lives in that directory.

So every `autoload` issued while the substitution was installed got the currently loading plug-in's directory baked in, regardless of whose function it was.

The usual source of such calls is `compinit`. `compdump` writes bulk `autoload -Uz <every completion function>` lines into `.zcompdump` (`Completion/compdump:113,129`), and `compinit` sources that dump plus runs `autoload -rUz "$func"` per scanned file (`Completion/compinit:333,545`). Running `compinit` inside a zi-loaded plug-in therefore rewrites every one of those registrations into a stub claimed by that plug-in.

Not all of them break. The generated stub bakes the live global `$fpath` after `$PLUGIN_DIR`, so a function whose real provider directory is already in `$fpath` at that moment still resolves. The ones that fail with `function definition file not found` on first call are those whose provider directory is not in `$fpath` yet: the provider plug-in is loaded after the plug-in that ran `compinit`, or its `$fpath` additions are later reverted by `blockf''`. That is exactly the reported shape, with fzf-tab loaded after the `compinit` plug-in.

The reporter's secondary symptom, `pip` + Tab inserting `pip pip` while `$_comps[pip]` looked correct, is the same bug: `_comps` is restored from the dump and is fine, but `_pip` itself was a broken stub.

Turbo is not involved. Two plain sequential `zi load` calls reproduce it.

## Change

Look the function up under the plug-in's own directory and its own `$fpath` entries first, which is the same ownership test the `-C` branch already performs at `zi.zsh:490-493`. When it is not found there, hand the call to `builtin autoload`, which resolves lazily against the live `$fpath` and therefore succeeds once the real provider is loaded.

The `-C` (custom name) form arrives only from an explicit `autoload''` ice, never from a plug-in's own `autoload` call, and `-C` is not a real `autoload` option, so it is excluded from the fall-through and keeps its own search. The guard is an `elif` chain rather than an early `continue` so the trailing `-I` (immediate invocation) block stays reachable.

Three follow-up commits fix cases where the ownership test did not recognise a directory that is in fact the plug-in's own. All three were invisible before that test, because every earlier consumer appended the global `$fpath` afterwards and the ownership test deliberately does not. All three are real changes in behaviour, not cleanups, and each is pinned by its own assertion.

1. `(R)` instead of `(r)`. `(r)` yields only the first matching element, so a plug-in registering more than one `$fpath` subdirectory had all but the first hidden. Under `blockf''` a function in the plug-in's second subdirectory was judged foreign, deferred to `builtin autoload`, and then failed once `blockf''` reverted the plug-in's `$fpath` additions.

2. `${PLUGIN_DIR:A}` matched in addition to `$PLUGIN_DIR`. The Plug Standard idiom `0=${(%):-%N}; fpath+=( ${0:A:h}/lib )` resolves symlinks, while `$PLUGIN_DIR` keeps the path zi was given. A plug-in reached through a symlinked directory (a symlinked `ZI[HOME_DIR]`, a dotfiles-managed plug-ins directory, a local checkout loaded through a link) therefore registered `$fpath` entries sharing no prefix with `$PLUGIN_DIR`, so all of them were hidden and the plug-in's own functions were judged foreign. Same failure class as the previous item, one step further out.

3. `-f $apth.zwc` accepted alongside `-f $apth/$func`. An `$fpath` directory may be backed by a `<directory>.zwc` digest instead of by plain files, in which case the directory itself need not exist, so the plain-file test is false for a function the plug-in does own. The entry is already known to be one of the plug-in's own `$fpath` entries, so claiming it is the conservative direction. The same commit uses `${aowner:-$PLUGIN_DIR}` rather than `$PLUGIN_DIR` in the `ZI[NEW_AUTOLOAD]=2` branch: that branch is unreachable while `zi.zsh:239` stays commented out, but as written it is wrong for a function owned by an `$fpath` subdirectory, and the fallback keeps the `-C` form unchanged.

## Tests

`tests/plugin-autoload-ownership.zsh` is new and registered in `zsh-n.yml`. It needs no pty and no turbo, so it fits the existing non-interactive harness unchanged. It asserts:

1. A function autoloaded by one plug-in but owned by a later one resolves from its real owner.
2. A plug-in's own function still autoloads with the plug-in directory absent from `$fpath`, which is the behaviour the substitution exists for.
3. A function in the plug-in's *second* `$fpath` subdirectory still resolves after `blockf''` reverts the plug-in's `$fpath` additions.
4. A plug-in loaded through a symlinked directory still owns the `$fpath` entry it registers with `${0:A:h}`, again under `blockf''`.
5. A plug-in whose `$fpath` subdirectory is backed by a compiled `functions.zwc` digest, with the directory itself removed, still owns it, again under `blockf''`.

Verified:

- The new test fails against `next` at `db2ff0e` with `registrar's directory was baked into a function it does not own`, and passes on this branch.
- Every assertion is load-bearing. Confirmed by taking a scratch copy of this branch, reverting exactly one hunk in that copy, and re-running the test: put `(R)` back to `(r)` and assertion 3 fails; delete the `${PLUGIN_DIR:A}` match and assertion 4 fails; delete the `-f $apth.zwc` match and assertion 5 fails. This describes throwaway experiments, not the branch. All three matches are present in the diff above.
- A real `compinit`-generated `.zcompdump`, replayed by a plug-in in a shell that had never run `compinit`, was confirmed to route every one of its `autoload` calls through the substitution.
- Full `tests/*.zsh` sweep: 14 of 14 pass.
- `zsh -n zi.zsh` and `zsh -fc "zcompile zi.zsh"` clean.
- `autoload'a->b'` behaviour is byte-identical before and after.

### Behavioural sweep against `next`

Eighteen cases exercised through `zi load` on `next` and on this branch, in isolated `HOME`/`ZDOTDIR` environments, comparing the resulting function kind, call result and `$fpath` state: own function in the plug-in directory, in an `$fpath` subdirectory, in `functions/` per Plug Standard 1.07, in a second `$fpath` subdirectory, foreign function present in `$fpath`, foreign function absent everywhere, several names in one `autoload` call, function already defined, `+X` operand, `-X` option, `-w` option, absolute-path function, the `autoload'a->b'`, `autoload'#f'` and `autoload'!f'` ices, a plug-in reached through a symlink, a digest-backed `$fpath` entry, and `zi report` output.

The only differences from `next` are the intended ones, and only for functions the loading plug-in does not own: the generated stub changes from the baked-directory form to a plain `autoload` registration, the call result is unchanged where the provider is reachable, and the not-found message loses its `(eval):1:` prefix. Every other case is byte-identical, `zi report` included.

Each commit was swept separately, which shows why the two follow-ups are needed rather than cosmetic:

| case | `next` | ownership test alone | `+ (R)` | `+ :A` and `.zwc` |
| :--- | :--- | :--- | :--- | :--- |
| own function in plug-in directory | ok | ok | ok | ok |
| own function in an `$fpath` subdirectory | ok | ok | ok | ok |
| own function in `functions/` | ok | ok | ok | ok |
| own function in the *second* subdirectory | ok | **fails** | ok | ok |
| plug-in reached through a symlink | ok | **fails** | **fails** | ok |
| digest-backed `$fpath` entry | ok | **fails** | **fails** | ok |
| foreign function | broken stub | fixed | fixed | fixed |

### Performance

Median of 11 runs, `zi load` wall time for a plug-in issuing N `autoload` calls, same machine, Zsh 5.9.2:

| shape | N | `next` | this branch | delta |
| :--- | ---: | ---: | ---: | ---: |
| own functions, one `autoload` call each | 400 | 0.0991 s | 0.1122 s | +13.2% |
| own functions, one `autoload` call each | 5 | 0.0045 s | 0.0046 s | +2.2% |
| foreign functions, one `autoload` call each | 400 | 0.0981 s | 0.0953 s | -2.9% |
| foreign functions, one bulk `autoload` call | 400 | 0.0251 s | 0.0228 s | -9.2% |

The ownership lookup costs roughly 30 microseconds per `autoload` call, so a plug-in making a handful of calls pays about 0.1 ms. The shape that actually reaches hundreds of names is the `.zcompdump` replay, and that one gets faster, because a foreign function no longer needs an `eval` to build a stub. Two variants were tried to remove the remaining cost, hoisting the loop-local declaration and caching `${PLUGIN_DIR:A}` per plug-in, and neither was measurable above noise, so neither is included.

The stub is also much smaller. Five hundred foreign `autoload` registrations occupy 273500 bytes of function-table text on `next`, because each stub embeds the whole `$fpath`, against 10000 bytes here.

## Noticed while investigating, not addressed here

`.zi-load` clears `ZI[CUR_USPL2]` at `zi.zsh:1674` instead of restoring the previous value, so after a nested load the outer plug-in's remaining registrations see an empty current plug-in. Filed separately as #473, with a reproduction. Independent root cause, deliberately kept out of this PR.

`:zi-tmp-subst-autoload`'s `+X` branch reads a bare, undefined `$PLUGINS_DIR` at `zi.zsh:453` where it means `$PLUGIN_DIR`, which leaves an empty leading `FPATH` component and so puts the current directory on the autoload search path. Long-standing, and untouched here. Filed separately as #475. `autoload +X` inside a zi-loaded plug-in was checked to behave identically on this branch and on `next`, for both a direct and a symlinked plug-in path.
