### PR TITLE
fix(ci): allow agent-generated and slugged branch names

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -95,14 +95,14 @@ jobs:
         env:
           BRANCH: ${{ github.head_ref }}
         run: |
-          PATTERN='^(feature|bug|hotfix)-[1-9][0-9]*$'
-          if echo "$BRANCH" | grep -qE '^(dependabot|renovate)/' || \
+          PATTERN='^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$'
+          if echo "$BRANCH" | grep -qE '^(dependabot|renovate|copilot|codex)/' || \
              [ "$BRANCH" = "next" ]; then
             echo "✅ OK"
             exit 0
           fi
           if ! echo "$BRANCH" | grep -qE "$PATTERN"; then
-            echo "::error::Branch name must be feature-<id>, bug-<id>, or hotfix-<id>"
+            echo "::error::Branch name must be feature-<id>, bug-<id>, or hotfix-<id>, optionally followed by a lowercase slug"
             exit 1
           fi
           echo "✅ Branch name valid"


### PR DESCRIPTION
Applies the two branch-name corrections tracked in
[z-shell/.github#590](https://github.com/z-shell/.github/issues/590) to this
repository's copy of the job.

1. `copilot/` and `codex/` join `dependabot/` and `renovate/` in the
   always-allowed prefixes. A coding agent picks those names, not the
   pull-request author, so rejecting them penalises something nobody chose.
   `app/copilot-swe-agent` produced `copilot/docs-adr-classify-zpmod`,
   `copilot/investigate-github-pages-ci`, and
   `copilot/fix-metrics-job-failure` in the organization repository.
2. The pattern becomes `^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$`, so a
   descriptive slug may follow the issue id. The old trailing anchor rejected
   `feature-478-repo-settings-audit` and
   `feature-505-zsh-lint-reference-corpus`, which carry the id and read better
   for it.

The issue id stays mandatory for author-chosen branches and `next` keeps its
persistent-integration exemption, so `decisions/0019-trunk-on-main-default.md`
is unchanged in substance. Shapes with no issue id at all, such as `code/` and
`fix/`, are still rejected; admitting those would reverse the issue-linked
naming the ADR decided and belongs in an ADR amendment rather than a pattern
tweak.

Verified with a table over 18 branch names covering both new allowances, the
existing bot prefixes, `next`, and the shapes that must keep failing
(`code/*`, `fix/*`, `feature-0`, `feature-505-`, `feature-505-Bad-Caps`,
`bugfix-12`). `actionlint` is clean.

Closes #484
