### PR TITLE
fix(release): install Zsh before verifying the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install -yq zsh
+
       - name: Verify release authorization
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds the missing Zsh install to the publish job. One step.

## The defect

`release.yml` runs the authorization verifier under Zsh:

```yaml
- name: Verify release authorization
  run: zsh -f scripts/verify-release-tag.zsh
```

`ubuntu-latest` ships no Zsh, so the step exits 127 before any verification happens and publication fails for every tag:

```text
/home/runner/work/_temp/....sh: line 1: zsh: command not found
##[error]Process completed with exit code 127
```

Every other workflow that runs Zsh installs it first (`promotion-readiness.yml:27`, `zsh-n.yml:84`). The publish job was the only one that did not. I swept the remaining workflows for the same shape and found no other occurrence.

## Why it went unnoticed

The workflow reached `main` only with #494, since #470 added it on `next` before v2.0.0 shipped. Pushing `v2.0.1` was its first ever execution, and it failed on that run. Latent since #470.

## What happened to v2.0.1

Published manually, because the alternative was worse. `verify-release-tag.zsh` requires the tag target to equal the current `origin/main`, so landing this fix moves `main` and invalidates any tag already pushed. Recovering through the workflow would have meant either moving a public tag or burning a version number.

Before publishing I ran the verifier locally against the exact tag:

```text
Release authorization verified for v2.0.1 at 86758198344052d60b25f454cd3b64269a8ef2ea.
```

so the authorization logic was exercised in full and only its broken execution environment was bypassed.

## Follow-up worth considering, not in this PR

That same tag-equals-`main` precondition is what made this failure expensive to recover from: any fix to the release path invalidates the pending tag. Loosening it to "tag target is an ancestor of `origin/main`" would preserve the intent, that a release comes from reviewed stable history, while allowing a straightforward retry. Raised in #496 and left for a separate decision.

Closes #496
