### PR TITLE
feat(ci): apply the ADR-0022 branch shape check and issue link

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -100,14 +100,62 @@ jobs:
         env:
           BRANCH: ${{ github.head_ref }}
         run: |
-          PATTERN='^(feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*$'
+          # decisions/0022: a shape check, not an identifier check.
+          # Traceability moved to Validate Issue Link.
+          PATTERN='^((feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*|(feat|fix|perf|refactor|docs|test|build|ci|style|chore|revert|feature|bug|hotfix)/[a-z0-9]+(-[a-z0-9]+)*)$'
           if echo "$BRANCH" | grep -qE '^(dependabot|renovate|copilot|codex)/' || \
              [ "$BRANCH" = "next" ]; then
             echo "✅ OK"
             exit 0
           fi
           if ! echo "$BRANCH" | grep -qE "$PATTERN"; then
-            echo "::error::Branch name must be feature-<id>, bug-<id>, or hotfix-<id>, optionally followed by a lowercase slug"
+            echo "::error::Branch name must be feature-<id>, bug-<id>, or hotfix-<id> with an optional lowercase slug, or <type>/<slug> over the Conventional Commits types (z-shell/.github decisions/0022)"
             exit 1
           fi
           echo "✅ Branch name valid"
+
+  issue-link:
+    name: Validate Issue Link
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🔗 Check the pull request is traceable to an issue"
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BRANCH: ${{ github.head_ref }}
+          EXEMPT_LABEL: meta:no-issue
+        run: |
+          set -euo pipefail
+
+          # z-shell/.github decisions/0022 moves traceability off the branch
+          # name and onto the pull request. Three outcomes pass, and the job
+          # says which applied, so an exemption is visible in review rather
+          # than silent. Everything comes from the pull_request event payload,
+          # so the job needs no token.
+
+          if printf '%s\n' "$BRANCH" | grep -qE '^(dependabot|renovate|copilot|codex)/'; then
+            echo "✅ Exempt: $BRANCH is an automation branch"
+            exit 0
+          fi
+
+          if [ "$BRANCH" = "next" ]; then
+            echo "✅ Exempt: next is the persistent integration branch"
+            exit 0
+          fi
+
+          if printf '%s\n' "$PR_LABELS" | tr ',' '\n' | grep -qxF "$EXEMPT_LABEL"; then
+            echo "✅ Exempt: labelled $EXEMPT_LABEL"
+            exit 0
+          fi
+
+          # A bare #123, the cross-repository owner/repo#123 shorthand, or a
+          # full issue or pull-request URL.
+          ISSUE_REFERENCE_PATTERN='(^|[^A-Za-z0-9_])#[1-9][0-9]*([^0-9]|$)|[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[1-9][0-9]*|https://github\.com/[^/ ]+/[^/ ]+/(issues|pull)/[1-9][0-9]*'
+
+          if printf '%s\n' "${PR_BODY:-}" | grep -qE "$ISSUE_REFERENCE_PATTERN"; then
+            echo "✅ The pull request references an issue"
+            exit 0
+          fi
+
+          echo "::error::No issue reference found. Link the owning issue in the pull-request body (Closes #123, or a plain #123 for work an issue tracks but this does not close). If this pull request genuinely has no owning issue, a maintainer applies the ${EXEMPT_LABEL} label (z-shell/.github decisions/0022)."
+          exit 1


### PR DESCRIPTION
Applies `decisions/0022-issue-traceability-on-pull-requests.md` here, matching
z-shell/.github#600 and z-shell/.github#601. This repository carries the same
`commit-lint.yml` jobs with their patterns inlined, so it moves in step or the
two copies drift, which ADR-0022 step 5 warns about.

## Validate Branch Name becomes a shape check

```text
^((feature|bug|hotfix)-[1-9][0-9]*(-[a-z0-9]+)*
 |(feat|fix|perf|refactor|docs|test|build|ci|style|chore|revert|feature|bug|hotfix)/[a-z0-9]+(-[a-z0-9]+)*)$
```

`feature-<id>` stays valid and recommended. `next` keeps its
persistent-integration exemption under `decisions/0019`, and the automation
prefixes are unchanged.

Verified against the extracted pattern:

| Allowed | Rejected |
| ------- | -------- |
| `feature-489`, `bug-1` | `code/foo` |
| `fix/labeler-audit`, `docs/adr-rollout` | `ss-o-thing` |
| `feature/no-id` | `fix/Bad-Caps`, `bugfix-12` |

## Validate Issue Link is added

Passes on four outcomes and prints which applied, so an exemption is visible in
review rather than silent: an automation branch, `next`, a `meta:no-issue`
label, or an issue reference in the body. It reads only the `pull_request`
event payload, so it needs no token.

Reference forms accepted, each verified: `Closes #489`, the cross-repository
`z-shell/.github#595` shorthand, and a full URL. A body with no work item and
an empty body both fail.

## Two things to know before merging

**`code/` branches are still rejected.** `code` is not in the Conventional
Commits type set that ADR-0022 scoped the `<type>/<slug>` form to. That was the
accepted decision, not an oversight here.

**`meta:no-issue` does not yet exist as a label in this repository.** It is
declared in the organization catalog at `z-shell/.github:lib/labels.yml` and
reaches here through label sync. Until then the exemption path is simply
unusable; nothing breaks, because the check falls through to the body
reference. Worth syncing before anyone needs the exemption.

`actionlint` is clean.

Closes #489
