### PR TITLE
fix(load): restore the enclosing plug-in after a nested load

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -17,6 +17,7 @@ on:
       - "tests/parallel-update.zsh"
       - "tests/plugin-autoload-fpath-scope.zsh"
       - "tests/plugin-autoload-ice.zsh"
+      - "tests/nested-load-state.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -36,6 +37,7 @@ on:
       - "tests/parallel-update.zsh"
       - "tests/plugin-autoload-fpath-scope.zsh"
       - "tests/plugin-autoload-ice.zsh"
+      - "tests/nested-load-state.zsh"
       - "tests/plugin-autoload-ownership.zsh"
       - "tests/plugin-standard-callbacks.zsh"
       - "tests/scheduler-idle.zsh"
@@ -143,6 +145,16 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test autoload ice forms
         run: zsh -f tests/plugin-autoload-ice.zsh
+  nested-load-state:
+    name: Nested Load State
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test nested load state
+        run: zsh -f tests/nested-load-state.zsh
 
   plugin-autoload-ownership:
     name: Plugin Autoload Ownership

--- a/tests/nested-load-state.zsh
+++ b/tests/nested-load-state.zsh
@@ -1,0 +1,87 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-nested-load-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/inner" \
+  "${temp_root}/plugin" \
+  "${temp_root}/cloneonly" \
+  "${temp_root}/snippetter" || fail "create isolated environment"
+
+builtin print -r -- ':' \
+  > "${temp_root}/inner/inner.plugin.zsh" || fail "write inner plug-in"
+builtin print -r -- ':' \
+  > "${temp_root}/inner/snippet.zsh" || fail "write inner snippet"
+
+# Each outer plug-in records the current plug-in before and after a nested load
+# of one shape, so the assertions can run outside the load.
+record() {  # record <plug-in directory> <nested load command>
+  builtin print -rl -- \
+    'builtin print -r -- "before ${ZI[CUR_USPL2]}" >> $ZI_TEST_LOG' \
+    "$2" \
+    'builtin print -r -- "after ${ZI[CUR_USPL2]}" >> $ZI_TEST_LOG' \
+    > "${temp_root}/${1}/${1}.plugin.zsh" || fail "write ${1} plug-in"
+}
+record plugin     'zi light $ZI_TEST_ROOT/inner >/dev/null 2>&1'
+record cloneonly  'zi ice cloneonly; zi light $ZI_TEST_ROOT/inner >/dev/null 2>&1'
+record snippetter 'zi snippet $ZI_TEST_ROOT/inner/snippet.zsh >/dev/null 2>&1'
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  ZI_TEST_LOG="${temp_root}/log" \
+  zsh -f <<'ZSH' || fail "a nested load does not restore the enclosing plug-in"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+typeset shape
+for shape ( plugin cloneonly snippetter ) {
+  : > "$ZI_TEST_LOG"
+  zi light "${ZI_TEST_ROOT}/${shape}" >/dev/null 2>&1
+  typeset -a lines
+  lines=( ${(f)"$(<$ZI_TEST_LOG)"} )
+  [[ ${lines[1]} == "before %${ZI_TEST_ROOT}/${shape}" ]] || {
+    builtin print -u2 -r -- "${shape}: unexpected state before the nested load: ${lines[1]}"
+    return 1
+  }
+  [[ ${lines[2]} == "after %${ZI_TEST_ROOT}/${shape}" ]] || {
+    builtin print -u2 -r -- "${shape}: the nested load did not restore the enclosing plug-in: ${lines[2]}"
+    return 1
+  }
+}
+
+# Back at the top level nothing is loading, which is what clearing used to mean.
+[[ -z ${ZI[CUR_USPL2]} && -z ${ZI[CUR_USR]} && -z ${ZI[CUR_PLUGIN]} ]] || {
+  builtin print -u2 -r -- "a load leaked to the top level: [${ZI[CUR_USR]}] [${ZI[CUR_PLUGIN]}] [${ZI[CUR_USPL2]}]"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - a nested load restores the enclosing plug-in and leaves the top level clear"

--- a/zi.zsh
+++ b/zi.zsh
@@ -1483,7 +1483,11 @@ builtin setopt no_aliases
   }
   (( ${+ICE[cloneonly]} || retval )) && return 0
   ZI_SNIPPETS[$id_as]="$id_as <${${ICE[svn]+svn}:-single file}>"
+  # Same re-entrancy as .zi-load: a plug-in body may load a snippet, and a
+  # snippet may load further objects.
+  local ___prev_uspl2="${ZI[CUR_USPL2]}"
   ZI[CUR_USPL2]="$id_as" ZI_REPORTS[$id_as]=
+  {
   reply=( ${(on)ZI_EXTS[(I)z-annex hook:\!atinit-<-> <->]} )
   for key in "${reply[@]}"; do
     arr=( "${(Q)${(z@)ZI_EXTS[$key]}[@]}" )
@@ -1610,7 +1614,9 @@ builtin setopt no_aliases
   done
   (( ${+ICE[notify]} == 1 )) && { [[ $retval -eq 0 || -n ${(M)ICE[notify]#\!} ]] && { local msg; eval "msg=\"${ICE[notify]#\!}\""; +zi-deploy-message @msg "$msg" } || +zi-deploy-message @msg "notify: Plugin not loaded / loaded with problem, the return code: $retval"; }
   (( ${+ICE[reset-prompt]} == 1 )) && +zi-deploy-message @rst
-  ZI[CUR_USPL2]=
+  } always {
+    ZI[CUR_USPL2]="$___prev_uspl2"
+  }
   ZI[TIME_INDEX]=$(( ${ZI[TIME_INDEX]:-0} + 1 ))
   ZI[TIME_${ZI[TIME_INDEX]}_${id_as}]=$SECONDS
   ZI[AT_TIME_${ZI[TIME_INDEX]}_${id_as}]=$EPOCHREALTIME
@@ -1629,7 +1635,15 @@ builtin setopt no_aliases
   local ___user="${reply[-2]}" ___plugin="${reply[-1]}" ___id_as="${ICE[id-as]:-${reply[-2]}${${reply[-2]:#(%|/)*}:+/}${reply[-1]}}"
   local ___pdir_path="${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"
   local ___pdir_orig="$___pdir_path"
+  # .zi-load is re-entrant: a plug-in body may load another plug-in or a
+  # snippet. Save what was current and restore it afterwards rather than
+  # clearing, so the outer plug-in keeps its identity for the rest of its body.
+  # At the top level the saved values are empty, which is the previous "no load
+  # is in progress" behaviour. The always block also covers the early returns
+  # below, cloneonly'' among them.
+  local ___prev_usr="${ZI[CUR_USR]}" ___prev_plugin="${ZI[CUR_PLUGIN]}" ___prev_uspl2="${ZI[CUR_USPL2]}"
   ZI[CUR_USR]="$___user" ZI[CUR_PLUGIN]="$___plugin" ZI[CUR_USPL2]="$___id_as"
+  {
   if [[ -n ${ICE[teleid]} ]] {
     .zi-any-to-user-plugin "${ICE[teleid]}"
     ___user="${reply[-2]}" ___plugin="${reply[-1]}"
@@ -1698,8 +1712,11 @@ builtin setopt no_aliases
   (( ${+ICE[reset-prompt]} == 1 )) && +zi-deploy-message @___rst
   # Unset the `m` function.
   .zi-set-m-func unset
-  # Mark no load is in progress.
-  ZI[CUR_USR]= ZI[CUR_PLUGIN]= ZI[CUR_USPL2]=
+  } always {
+    # Restore the enclosing load. Empty at the top level, which is what
+    # "no load is in progress" meant here before.
+    ZI[CUR_USR]="$___prev_usr" ZI[CUR_PLUGIN]="$___prev_plugin" ZI[CUR_USPL2]="$___prev_uspl2"
+  }
   ZI[TIME_INDEX]=$(( ${ZI[TIME_INDEX]:-0} + 1 ))
   ZI[TIME_${ZI[TIME_INDEX]}_${___id_as//\//---}]=$SECONDS
   ZI[AT_TIME_${ZI[TIME_INDEX]}_${___id_as//\//---}]=$EPOCHREALTIME


### PR DESCRIPTION
Refs #473. Fixes the cause that issue names. Its reproduction needs a second fix as well, described at the bottom.

## Problem

`.zi-load` and `.zi-load-snippet` set the current plug-in on entry and cleared it unconditionally on exit, under the comment "mark no load is in progress". Both are re-entrant: a plug-in body may call `zi load`, `zi light` or `zi snippet`. The inner call cleared state the outer call still needed.

`ZI[CUR_USPL2]` drives report attribution through `.zi-add-report`, and the `ZI[BINDKEYS__...]`, `ZI[ZSTYLES__...]`, `ZI[ALIASES__...]` and `ZI[WIDGETS_*__...]` tracking keys that unload depends on, so anything the outer plug-in did after a nested load was recorded against the empty id.

## Change

Save the previous values on entry and restore them on exit. At the top level the saved values are empty, so the previous "no load is in progress" behaviour is preserved without a special case.

The restore lives in an `always` block rather than at the old assignment site. Both functions return early on several paths, `cloneonly''` among them, and a plain restore at the end would leave those paths clobbering the outer plug-in exactly as before. Measured on `next` at `fe5ee80`: a nested `cloneonly''` load and a nested snippet both clobber, and both are fixed here. `{ } always { }` is already the idiom for this shape in `lib/zsh/autoload.zsh` and `lib/zsh/install.zsh`.

`.zi-load-snippet` only manages `ZI[CUR_USPL2]`, so only that key is saved there.

## Tests

`tests/nested-load-state.zsh` is new and registered in `zsh-n.yml`. Each outer plug-in records `ZI[CUR_USPL2]` before and after one nested load, so the assertions run outside the load. It covers a plain nested plug-in load, a nested load that returns early through `cloneonly''`, and a nested snippet, and then asserts all three keys are empty back at the top level.

Fails against `next` with `the nested load did not restore the enclosing plug-in: after `, passes here. Full `tests/*.zsh` sweep 15 of 15, `zsh -n` and `zcompile` clean, workflow parses as YAML.

## Why the issue's reproduction still fails

The `autoload -Uz outer-func` in #473 still does not resolve, for a reason unrelated to this change. `.zi-tmp-subst-on` returns early when a substitution is already installed, but `.zi-tmp-subst-off` tears it down as soon as a nested load of the same mode finishes:

```zsh
.zi-tmp-subst-on:  [[ ${ZI[TMP_SUBST]} != inactive ]] && builtin return 0
.zi-tmp-subst-off: [[ ${ZI[TMP_SUBST]} = inactive || ${ZI[TMP_SUBST]} != $mode ]] && return 0
                   ZI[TMP_SUBST]=inactive
```

Observed from inside an outer plug-in around a nested `zi light`, identically on `next` and on this branch:

```text
[outer] before: TMP_SUBST=[load] autoload_shadowed=1
[outer] after:  TMP_SUBST=[inactive] autoload_shadowed=0
```

So the outer plug-in's later `autoload` calls are not intercepted at all. That needs `.zi-tmp-subst-on` and `.zi-tmp-subst-off` to count nesting, which the file already does for the compdef-only substitution at three other sites that write `ZI[TMP_SUBST]` directly. Reconciling two regimes on one key in the core load path is a materially riskier change than this one, so it is filed separately rather than folded in.

#473 should stay open until that lands, which is why this says `Refs` rather than `Closes`.
