### PR TITLE
fix(autoload): restore the caller's $fpath in the +X branch

### DIFF
--- a/tests/plugin-autoload-fpath-scope.zsh
+++ b/tests/plugin-autoload-fpath-scope.zsh
@@ -23,6 +23,7 @@ command mkdir -p \
   "${temp_root}/data" \
   "${temp_root}/zdotdir" \
   "${temp_root}/cwd" \
+  "${temp_root}/foreign" \
   "${temp_root}/plugins/plusx/lib" || fail "create isolated environment"
 
 # The plug-in's own functions, one directly in the plug-in directory and one in
@@ -38,13 +39,22 @@ builtin print -r -- 'builtin print -r -- lib-body' \
 builtin print -r -- 'builtin print -r -- cwd-body' \
   > "${temp_root}/cwd/_issue_475_cwd" || fail "write working-directory function"
 
+# A function the plug-in does not own, in a directory the caller had in $fpath
+# before the load began. This is what zsh itself ships to a plug-in, and what
+# `Aloxaf/fzf-tab' needs when it copies $functions[_main_complete] at load time.
+# Immediate `autoload +X' has to resolve it from the caller's search path, which
+# means the +X branch must carry that path across its own localisation of $fpath.
+builtin print -r -- 'builtin print -r -- foreign-body' \
+  > "${temp_root}/foreign/_issue_488_foreign" || fail "write foreign function"
+
 builtin print -rl -- \
   '0=${(%):-%N}' \
   'fpath+=( ${0:A:h}/lib )' \
   'autoload +X -Uz _issue_475_own' \
   'autoload +X -Uz _issue_475_lib' \
   'autoload +X -Uz _issue_475_cwd 2>/dev/null' \
-  ': the third autoload is expected to find nothing' \
+  'autoload +X -Uz _issue_488_foreign 2>/dev/null' \
+  ': a failed +X must not change the plug-in exit status' \
   > "${temp_root}/plugins/plusx/plusx.plugin.zsh" || fail "write plug-in"
 
 env \
@@ -62,6 +72,7 @@ setopt pipe_fail
 builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
 .zi-prepare-home || return 1
 
+fpath+=( "${ZI_TEST_ROOT}/foreign" )
 typeset before_fpath="${(j.:.)fpath}" before_FPATH="$FPATH"
 builtin cd -q "${ZI_TEST_ROOT}/cwd" || return 1
 # blockf so that the plug-in's own `fpath+=' is reverted and anything left
@@ -104,6 +115,15 @@ result="$(_issue_475_lib 2>&1)" || {
   builtin print -u2 -r -- "the working directory was searched: _issue_475_cwd was loaded from \$PWD"
   return 1
 }
+
+result="$(_issue_488_foreign 2>&1)" || {
+  builtin print -u2 -r -- "immediate autoload of a function the plug-in does not own failed: $result"
+  return 1
+}
+[[ $result == foreign-body ]] || {
+  builtin print -u2 -r -- "unexpected foreign body resolved: $result"
+  return 1
+}
 ZSH
 
-builtin print -r -- "ok - immediate autoload keeps to the plug-in's own directories and restores \$fpath"
+builtin print -r -- "ok - immediate autoload resolves the plug-in's own and the caller's functions, and restores \$fpath"

--- a/zi.zsh
+++ b/zi.zsh
@@ -458,8 +458,15 @@ builtin setopt no_aliases
   fi
   if [[ -n ${(M)@:#+X} ]]; then
     .zi-add-report "${ZI[CUR_USPL2]}" "Autoload +X ${opts:+${(j: :)opts[@]} }${(j: :)${@:#+X}}"
+    # Capture the caller's search path before localising, exactly as
+    # :zi-reload-and-run does. `local +h -a fpath' creates a fresh empty array,
+    # so a $fpath on the right-hand side of the assignment below would expand to
+    # nothing and drop every foreign search path -- and `autoload +X' of a
+    # function the plug-in does not own would then resolve nowhere.
+    local -a ___fpath
+    ___fpath=( $fpath )
     local +h -a fpath
-    fpath=( $PLUGIN_DIR $fpath_elements $fpath )
+    fpath=( $PLUGIN_DIR $fpath_elements $___fpath )
     builtin autoload +X ${opts[@]} "${@:#+X}"
     return $?
   fi


### PR DESCRIPTION
Restores the caller's `$fpath` in the `+X` branch of `:zi-tmp-subst-autoload`, and pins the neighbouring `-w` branch against the same class of mistake.

## The defect

#477 removed this line as dead:

```zsh
local +h FPATH=$PLUGINS_DIR${fpath_elements:+:${(j.:.)fpath_elements[@]}}:$FPATH
```

It was not dead. `fpath` and `FPATH` are tied, so that line already created the local pair populated with the caller's search path. The `local +h -a fpath` that follows does not reset it, because the variable is by then already local to the scope. Without the scalar, `local +h -a fpath` creates a fresh empty array, `$fpath` on the right-hand side of `fpath=( $PLUGIN_DIR $fpath_elements $fpath )` expands to nothing, and only `$PLUGIN_DIR` survives.

Immediate `autoload +X` of any function the loading plug-in does not own then resolves nowhere. The prominent casualty is `Aloxaf/fzf-tab`, which copies `$functions[_main_complete]` at load time and so needs the function genuinely resolved rather than left as a stub. This matters more since #472, which deliberately routes foreign functions down this branch.

The `$PLUGINS_DIR` typo #475 reported was real, but it only blanked the first field; the trailing `:$FPATH` was carrying the entire search path.

## The fix

Capture the caller's value explicitly rather than restoring the scalar. The tie is subtle enough that it invited the removal once already, and restoring the old line verbatim would prepend `$PLUGIN_DIR` twice, once through the scalar and once through the array assignment. The capture-then-localise form is the idiom `:zi-reload-and-run` already uses a few lines above, so the branch becomes consistent with its neighbour instead of acquiring a new local style. The typo is not reintroduced in any form.

## Test

`tests/plugin-autoload-fpath-scope.zsh` gains the case that would have caught this: `autoload +X` of a function in a directory the caller had in `$fpath` before the load, outside the plug-in's own tree. The existing assertions only covered the plug-in's own directories, which still resolve from `$PLUGIN_DIR`, so they passed on both sides of #477. It uses a synthetic directory rather than `_main_complete`, so it does not depend on what the CI zsh image ships. It fails without this change.

Full suite 18/18, `zsh -n` clean, also green under `umask 077`.

Closes #488
