### PR TITLE
fix(unload): reach the Plugin Standard unload function

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -27,6 +27,7 @@ on:
       - "tests/snippet-directory-mirror.zsh"
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
+      - "tests/unload-hook-dispatch.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
@@ -50,6 +51,7 @@ on:
       - "tests/snippet-directory-mirror.zsh"
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
+      - "tests/unload-hook-dispatch.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -97,6 +99,17 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+
+  unload-hook-dispatch:
+    name: Unload Hook Dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test unload hook dispatch
+        run: zsh -f tests/unload-hook-dispatch.zsh
 
   version-reporting:
     name: Version reporting

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -897,7 +897,26 @@ ZI[EXTENDED_GLOB]=""
   # Call the Zsh Plugin's Standard *_plugin_unload function
   #
 
-  (( ${+functions[${plugin}_plugin_unload]} )) && ${plugin}_plugin_unload
+  # The Plugin Standard derives this name from the plug-in's name, and $plugin
+  # was used verbatim. Two kinds of plug-in could therefore never be reached:
+  #
+  #   - a hyphenated repository, because ADR-0020's namespace rules require the
+  #     shell prefix to use underscores, so `zsh-eza' can define
+  #     `zsh_eza_plugin_unload' or be unloadable by Zi, but not both;
+  #   - a plug-in loaded by path, whose $plugin is the absolute directory, so
+  #     `/path/to/thing_plugin_unload' names nothing.
+  #
+  # Try the literal name first so plug-ins already defining it keep working,
+  # then the underscore form, then the same pair derived from the directory
+  # basename, which is the closest analogue of a repository name for a
+  # path-loaded plug-in. Call the first that exists; the Standard defines a
+  # single unload function per plug-in.
+  local ___base="${plugin:t}" ___cand
+  local -a ___cand_names
+  ___cand_names=( "$plugin" "${plugin//-/_}" "$___base" "${___base//-/_}" )
+  for ___cand ( ${(u)___cand_names[@]} ) {
+    (( ${+functions[${___cand}_plugin_unload]} )) && { "${___cand}_plugin_unload"; break; }
+  }
 
   #
   # Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload

--- a/tests/unload-hook-dispatch.zsh
+++ b/tests/unload-hook-dispatch.zsh
@@ -1,0 +1,90 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-unload-hook-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/plain" \
+  "${temp_root}/hyph-en" || fail "create isolated environment"
+
+# A plug-in whose directory name has no hyphen. Its unload function is named
+# after the directory, which is the Plugin Standard shape.
+builtin print -rl -- \
+  'plain_plugin_unload() { builtin print -r -- plain-hook-ran >> $ZI_TEST_LOG; }' \
+  > "${temp_root}/plain/plain.plugin.zsh" || fail "write the plain plug-in"
+
+# A plug-in whose directory name has a hyphen. ADR-0020 namespace rules require
+# the shell prefix to use underscores, so the only name it may define is the
+# underscore form. Before the fix nothing looked for that name.
+builtin print -rl -- \
+  'hyph_en_plugin_unload() { builtin print -r -- hyphen-hook-ran >> $ZI_TEST_LOG; }' \
+  > "${temp_root}/hyph-en/hyph-en.plugin.zsh" || fail "write the hyphenated plug-in"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  ZI_TEST_LOG="${temp_root}/hooks.log" \
+  zsh -f <<'ZSH' || fail "the Plugin Standard unload function was not called"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+: > "$ZI_TEST_LOG"
+
+zi load "${ZI_TEST_ROOT}/plain" >/dev/null 2>&1
+(( ${+functions[plain_plugin_unload]} )) || {
+  builtin print -u2 -r -- "the plain plug-in did not define its unload function"
+  return 1
+}
+zi unload "${ZI_TEST_ROOT}/plain" >/dev/null 2>&1
+
+zi load "${ZI_TEST_ROOT}/hyph-en" >/dev/null 2>&1
+(( ${+functions[hyph_en_plugin_unload]} )) || {
+  builtin print -u2 -r -- "the hyphenated plug-in did not define its unload function"
+  return 1
+}
+zi unload "${ZI_TEST_ROOT}/hyph-en" >/dev/null 2>&1
+
+typeset log="$(<$ZI_TEST_LOG)"
+
+# A path-loaded plug-in is identified as `%<absolute path>', so the name derived
+# verbatim from the id can never match. The basename is the analogue of a
+# repository name.
+[[ $log == *plain-hook-ran* ]] || {
+  builtin print -u2 -r -- "the unload function of a path-loaded plug-in was not called: [$log]"
+  return 1
+}
+
+# The underscore form, which is the only name ADR-0020 permits a hyphenated
+# plug-in to define.
+[[ $log == *hyphen-hook-ran* ]] || {
+  builtin print -u2 -r -- "the underscore-named unload function was not called: [$log]"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - the Plugin Standard unload function is reached for hyphenated and path-loaded plug-ins"


### PR DESCRIPTION
Makes the Plugin Standard unload function reachable. Fixes the reported case and a second one found while building z-shell/zd#119.

## The defect

```zsh
(( ${+functions[${plugin}_plugin_unload]} )) && ${plugin}_plugin_unload
```

`$plugin` was used verbatim, so two kinds of plug-in could never be reached.

**Hyphenated repositories**, the reported case. ADR-0020's namespace rules require the shell prefix to use underscores, so `zsh-eza` can define `zsh_eza_plugin_unload` and satisfy the standard, or define `zsh-eza_plugin_unload` and be unloadable by Zi. Not both.

**Path-loaded plug-ins**, which were not in the report. Such a plug-in is identified as `%<absolute path>` and `$plugin` is the directory, so the derived name is `/path/to/thing_plugin_unload`, which names nothing. Demonstrated while adding unload coverage:

```text
PLUGINS_LIST: %/tmp/.../ulprobe
UNLOADED: func=0 alias=0 fpath_restored=1     # ulprobe_plugin_unload never ran
Running plugin's provided unload code: print -r -- STD-HOOK-RAN   # this did
```

`@zsh-plugin-run-on-unload` worked in both cases, which is why the gap stayed invisible: plug-ins using the callback were fine, and only the named-hook contract was broken.

## The fix

Try candidate names in order and call the first that exists:

1. the literal name, so plug-ins already defining it keep working
2. the underscore form, which is the only name ADR-0020 permits a hyphenated plug-in to define
3. and 4. the same pair derived from the directory basename, the closest analogue of a repository name for a path-loaded plug-in

Duplicates collapse through `(u)`, and exactly one function is called, since the Standard defines a single unload function per plug-in.

**The change is additive.** No name that resolved before stops resolving.

## Test

`tests/unload-hook-dispatch.zsh` loads and unloads two plug-ins, one plainly named and one hyphenated, each defining only the name its own rules permit, then asserts both hooks ran. Against the previous dispatch:

```text
the unload function of a path-loaded plug-in was not called: []
not ok - the Plugin Standard unload function was not called      exit=1
```

Registered in `zsh-n.yml`, both path filters and a job. Full suite 21/21.

## Note on scope

This restores the hook's reachability. It does not change what the hook is expected to do, and it does not touch z-shell/zi#113 or z-shell/zi#483, which are separate unload defects. z-shell/zd#119 now asserts the four unload contracts that already worked, so a case for each of those can land with its fix.

Closes #482
