### PR TITLE
fix(autoload): drop the dead FPATH assignment in the +X branch

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -15,6 +15,7 @@ on:
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-autoload-fpath-scope.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -32,6 +33,7 @@ on:
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
+      - "tests/plugin-autoload-fpath-scope.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -118,6 +120,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test parallel update
         run: zsh -f tests/parallel-update.zsh
+
+  plugin-autoload-fpath-scope:
+    name: Plugin Autoload Fpath Scope
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test plugin autoload fpath scope
+        run: zsh -f tests/plugin-autoload-fpath-scope.zsh
 
   plugin-autoload-ownership:
     name: Plugin Autoload Ownership

--- a/tests/plugin-autoload-fpath-scope.zsh
+++ b/tests/plugin-autoload-fpath-scope.zsh
@@ -1,0 +1,109 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-fpath-scope-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/cwd" \
+  "${temp_root}/plugins/plusx/lib" || fail "create isolated environment"
+
+# The plug-in's own functions, one directly in the plug-in directory and one in
+# an $fpath subdirectory it registers. Immediate `autoload +X' of either has to
+# resolve while the plug-in is loading.
+builtin print -r -- 'builtin print -r -- own-body' \
+  > "${temp_root}/plugins/plusx/_issue_475_own" || fail "write own function"
+builtin print -r -- 'builtin print -r -- lib-body' \
+  > "${temp_root}/plugins/plusx/lib/_issue_475_lib" || fail "write lib function"
+
+# A function file that exists only in the directory the shell happens to be in.
+# The working directory is not a search path and must never be consulted.
+builtin print -r -- 'builtin print -r -- cwd-body' \
+  > "${temp_root}/cwd/_issue_475_cwd" || fail "write working-directory function"
+
+builtin print -rl -- \
+  '0=${(%):-%N}' \
+  'fpath+=( ${0:A:h}/lib )' \
+  'autoload +X -Uz _issue_475_own' \
+  'autoload +X -Uz _issue_475_lib' \
+  'autoload +X -Uz _issue_475_cwd 2>/dev/null' \
+  ': the third autoload is expected to find nothing' \
+  > "${temp_root}/plugins/plusx/plusx.plugin.zsh" || fail "write plug-in"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "immediate autoload does not keep to the plug-in's own directories"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+typeset before_fpath="${(j.:.)fpath}" before_FPATH="$FPATH"
+builtin cd -q "${ZI_TEST_ROOT}/cwd" || return 1
+# blockf so that the plug-in's own `fpath+=' is reverted and anything left
+# behind afterwards is a leak from the substitution rather than from the
+# plug-in itself.
+zi ice blockf
+zi load "${ZI_TEST_ROOT}/plugins/plusx" >/dev/null 2>&1
+
+# The `+X' branch replaces $fpath for the duration of the call. Both the array
+# and the tied scalar have to be restored for the caller.
+[[ ${(j.:.)fpath} == $before_fpath ]] || {
+  builtin print -u2 -r -- "\$fpath leaked out of the immediate autoload"
+  return 1
+}
+[[ $FPATH == $before_FPATH ]] || {
+  builtin print -u2 -r -- "\$FPATH leaked out of the immediate autoload: $FPATH"
+  return 1
+}
+
+typeset result
+result="$(_issue_475_own 2>&1)" || {
+  builtin print -u2 -r -- "immediate autoload of the plug-in's own function failed: $result"
+  return 1
+}
+[[ $result == own-body ]] || {
+  builtin print -u2 -r -- "unexpected own body resolved: $result"
+  return 1
+}
+
+result="$(_issue_475_lib 2>&1)" || {
+  builtin print -u2 -r -- "immediate autoload from the plug-in's \$fpath subdirectory failed: $result"
+  return 1
+}
+[[ $result == lib-body ]] || {
+  builtin print -u2 -r -- "unexpected lib body resolved: $result"
+  return 1
+}
+
+[[ ${functions[_issue_475_cwd]} != *cwd-body* ]] || {
+  builtin print -u2 -r -- "the working directory was searched: _issue_475_cwd was loaded from \$PWD"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - immediate autoload keeps to the plug-in's own directories and restores \$fpath"

--- a/zi.zsh
+++ b/zi.zsh
@@ -458,7 +458,6 @@ builtin setopt no_aliases
   fi
   if [[ -n ${(M)@:#+X} ]]; then
     .zi-add-report "${ZI[CUR_USPL2]}" "Autoload +X ${opts:+${(j: :)opts[@]} }${(j: :)${@:#+X}}"
-    local +h FPATH=$PLUGINS_DIR${fpath_elements:+:${(j.:.)fpath_elements[@]}}:$FPATH
     local +h -a fpath
     fpath=( $PLUGIN_DIR $fpath_elements $fpath )
     builtin autoload +X ${opts[@]} "${@:#+X}"


### PR DESCRIPTION
Closes #475.

## Problem

`:zi-tmp-subst-autoload`'s `+X` branch opened with an assignment built from `$PLUGINS_DIR`, a parameter that has never existed. The plug-in directory is `$PLUGIN_DIR`; the plug-ins root is `ZI[PLUGINS_DIR]`.

The value was never used either. `local +h -a fpath` on the next line declares a fresh local array, and because `fpath` and `FPATH` are tied that discards the scalar assigned the line before. `fpath=( $PLUGIN_DIR $fpath_elements $fpath )` then establishes the real search path.

I originally filed #475 claiming the empty leading `FPATH` field put the working directory on the autoload search path. That was wrong, and the issue has been corrected. Tracing the branch on `next` at `db2ff0e`, with the shell sitting in a directory holding a matching function file:

```text
[TRACE] FPATH=</tmp/tmp.XGR2a14gwa/p:/tmp/tmp.XGR2a14gwa/data/zi/completions:/usr/share/zsh/functions/Misc>
[TRACE] fpath=(/tmp/tmp.XGR2a14gwa/p|/tmp/tmp.XGR2a14gwa/data/zi/completions|/usr/share/zsh/functions/Misc)
[TRACE] PWD=/tmp/tmp.XGR2a14gwa/cwd
```

No empty field, no working directory.

## Change

Remove the assignment rather than repair the name. It is inert, it names a parameter that does not exist, and it sits inside the search-path construction it appears to belong to, which has already produced one wrong bug report.

No behaviour changes. This is a readability fix with a guard attached.

## Tests

`tests/plugin-autoload-fpath-scope.zsh` is new and registered in `zsh-n.yml`. It pins the invariant that made the removal safe, and asserts, under `blockf''` so that the plug-in's own `fpath+=` is reverted and anything remaining is a genuine leak:

1. Immediate `autoload +X` resolves a function in the plug-in directory.
2. Immediate `autoload +X` resolves a function in an `$fpath` subdirectory the plug-in registers.
3. The caller's `$fpath` and `$FPATH` are unchanged after the load.
4. A function file present only in the working directory is never loaded from there.

It passes both before and after the change, which is the point: it is an invariant guard, not a regression test, and there is no failing case to demonstrate because the defect had no observable effect. It would fail if someone "repaired" the assignment by making it live again with an empty leading field.

Verified: full `tests/*.zsh` sweep 15 of 15, `zsh -n zi.zsh` clean, workflow parses as YAML.
