### PR TITLE
fix(autoload): make the autoload'' ice and @autoload work again

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -16,6 +16,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-autoload-fpath-scope.zsh"
+      - "tests/plugin-autoload-ice.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -34,6 +35,7 @@ on:
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
       - "tests/plugin-autoload-fpath-scope.zsh"
+      - "tests/plugin-autoload-ice.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -131,6 +133,16 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test plugin autoload fpath scope
         run: zsh -f tests/plugin-autoload-fpath-scope.zsh
+  plugin-autoload-ice:
+    name: Plugin Autoload Ice
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test autoload ice forms
+        run: zsh -f tests/plugin-autoload-ice.zsh
 
   plugin-autoload-ownership:
     name: Plugin Autoload Ownership

--- a/tests/plugin-autoload-ice.zsh
+++ b/tests/plugin-autoload-ice.zsh
@@ -1,0 +1,110 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-autoload-ice-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/fns" || fail "create isolated environment"
+
+# zi skips a plug-in it has already loaded, and the autoload substitution never
+# touches a function that already exists, so every ice form needs both its own
+# plug-in directory and its own function name.
+typeset case_name
+for case_name ( plain spaced tight bang ) {
+  command mkdir -p "${temp_root}/plugins/${case_name}" || fail "create plug-in ${case_name}"
+  builtin print -r -- "builtin print -r -- ${case_name}-body" \
+    > "${temp_root}/plugins/${case_name}/_issue_476_${case_name}" || fail "write function for ${case_name}"
+  builtin print -r -- ': nothing, the ice does the work' \
+    > "${temp_root}/plugins/${case_name}/${case_name}.plugin.zsh" || fail "write plug-in ${case_name}"
+}
+
+# Reachable through $fpath only, for the @autoload helper, which runs outside
+# any plug-in load.
+builtin print -r -- 'builtin print -r -- at-plain-body' \
+  > "${temp_root}/fns/_issue_476_at_plain" || fail "write @autoload function"
+builtin print -r -- 'builtin print -r -- at-rename-body' \
+  > "${temp_root}/fns/_issue_476_at_src" || fail "write @autoload rename source"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "the autoload'' ice does not resolve its forms"
+builtin emulate -R zsh
+setopt pipe_fail
+
+fpath=( "${ZI_TEST_ROOT}/fns" $fpath )
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+typeset result
+
+check() {  # check <function> <expected output> <label>
+  (( ${+functions[$1]} )) || {
+    builtin print -u2 -r -- "$3: $1 was never defined"
+    return 1
+  }
+  result="$( $1 2>&1 )" || {
+    builtin print -u2 -r -- "$3: calling $1 failed: $result"
+    return 1
+  }
+  [[ $result == $2 ]] || {
+    builtin print -u2 -r -- "$3: $1 produced '$result', expected '$2'"
+    return 1
+  }
+}
+
+# Plain form, which already worked. Guards against a regression.
+zi ice autoload'_issue_476_plain'
+zi load "${ZI_TEST_ROOT}/plugins/plain" >/dev/null || return 1
+check _issue_476_plain plain-body "plain form" || return 1
+
+# Rename form, spaced and unspaced. The arrow has to be rewritten to -S, which
+# needs extended_glob at the substitution that does it.
+zi ice autoload'_issue_476_spaced -> _issue_476_spaced_new'
+zi load "${ZI_TEST_ROOT}/plugins/spaced" >/dev/null || return 1
+check _issue_476_spaced_new spaced-body "spaced rename form" || return 1
+
+zi ice autoload'_issue_476_tight->_issue_476_tight_new'
+zi load "${ZI_TEST_ROOT}/plugins/tight" >/dev/null || return 1
+check _issue_476_tight_new tight-body "unspaced rename form" || return 1
+
+# Bang form. It takes the same -C branch as a rename but supplies no new name,
+# so the generated wrapper has to install the body under the original name
+# rather than under an empty one, which would recurse until FUNCNEST.
+zi ice autoload'!_issue_476_bang'
+zi load "${ZI_TEST_ROOT}/plugins/bang" >/dev/null || return 1
+check _issue_476_bang bang-body "bang form" || return 1
+
+# The public @autoload helper runs outside a plug-in load and carries both
+# defects.
+@autoload _issue_476_at_plain >/dev/null 2>&1
+check _issue_476_at_plain at-plain-body "@autoload plain" || return 1
+
+@autoload '_issue_476_at_src -> _issue_476_at_new' >/dev/null 2>&1
+check _issue_476_at_new at-rename-body "@autoload rename" || return 1
+ZSH
+
+builtin print -r -- "ok - the autoload'' ice resolves its plain, rename and bang forms"

--- a/zi.zsh
+++ b/zi.zsh
@@ -530,7 +530,7 @@ builtin setopt no_aliases
                 body2=\"\${body##[[:space:]]#${func}[[:blank:]]#\(\)[[:space:]]#\{}\"
                 [[ \$body2 != \$body ]] && body2=\"\${body2%\}[[:space:]]#([$nl]#([[:blank:]]#\#[^$nl]#((#e)|[$nl]))#)#}\"
               }
-              functions[${${(q)custom[count*2]}:-$func}]=\"\$body2\"
+              functions[${(q)${custom[count*2]}:-$func}]=\"\$body2\"
               ${(q)${custom[count*2]}:-$func} \"\$@\"
             }"
             retval=$?
@@ -1731,9 +1731,22 @@ builtin setopt no_aliases
   [[ -z ${ICE[subst]} ]] && local ___builtin=builtin
   [[ ${ICE[as]} = null || ${+ICE[null]} -eq 1 || ${+ICE[binary]} -eq 1 ]] && ICE[pick]="${ICE[pick]:-/dev/null}"
   if [[ -n ${ICE[autoload]} ]] {
-    :zi-tmp-subst-autoload -Uz \
-      ${(s: :)${${${(s.;.)ICE[autoload]#[\!\#]}#[\!\#]}//(#b)((*)(->|=>|→)(*)|(*))/${match[2]:+$match[2] -S $match[4]}${match[5]:+${match[5]} -S ${match[5]}}}} \
-      ${${(M)ICE[autoload]:#*(->|=>|→)*}:+-C} ${${(M)ICE[autoload]#(?\!|\!)}:+-C} ${${(M)ICE[autoload]#(?\#|\#)}:+-I}
+    # The (#b) backreferences that turn `a -> b' into `a -S b' need
+    # extended_glob, which this function does not set. Without it the
+    # substitution matches nothing and the rename form reaches
+    # :zi-tmp-subst-autoload untranslated. Build the argument list in an
+    # anonymous function so both the option and the match parameters stay local.
+    local -a ___autoload_args
+    () {
+      builtin emulate -LR zsh
+      builtin setopt extended_glob
+      local -a match mbegin mend
+      ___autoload_args=(
+        ${(s: :)${${${(s.;.)ICE[autoload]#[\!\#]}#[\!\#]}//(#b)((*)(->|=>|→)(*)|(*))/${match[2]:+$match[2] -S $match[4]}${match[5]:+${match[5]} -S ${match[5]}}}}
+        ${${(M)ICE[autoload]:#*(->|=>|→)*}:+-C} ${${(M)ICE[autoload]#(?\!|\!)}:+-C} ${${(M)ICE[autoload]#(?\#|\#)}:+-I}
+      )
+    }
+    :zi-tmp-subst-autoload -Uz $___autoload_args
   }
   if [[ ${ICE[as]} = command ]]; then
     [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]] && ICE[pick]="${___id_as:t}"
@@ -3282,7 +3295,18 @@ zpextract() {
 # ]]]
 # FUNCTION: @autoload. [[[
 @autoload() {
-  :zi-tmp-subst-autoload -Uz ${(s: :)${${(j: :)${@#\!}}//(#b)((*)(->|=>|→)(*)|(*))/${match[2]:+$match[2] -S $match[4]}${match[5]:+${match[5]} -S ${match[5]}}}} ${${${(@M)${@#\!}:#*(->|=>|→)*}}:+-C} ${${@#\!}:+-C}
+  # Same extended_glob requirement as the autoload'' ice in .zi-load-plugin.
+  local -a ___autoload_args
+  () {
+    builtin emulate -LR zsh
+    builtin setopt extended_glob
+    local -a match mbegin mend
+    ___autoload_args=(
+      ${(s: :)${${(j: :)${@#\!}}//(#b)((*)(->|=>|→)(*)|(*))/${match[2]:+$match[2] -S $match[4]}${match[5]:+${match[5]} -S ${match[5]}}}}
+      ${${${(@M)${@#\!}:#*(->|=>|→)*}}:+-C} ${${@#\!}:+-C}
+    )
+  } "$@"
+  :zi-tmp-subst-autoload -Uz $___autoload_args
 } # ]]]
 # FUNCTION: zi-turbo. [[[
 # With zi-turbo first argument is a wait time and suffix, i.e. "0a".


### PR DESCRIPTION
Closes #476.

Two independent defects left every form of the `autoload''` ice broken except the plain and `#` ones, and left the public `@autoload` helper broken in all of its forms.

## Defect 1: the rename arrow is never translated

The `(#b)` backreference substitution that rewrites `a -> b` into `a -S b` needs `extended_glob`. Neither `.zi-load-plugin` nor `@autoload` sets it, so the substitution matched nothing and the ice value reached `:zi-tmp-subst-autoload` untranslated: the unspaced form arrived as one literal name, the spaced form word-split into `a`, `->` and `b`. The `-C` flag was still added, since plain alternation does not need `extended_glob`, so the `-C` branch searched `$fpath` for names that cannot exist.

Both argument lists are now built inside an anonymous function that sets the option and localises `match`, `mbegin` and `mend`, rather than enabling `extended_glob` for the remainder of a large function.

## Defect 2: the `-C` wrapper assigns to an empty function name

The generated wrapper's two lines nest `(q)` differently:

```zsh
functions[${${(q)custom[count*2]}:-$func}]=\"\$body2\"
${(q)${custom[count*2]}:-$func} \"\$@\"
```

The call line falls back to `$func` when the element is unset, then quotes. The assignment line quotes first, and quoting an unset element yields a two-character string, which is not empty, so `:-` never fires and the wrapper assigns to `functions['']`. The real function is never redefined, so calling it re-enters the wrapper until `FUNCNEST`.

## How the two interact

They are not independent in effect, and the PR is explicit about it. Once the substitution runs, every name also receives `-S <name>`, so `custom` is always populated and the empty key stops arising. Either fix alone repairs the bang form. The nesting fix is kept because the assignment is wrong on its own terms, and it is the only thing protecting the wrapper if `custom` is ever unpopulated again.

## Before and after

Every form, in an isolated environment, on `next` at `fe5ee80` and on this branch:

| form | `next` | this branch |
| :--- | :--- | :--- |
| `autoload'_f'` | works | works |
| `autoload'_a -> _b'` | `_b` undefined | `_b` resolves |
| `autoload'_a->_b'` | `_b` undefined | `_b` resolves |
| `autoload'!_f'` | `maximum nested function level reached` | `_f` resolves |
| `autoload'#_f'` | works | works |
| `@autoload _f` | `maximum nested function level reached` | `_f` resolves |
| `@autoload '_a -> _b'` | two `Couldn't find autoload function` errors | `_b` resolves |

## Tests

`tests/plugin-autoload-ice.zsh` is new and registered in `zsh-n.yml`. It covers the plain, spaced rename, unspaced rename and bang forms of the ice plus `@autoload` in its plain and rename forms.

Each ice form gets its own plug-in directory and its own function name, because zi skips a plug-in it has already loaded and the substitution never touches a function that already exists. Both of those bit the first draft of this test and are called out in comments so the next person does not repeat them.

Verified by reverting hunks in isolation on a scratch copy: with the whole change reverted the test fails on the spaced rename; with only the `extended_glob` wrappers reverted it still fails on the rename; with only the nesting fix reverted it passes, which is the interaction described above rather than an unneeded hunk.

Full `tests/*.zsh` sweep 15 of 15, `zsh -n zi.zsh` and `zcompile` clean, workflow parses as YAML.

## Note on scope

`@autoload` passes `-C` unconditionally, through `${${@#\!}:+-C}`, where the ice only passes it for a rename or a `!` prefix. That looks wrong too, but `@autoload` is undocumented and changing it would alter the behaviour of a public helper for no reported reason, so it is left alone. Both `@autoload` forms work correctly with `-C` once these two defects are fixed.
