### PR TITLE
fix(ci): stop the trailer guard failing open on large messages

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -41,7 +41,12 @@ jobs:
           checked=0
 
           while IFS= read -r sha; do
-            if git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"; then
+            # grep -c, not grep -q. Under pipefail, grep -q exits on its first
+            # match while git is still writing, git takes SIGPIPE and returns
+            # 141, and the pipeline result turns a real match into a miss for
+            # any message larger than the pipe buffer. grep -c reads to the end,
+            # so the writer always finishes (z-shell/zi#486).
+            if [ "$(git show -s --format='%B' "$sha" | grep -ciE "$DISALLOWED_TRAILER_PATTERN")" -gt 0 ]; then
               echo "❌ Disallowed trailer found (${sha:0:7}): remove before merging"
               errors=$((errors + 1))
             fi


### PR DESCRIPTION
Fixes the fail-open reported in #486, matching z-shell/.github#596.

## The defect

`.github/workflows/commit-lint.yml` carries the same construct reported in
[z-shell/.github#587](https://github.com/z-shell/.github/issues/587). The
`Validate Commits` job matches the disallowed trailer as a pipeline under
`set -o pipefail`:

```sh
git show -s --format='%B' "$sha" | grep -qiE "$DISALLOWED_TRAILER_PATTERN"
```

`grep -q` exits on its first match. For a commit message larger than the pipe
buffer, `git` is still writing, takes `SIGPIPE`, and returns `141`. `pipefail`
promotes that to the pipeline result, so the `if` reads a real match as no
match and the banned trailer passes.

## Evidence

Four real commits evaluated under both constructs:

| Commit message               | `grep -q` | `grep -c` |
| ---------------------------- | --------- | --------- |
| Small, bot trailer           | FLAGGED   | FLAGGED   |
| 3 MB, bot trailer            | clean     | FLAGGED   |
| 3 MB, human `Co-authored-by` | clean     | clean     |
| 3 MB, no trailer             | clean     | clean     |

Only the second row changes, which is the defect.

## Fix

Use `grep -c` with a numeric test. `grep -c` reads to the end of its input, so
the writer always finishes and no `SIGPIPE` arises, and it keeps grep's own ERE
engine and `-i` semantics rather than swapping in bash `[[ =~ ]]` matching.

`grep -c` was chosen over a `[[ $message =~ $pattern ]]` rewrite deliberately.
Both stop the fail-open, but `[[ =~ ]]` swaps grep's ERE engine for bash's and
needs `shopt -s nocasematch` to keep the `-i` behaviour. The pattern contains
`[[:space:]]` and `\[bot\]`, and a silently different match here is worse than
the bug being fixed.

`actionlint` is clean.

## Why it matters here

This repository is one of the two AGENTS.md names as enforcing the bot and
AI-agent `Co-authored-by` ban in CI. A guard that fails open is the same class
of problem as z-shell/.github#575, where the enforcement existed but never
actually ran.

Closes #486
