### PR TITLE
fix(subst): count load nesting so substitutions install and remove once

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -24,6 +24,7 @@ on:
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
+      - "tests/subst-nesting.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
@@ -44,6 +45,7 @@ on:
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
+      - "tests/subst-nesting.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -243,6 +245,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test message formatting
         run: zsh -f tests/message-formatting.zsh
+
+  subst-nesting:
+    name: Subst Nesting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test substitution nesting
+        run: zsh -f tests/subst-nesting.zsh
 
   snippet-directory-mirror:
     name: Snippet directory mirror

--- a/tests/subst-nesting.zsh
+++ b/tests/subst-nesting.zsh
@@ -1,0 +1,120 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-subst-nesting-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/inner" \
+  "${temp_root}/snip" \
+  "${temp_root}/nests_plugin" \
+  "${temp_root}/nests_snippet" || fail "create isolated environment"
+
+builtin print -r -- ':' > "${temp_root}/inner/inner.plugin.zsh" || fail "write inner plug-in"
+builtin print -r -- ':' > "${temp_root}/snip/snippet.zsh" || fail "write inner snippet"
+
+# Loads a plug-in from its own body, then autoloads a function it owns. The
+# substitution has to still be installed for that autoload to be intercepted.
+builtin print -r -- 'builtin print -r -- nested-plugin-body' \
+  > "${temp_root}/nests_plugin/_issue_480_own" || fail "write owned function"
+builtin print -rl -- \
+  'zi light $ZI_TEST_ROOT/inner >/dev/null 2>&1' \
+  'autoload -Uz _issue_480_own' \
+  > "${temp_root}/nests_plugin/nests_plugin.plugin.zsh" || fail "write nesting plug-in"
+
+# Loads a snippet from its own body. The inlined compdef substitution used for
+# that must not tear down the enclosing plug-in's substitutions.
+builtin print -r -- 'zi snippet $ZI_TEST_ROOT/snip/snippet.zsh >/dev/null 2>&1' \
+  > "${temp_root}/nests_snippet/nests_snippet.plugin.zsh" || fail "write snippet-nesting plug-in"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "a nested load disturbs the enclosing substitutions"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+shadowed() {  # names currently replaced by a zi substitution
+  # Presence is not the test: compdef legitimately exists once compinit has
+  # run. Only a body that dispatches to :zi-tmp-subst-* is zi's.
+  typeset -a on
+  typeset name
+  for name ( autoload bindkey zstyle alias compdef ) {
+    [[ ${functions[$name]} == *:zi-tmp-subst-* ]] && on+=( $name )
+  }
+  builtin print -rn -- "${(j:,:)on}"
+}
+
+typeset baseline="$(shadowed)"
+[[ -z $baseline ]] || {
+  builtin print -u2 -r -- "substitutions were already installed before any load: $baseline"
+  return 1
+}
+
+# A plug-in that loads a snippet. The inlined compdef substitution shares the
+# nesting counter, so it must not remove what the enclosing load installed.
+zi light "${ZI_TEST_ROOT}/nests_snippet" >/dev/null 2>&1
+typeset leaked="$(shadowed)"
+[[ -z $leaked ]] || {
+  builtin print -u2 -r -- "a nested snippet load leaked substitutions to the top level: $leaked"
+  return 1
+}
+(( ${ZI[TMP_SUBST_DEPTH]} == 0 )) || {
+  builtin print -u2 -r -- "nesting depth did not return to zero: ${ZI[TMP_SUBST_DEPTH]}"
+  return 1
+}
+[[ ${ZI[TMP_SUBST]} == inactive ]] || {
+  builtin print -u2 -r -- "the substitution mode was left as ${ZI[TMP_SUBST]}"
+  return 1
+}
+
+# A plug-in that loads another plug-in and then autoloads its own function. The
+# substitution has to survive the inner load, so the function is claimed.
+zi light "${ZI_TEST_ROOT}/nests_plugin" >/dev/null 2>&1
+typeset result
+result="$(_issue_480_own 2>&1)" || {
+  builtin print -u2 -r -- "the enclosing plug-in's own function failed after a nested load: $result"
+  return 1
+}
+[[ $result == nested-plugin-body ]] || {
+  builtin print -u2 -r -- "unexpected body resolved: $result"
+  return 1
+}
+
+leaked="$(shadowed)"
+[[ -z $leaked ]] || {
+  builtin print -u2 -r -- "a nested plug-in load leaked substitutions to the top level: $leaked"
+  return 1
+}
+(( ${ZI[TMP_SUBST_DEPTH]} == 0 )) || {
+  builtin print -u2 -r -- "nesting depth did not return to zero: ${ZI[TMP_SUBST_DEPTH]}"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - nested loads keep the substitutions installed and remove them once"

--- a/zi.zsh
+++ b/zi.zsh
@@ -239,7 +239,7 @@ is-at-least 5.1 && ZI[NEW_AUTOLOAD]=1 || ZI[NEW_AUTOLOAD]=0
 #is-at-least 5.4 && ZI[NEW_AUTOLOAD]=2
 
 # Parameters - temporary substituting of functions. [[[
-ZI[TMP_SUBST]=inactive   ZI[DTRACE]=0    ZI[CUR_PLUGIN]=
+ZI[TMP_SUBST]=inactive   ZI[TMP_SUBST_DEPTH]=0   ZI[DTRACE]=0    ZI[CUR_PLUGIN]=
 # ]]]
 # Parameters - ICE. [[[
 typeset -gA ZI_1MAP ZI_2MAP
@@ -839,6 +839,12 @@ builtin setopt no_aliases
   #
   # It is always "dtrace" then "load" (i.e. dtrace then load) "dtrace" then "light" (i.e.:
   # dtrace then light load) "dtrace" then "compdef" (i.e.: dtrace then snippet).
+  # Loading is re-entrant: a plug-in body may load another plug-in or a
+  # snippet, and this is then entered again. Count the depth so the
+  # substitutions are installed once and removed only when the outermost load
+  # finishes. Every site that installs increments, every site that tears down
+  # decrements, and none of them can return in between.
+  (( ++ ZI[TMP_SUBST_DEPTH] ))
   [[ ${ZI[TMP_SUBST]} != inactive ]] && builtin return 0
   ZI[TMP_SUBST]="$mode"
   # The point about backups is: does the key exist in functions array.
@@ -888,7 +894,11 @@ builtin setopt no_aliases
   local mode="$1"
   # Disable temporary substituting of functions only once.
   # Disable temporary substituting of functions only the way it was enabled first.
+  (( ZI[TMP_SUBST_DEPTH] > 0 )) && (( -- ZI[TMP_SUBST_DEPTH] ))
   [[ ${ZI[TMP_SUBST]} = inactive || ${ZI[TMP_SUBST]} != $mode ]] && return 0
+  # An inner load of the same mode must not tear down what the outer one still
+  # needs.
+  (( ZI[TMP_SUBST_DEPTH] > 0 )) && return 0
   ZI[TMP_SUBST]=inactive
   if [[ $mode != compdef ]]; then
     # 0. Unfunction autoload.
@@ -1508,10 +1518,9 @@ builtin setopt no_aliases
       # Temporary substituting of functions code is inlined from .zi-tmp-subst-on.
       (( ${+functions[compdef]} )) && ZI[bkp-compdef]="${functions[compdef]}" || builtin unset "ZI[bkp-compdef]"
       functions[compdef]=':zi-tmp-subst-compdef "$@";'
-      ZI[TMP_SUBST]=1
-    else
-      (( ++ ZI[TMP_SUBST] ))
+      ZI[TMP_SUBST]=compdef
     fi
+    (( ++ ZI[TMP_SUBST_DEPTH] ))
 
     # Add to fpath.
     if [[ -d $local_dir/$dirname/functions ]] {
@@ -1552,7 +1561,8 @@ builtin setopt no_aliases
       .zi-wrap-functions "$save_url" "" "$id_as"
     }
     [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
-    (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+    (( ZI[TMP_SUBST_DEPTH] > 0 )) && (( -- ZI[TMP_SUBST_DEPTH] ))
+    (( ZI[TMP_SUBST_DEPTH] == 0 )) && [[ ${ZI[TMP_SUBST]} = compdef ]] && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
   elif [[ -n ${opts[(r)--command]} || ${ICE[as]} = command ]]; then
     [[ ${+ICE[pick]} = 1 && -z ${ICE[pick]} ]] && ICE[pick]="${id_as:t}"
     # Directory snippet - a directory and multiple files are possible.
@@ -1578,10 +1588,9 @@ builtin setopt no_aliases
         # Temporary substituting of functions code is inlined from .zi-tmp-subst-on.
         (( ${+functions[compdef]} )) && ZI[bkp-compdef]="${functions[compdef]}" || builtin unset "ZI[bkp-compdef]"
         functions[compdef]=':zi-tmp-subst-compdef "$@";'
-        ZI[TMP_SUBST]=1
-      else
-        (( ++ ZI[TMP_SUBST] ))
+        ZI[TMP_SUBST]=compdef
       fi
+      (( ++ ZI[TMP_SUBST_DEPTH] ))
     }
     if [[ -n ${ICE[src]} ]]; then
       ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"
@@ -1601,7 +1610,8 @@ builtin setopt no_aliases
     }
     [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$local_dir/$dirname/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$local_dir/$dirname"; } && builtin eval "${ICE[atload]#\!}"; ((1)); } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( ZI[TMP_SUBST_DEPTH] > 0 )) && (( -- ZI[TMP_SUBST_DEPTH] ))
+      (( ZI[TMP_SUBST_DEPTH] == 0 )) && [[ ${ZI[TMP_SUBST]} = compdef ]] && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))
@@ -1784,10 +1794,9 @@ builtin setopt no_aliases
         # Temporary substituting of functions code is inlined from .zi-tmp-subst-on.
         (( ${+functions[compdef]} )) && ZI[bkp-compdef]="${functions[compdef]}" || builtin unset "ZI[bkp-compdef]"
         functions[compdef]=':zi-tmp-subst-compdef "$@";'
-        ZI[TMP_SUBST]=1
-      else
-        (( ++ ZI[TMP_SUBST] ))
+        ZI[TMP_SUBST]=compdef
       fi
+      (( ++ ZI[TMP_SUBST_DEPTH] ))
     }
     local ZERO
     [[ $ICE[atinit] = '!'* ]] && { local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "${${${(M)___user:#%}:+$___plugin}:-${ZI[PLUGINS_DIR]}/${___id_as//\//---}}"; } && eval "${ICE[atinit#!]}"; ((1)); } || eval "${ICE[atinit]#!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
@@ -1806,7 +1815,8 @@ builtin setopt no_aliases
     }
     [[ ${ICE[atload][1]} = "!" ]] && { .zi-add-report "$___id_as" "Note: Starting to track the atload'!…' ice…"; ZERO="$___pdir_orig/-atload-"; local ___oldcd="$PWD"; (( ${+ICE[nocd]} == 0 )) && { () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___pdir_orig"; } && builtin eval "${ICE[atload]#\!}"; } || eval "${ICE[atload]#\!}"; () { builtin setopt local_options no_auto_pushd; builtin cd -q "$___oldcd"; }; }
     [[ -n ${ICE[src]} || -n ${ICE[multisrc]} || ${ICE[atload][1]} = "!" ]] && {
-      (( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
+      (( ZI[TMP_SUBST_DEPTH] > 0 )) && (( -- ZI[TMP_SUBST_DEPTH] ))
+      (( ZI[TMP_SUBST_DEPTH] == 0 )) && [[ ${ZI[TMP_SUBST]} = compdef ]] && { ZI[TMP_SUBST]=inactive; builtin setopt no_aliases; (( ${+ZI[bkp-compdef]} )) && functions[compdef]="${ZI[bkp-compdef]}" || unfunction compdef; (( ZI[ALIASES_OPT] )) && builtin setopt aliases; }
     }
   elif [[ ${ICE[as]} = completion ]]; then
     ((1))


### PR DESCRIPTION
Closes #480. Also completes #473, which #479 fixed only halfway.

## Problem

`ZI[TMP_SUBST]` carried two incompatible encodings on one key. `.zi-tmp-subst-on` stored a mode name (`load`, `light`, `compdef`, `dtrace`). Three inlined compdef-only blocks in `.zi-load-snippet` and `.zi-load-plugin` used the same key as a depth counter:

```zsh
ZI[TMP_SUBST]=1
(( ++ ZI[TMP_SUBST] ))
(( -- ZI[TMP_SUBST] == 0 )) && { ZI[TMP_SUBST]=inactive; ... }
```

Loading is re-entrant, so the two regimes met. Two distinct failures follow.

**A plug-in that loads another plug-in.** The inner `.zi-tmp-subst-on` returns early because a substitution is already installed, and then the inner `.zi-tmp-subst-off` matches on mode and tears it down while the outer plug-in is still running:

```text
[outer] before nested load: TMP_SUBST=[load] autoload_shadowed=1
[outer] after  nested load: TMP_SUBST=[inactive] autoload_shadowed=0
```

Everything the outer plug-in does afterwards stops being intercepted: FPATH-clean autoloading, and the `bindkey`, `zstyle`, `alias`, `zle` and `compdef` tracking that `zi report` and unload depend on. The plug-in loads, so nothing announces the loss.

**A plug-in that loads a snippet.** This hits the inlined blocks. `(( ++ ZI[TMP_SUBST] ))` on the string `load` evaluates it as an unset parameter name, so the mode silently becomes `1`:

```console
% ZI[TMP_SUBST]=load; (( ++ ZI[TMP_SUBST] )); print -r -- $ZI[TMP_SUBST]
1
```

The matching decrement then reaches 0, the compdef teardown runs and sets the key to `inactive`, and the outer `.zi-tmp-subst-off` returns early on `inactive`. The result is that zi's substitutions are never removed:

```text
top level before: autoload=0 bindkey=0 zstyle=0
top level after:  autoload=1 bindkey=1 zstyle=1
```

Every `autoload`, `bindkey` and `zstyle` the user types afterwards goes through zi's interception, attributed to no plug-in, for the life of the shell.

## Change

Give the depth its own key. `ZI[TMP_SUBST]` keeps meaning the installed mode or `inactive`; `ZI[TMP_SUBST_DEPTH]` counts entries. Every site that installs increments, every site that tears down decrements, the substitutions are installed on the transition out of `inactive`, and removed only when the count returns to zero.

Counting was chosen over wrapping the loaders in `always` blocks because no site returns between its install and its teardown. That was checked at all four sites before deciding; had any of them returned early, a leaked count would have been stickier than today's behaviour.

The three inlined blocks keep their own compdef-only install and restore. Only their bookkeeping changes, so what gets installed is untouched.

## Tests

`tests/subst-nesting.zsh` is new and registered in `zsh-n.yml`. It asserts that neither a nested plug-in load nor a nested snippet load leaks a substitution to the top level, that the depth returns to zero and the mode to `inactive`, and that a plug-in's own `autoload` still resolves after it has loaded another plug-in.

It tests for a body dispatching to `:zi-tmp-subst-*` rather than for the mere presence of the function, because `compdef` legitimately exists once `compinit` has run. The first draft got that wrong and reported a false leak at baseline.

Against `next` it fails with `a nested snippet load leaked substitutions to the top level: autoload,bindkey,zstyle,alias`.

## Verified

- Full `tests/*.zsh` sweep 18 of 18. `zsh -n` and `zcompile` clean.
- The #473 reproduction now passes end to end, along with the `cloneonly''` and nested-snippet shapes.
- The seven `autoload''` and `@autoload` forms from #478 still resolve.
- Performance: 150 sequential plug-in loads, medians of 14 interleaved rounds, `next` 0.4567 s against 0.4513 s here. Within noise.
