### PR TITLE
chore: promote next to main

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -25,6 +25,7 @@ on:
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
+      - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
@@ -47,6 +48,7 @@ on:
       - "tests/fixtures/plugin-standard-callbacks/**"
       - "tests/self-update-reload.zsh"
       - "tests/snippet-directory-mirror.zsh"
+      - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
@@ -258,6 +260,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test message formatting
         run: zsh -f tests/message-formatting.zsh
+
+  source-hygiene:
+    name: Source Hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test source hygiene
+        run: zsh -f tests/source-hygiene.zsh
 
   subst-nesting:
     name: Subst Nesting

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -27,6 +27,7 @@ on:
       - "tests/snippet-directory-mirror.zsh"
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
+      - "tests/unload-hook-dispatch.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
@@ -50,6 +51,7 @@ on:
       - "tests/snippet-directory-mirror.zsh"
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
+      - "tests/unload-hook-dispatch.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -97,6 +99,17 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+
+  unload-hook-dispatch:
+    name: Unload Hook Dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test unload hook dispatch
+        run: zsh -f tests/unload-hook-dispatch.zsh
 
   version-reporting:
     name: Version reporting

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -29,6 +29,7 @@ on:
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
       - "tests/unload-hook-dispatch.zsh"
+      - "tests/unload-ownership-contracts.zsh"
       - "tests/version-reporting.zsh"
   pull_request:
     paths:
@@ -54,6 +55,7 @@ on:
       - "tests/source-hygiene.zsh"
       - "tests/subst-nesting.zsh"
       - "tests/unload-hook-dispatch.zsh"
+      - "tests/unload-ownership-contracts.zsh"
       - "tests/version-reporting.zsh"
   workflow_dispatch: {}
 
@@ -101,6 +103,17 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+
+  unload-ownership-contracts:
+    name: Unload Ownership Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test unload ownership contracts
+        run: zsh -f tests/unload-ownership-contracts.zsh
 
   unload-hook-dispatch:
     name: Unload Hook Dispatch

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -12,6 +12,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/hook-ownership.zsh"
+      - "tests/load-object-status.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -33,6 +34,7 @@ on:
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/hook-ownership.zsh"
+      - "tests/load-object-status.zsh"
       - "tests/message-formatting.zsh"
       - "tests/path-resolution.zsh"
       - "tests/parallel-update.zsh"
@@ -147,6 +149,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test autoload ice forms
         run: zsh -f tests/plugin-autoload-ice.zsh
+  load-object-status:
+    name: Load Object Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test load object status
+        run: zsh -f tests/load-object-status.zsh
+
   nested-load-state:
     name: Nested Load State
     runs-on: ubuntu-latest

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/annex-unregister.zsh"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/hook-ownership.zsh"
@@ -33,6 +34,7 @@ on:
     paths:
       - "zi.zsh"
       - "lib/**"
+      - "tests/annex-unregister.zsh"
       - "tests/archive-extraction.zsh"
       - "tests/completion-refresh.zsh"
       - "tests/hook-ownership.zsh"
@@ -229,6 +231,17 @@ jobs:
         run: sudo apt update && sudo apt-get install -yq zsh
       - name: Test scheduler idle behavior
         run: zsh -f tests/scheduler-idle.zsh
+
+  annex-unregister:
+    name: Annex Unregister
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Zsh
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: Test annex unregister
+        run: zsh -f tests/annex-unregister.zsh
 
   archive-extraction:
     name: Archive extraction

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -897,7 +897,26 @@ ZI[EXTENDED_GLOB]=""
   # Call the Zsh Plugin's Standard *_plugin_unload function
   #
 
-  (( ${+functions[${plugin}_plugin_unload]} )) && ${plugin}_plugin_unload
+  # The Plugin Standard derives this name from the plug-in's name, and $plugin
+  # was used verbatim. Two kinds of plug-in could therefore never be reached:
+  #
+  #   - a hyphenated repository, because ADR-0020's namespace rules require the
+  #     shell prefix to use underscores, so `zsh-eza' can define
+  #     `zsh_eza_plugin_unload' or be unloadable by Zi, but not both;
+  #   - a plug-in loaded by path, whose $plugin is the absolute directory, so
+  #     `/path/to/thing_plugin_unload' names nothing.
+  #
+  # Try the literal name first so plug-ins already defining it keep working,
+  # then the underscore form, then the same pair derived from the directory
+  # basename, which is the closest analogue of a repository name for a
+  # path-loaded plug-in. Call the first that exists; the Standard defines a
+  # single unload function per plug-in.
+  local ___base="${plugin:t}" ___cand
+  local -a ___cand_names
+  ___cand_names=( "$plugin" "${plugin//-/_}" "$___base" "${___base//-/_}" )
+  for ___cand ( ${(u)___cand_names[@]} ) {
+    (( ${+functions[${___cand}_plugin_unload]} )) && { "${___cand}_plugin_unload"; break; }
+  }
 
   #
   # Call the code provided by the Zsh Plugin Standard @zsh-plugin-run-on-unload

--- a/lib/zsh/autoload.zsh
+++ b/lib/zsh/autoload.zsh
@@ -299,14 +299,6 @@ ZI[EXTENDED_GLOB]=""
   fi
   return 0
 } # ]]]
-# FUNCTION: .zi-at-eval [[[
-.zi-at-eval() {
-  local atclone="$2" atpull="$1"
-  integer retval
-  @zi-substitute atclone atpull
-  [[ $atpull = "%atclone" ]] && { eval "$atclone"; retval=$?; } || { eval "$atpull"; retval=$?; }
-  return $retval
-} # ]]]
 
 #
 # Format functions
@@ -1917,7 +1909,7 @@ ZI[EXTENDED_GLOB]=""
   +zi-message "{mmdsh}{happy} Zi{rst} » {info3}update took {num}$SECONDS{info3} seconds{rst}{…}"
   return "$retval"
 } # ]]]
-# FUNCTION: .zi-update-in-parallel [[[
+# FUNCTION: .zi-update-all-parallel [[[
 .zi-update-all-parallel() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops no_monitor no_notify

--- a/tests/annex-unregister.zsh
+++ b/tests/annex-unregister.zsh
@@ -1,0 +1,100 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-annex-unregister-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/first" \
+  "${temp_root}/second" || fail "create isolated environment"
+
+builtin print -r -- 'builtin print -r -- first-loaded' \
+  > "${temp_root}/first/first.plugin.zsh" || fail "write the first plug-in"
+builtin print -r -- 'builtin print -r -- second-loaded' \
+  > "${temp_root}/second/second.plugin.zsh" || fail "write the second plug-in"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "an unregistered annex hook still affects later plug-in loads"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+# Unregistering something never registered is a no-op, not an error.
+@zi-unregister-annex never-registered hook:before-load-2 || {
+  builtin print -u2 -r -- "unregistering an absent annex reported an error"
+  return 1
+}
+
+probe_annex_handler() { return 0; }
+@zi-register-annex probe-annex hook:before-load-2 probe_annex_handler '' ''
+
+# The Plugin Standard unload contract has the annex remove its own handler.
+# Without a matching unregister the ZI_EXTS entry survives, the before-load
+# dispatch calls a name that no longer exists, and the resulting 127 is folded
+# into the return value and shifts the argument list for the rest of the
+# session.
+@zi-unregister-annex probe-annex hook:before-load-2
+unfunction probe_annex_handler
+
+typeset output status_first status_second
+output="$(zi load "${ZI_TEST_ROOT}/first" 2>&1)"
+status_first=$?
+[[ $status_first -eq 0 ]] || {
+  builtin print -u2 -r -- "loading after unregister returned ${status_first}: ${output}"
+  return 1
+}
+[[ $output == *first-loaded* ]] || {
+  builtin print -u2 -r -- "the first plug-in did not load: ${output}"
+  return 1
+}
+
+# A second load proves the argument list was not shifted by the first.
+output="$(zi load "${ZI_TEST_ROOT}/second" 2>&1)"
+status_second=$?
+[[ $status_second -eq 0 ]] || {
+  builtin print -u2 -r -- "the second load returned ${status_second}: ${output}"
+  return 1
+}
+[[ $output == *second-loaded* ]] || {
+  builtin print -u2 -r -- "the second plug-in did not load: ${output}"
+  return 1
+}
+
+# The registry itself no longer holds the entry.
+typeset key found=0
+for key in "${(@k)ZI_EXTS}"; do
+  [[ ${ZI_EXTS[$key]} == *probe_annex_handler* ]] && found=1
+done
+(( found == 0 )) || {
+  builtin print -u2 -r -- "a ZI_EXTS entry for the unregistered annex survived"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - an unregistered annex hook is removed and later plug-in loads are unaffected"

--- a/tests/load-object-status.zsh
+++ b/tests/load-object-status.zsh
@@ -1,0 +1,86 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-load-object-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" || fail "create isolated environment"
+
+# .zi-load-object is a thin dispatcher over .zi-load and .zi-load-snippet. Stub
+# both so the status it reports is unambiguously the one it was given, with no
+# dependency on a real plug-in, the network, or the filesystem.
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  zsh -f <<'ZSH' || fail ".zi-load-object does not report the status of the load it performed"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+integer stub_status=0
+.zi-load()         { return $stub_status; }
+.zi-load-snippet() { return $stub_status; }
+
+check() {  # check <label> <type> <stubbed status> <expected status>
+  local label="$1" type="$2"
+  stub_status=$3
+  local -i expected=$4 actual
+  .zi-load-object "$type" some-id
+  actual=$?
+  [[ $actual -eq $expected ]] || {
+    builtin print -u2 -r -- "${label}: expected ${expected}, got ${actual}"
+    return 1
+  }
+}
+
+check "plugin success"  plugin  0 0 || return 1
+check "snippet success" snippet 0 0 || return 1
+# The failure paths are the point. Before this was fixed the helper returned the
+# undefined `__retval', which zsh evaluates arithmetically as 0, so every load
+# reported success and turbo scheduling proceeded after a failed immediate load.
+check "plugin failure"  plugin  7 7 || return 1
+check "snippet failure" snippet 5 5 || return 1
+
+# The caller adds the reported status to its own accumulator exactly once. The
+# helper must not also add to a dynamically scoped ___retval, which would
+# double-count every failure.
+() {
+  integer ___retval=0
+  stub_status=3
+  .zi-load-object plugin some-id
+  integer reported=$?
+  [[ $reported -eq 3 ]] || {
+    builtin print -u2 -r -- "aggregation: expected a reported status of 3, got ${reported}"
+    return 1
+  }
+  (( ___retval == 0 )) || {
+    builtin print -u2 -r -- "aggregation: the helper modified the caller's \$___retval to ${___retval}"
+    return 1
+  }
+} || return 1
+ZSH
+
+builtin print -r -- "ok - .zi-load-object reports its own load status and leaves aggregation to the caller"

--- a/tests/source-hygiene.zsh
+++ b/tests/source-hygiene.zsh
@@ -1,0 +1,80 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Structural checks over the shipped sources. Neither can be caught by a
+# behavioural test: a duplicate definition whose copies agree behaves correctly
+# until they drift, and a wrong header misleads only the next reader. Both are
+# cheap to assert and expensive to rediscover.
+
+builtin emulate -R zsh
+setopt extended_glob pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+builtin cd -q "$project_root" || fail "enter the project root"
+
+typeset -a sources
+sources=( zi.zsh lib/zsh/*.zsh(N) )
+(( ${#sources} )) || fail "locate the shipped sources"
+
+# A top-level definition: a name in column one followed by `()'. Indented
+# definitions are anonymous or nested helpers and are deliberately not counted.
+typeset -r name_class='[A-Za-z_@.:+][A-Za-z0-9_@.:+-]#'
+
+typeset -A seen_in
+typeset -a duplicates mismatches
+typeset src name header defined
+typeset -a lines
+typeset -i i j
+
+for src in "${sources[@]}"; do
+  lines=( "${(@f)$(<$src)}" )
+
+  for (( i = 1; i <= ${#lines}; i++ )); do
+    # Every function is defined exactly once across the shipped sources. Both
+    # libraries are sourced conditionally and in different orders depending on
+    # the command, so a second definition does not reliably override the first:
+    # which one wins varies by code path. `.zi-at-eval' was defined in both
+    # lib/zsh/autoload.zsh and lib/zsh/install.zsh with matching behaviour and
+    # different wording, exactly the shape that becomes a heisenbug once the
+    # two drift.
+    if [[ ${lines[i]} == (#b)(${~name_class})[[:space:]]#'()'* ]]; then
+      name="${match[1]}"
+      if [[ -n ${seen_in[$name]} ]]; then
+        duplicates+=( "${name}: ${seen_in[$name]} and ${src}:${i}" )
+      else
+        seen_in[$name]="${src}:${i}"
+      fi
+      continue
+    fi
+
+    # Every `# FUNCTION: <name>' header names the function it precedes.
+    if [[ ${lines[i]} == (#b)'#'[[:space:]]#'FUNCTION:'[[:space:]]#(${~name_class})* ]]; then
+      header="${match[1]%.}"
+      for (( j = i + 1; j <= i + 6 && j <= ${#lines}; j++ )); do
+        [[ ${lines[j]} == (#b)(${~name_class})[[:space:]]#'()'* ]] || continue
+        defined="${match[1]}"
+        [[ $header == $defined ]] ||
+          mismatches+=( "${src}:${i} header '${header}' precedes '${defined}'" )
+        break
+      done
+    fi
+  done
+done
+
+if (( ${#duplicates} )); then
+  builtin print -u2 -rl -- "functions defined more than once:" "${duplicates[@]}"
+  fail "a function is defined in more than one shipped source"
+fi
+
+if (( ${#mismatches} )); then
+  builtin print -u2 -rl -- "FUNCTION headers naming a different function:" "${mismatches[@]}"
+  fail "a FUNCTION header does not match the function it precedes"
+fi
+
+builtin print -r -- "ok - every function is defined once and every FUNCTION header matches (${#seen_in} functions)"

--- a/tests/unload-hook-dispatch.zsh
+++ b/tests/unload-hook-dispatch.zsh
@@ -1,0 +1,90 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-unload-hook-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/plain" \
+  "${temp_root}/hyph-en" || fail "create isolated environment"
+
+# A plug-in whose directory name has no hyphen. Its unload function is named
+# after the directory, which is the Plugin Standard shape.
+builtin print -rl -- \
+  'plain_plugin_unload() { builtin print -r -- plain-hook-ran >> $ZI_TEST_LOG; }' \
+  > "${temp_root}/plain/plain.plugin.zsh" || fail "write the plain plug-in"
+
+# A plug-in whose directory name has a hyphen. ADR-0020 namespace rules require
+# the shell prefix to use underscores, so the only name it may define is the
+# underscore form. Before the fix nothing looked for that name.
+builtin print -rl -- \
+  'hyph_en_plugin_unload() { builtin print -r -- hyphen-hook-ran >> $ZI_TEST_LOG; }' \
+  > "${temp_root}/hyph-en/hyph-en.plugin.zsh" || fail "write the hyphenated plug-in"
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  ZI_TEST_LOG="${temp_root}/hooks.log" \
+  zsh -f <<'ZSH' || fail "the Plugin Standard unload function was not called"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+: > "$ZI_TEST_LOG"
+
+zi load "${ZI_TEST_ROOT}/plain" >/dev/null 2>&1
+(( ${+functions[plain_plugin_unload]} )) || {
+  builtin print -u2 -r -- "the plain plug-in did not define its unload function"
+  return 1
+}
+zi unload "${ZI_TEST_ROOT}/plain" >/dev/null 2>&1
+
+zi load "${ZI_TEST_ROOT}/hyph-en" >/dev/null 2>&1
+(( ${+functions[hyph_en_plugin_unload]} )) || {
+  builtin print -u2 -r -- "the hyphenated plug-in did not define its unload function"
+  return 1
+}
+zi unload "${ZI_TEST_ROOT}/hyph-en" >/dev/null 2>&1
+
+typeset log="$(<$ZI_TEST_LOG)"
+
+# A path-loaded plug-in is identified as `%<absolute path>', so the name derived
+# verbatim from the id can never match. The basename is the analogue of a
+# repository name.
+[[ $log == *plain-hook-ran* ]] || {
+  builtin print -u2 -r -- "the unload function of a path-loaded plug-in was not called: [$log]"
+  return 1
+}
+
+# The underscore form, which is the only name ADR-0020 permits a hyphenated
+# plug-in to define.
+[[ $log == *hyphen-hook-ran* ]] || {
+  builtin print -u2 -r -- "the underscore-named unload function was not called: [$log]"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - the Plugin Standard unload function is reached for hyphenated and path-loaded plug-ins"

--- a/tests/unload-ownership-contracts.zsh
+++ b/tests/unload-ownership-contracts.zsh
@@ -1,0 +1,122 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# The unload ownership contracts that hold today, pinned so a future change to
+# the ownership model cannot quietly break them.
+#
+# z-shell/zi#113 proposes representing function, widget and bindkey ownership
+# per load instance rather than by plug-in id. Measuring the current behaviour
+# first showed the defect is narrower than that issue's prose: every
+# multi-plug-in path already restores the correct previous owner, and only a
+# repeated load of the *same* plug-in leaks. The repeated-load case is therefore
+# deliberately absent here; it belongs with its fix, not ahead of it.
+
+builtin emulate -R zsh
+setopt pipe_fail
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+typeset project_root="${ZI_TEST_CHECKOUT:-${0:A:h:h}}"
+typeset temp_root
+temp_root="$(command mktemp -d "${TMPDIR:-/tmp}/zi-ownership-test.XXXXXXXX")" ||
+  fail "create temporary directory"
+trap 'command rm -rf -- "$temp_root"' EXIT INT TERM
+
+command mkdir -p \
+  "${temp_root}/home" \
+  "${temp_root}/cache" \
+  "${temp_root}/config" \
+  "${temp_root}/data" \
+  "${temp_root}/zdotdir" \
+  "${temp_root}/first" \
+  "${temp_root}/second" || fail "create isolated environment"
+
+# Two plug-ins competing for the same function, widget and key binding.
+typeset which
+for which in first second; do
+  builtin print -rl -- \
+    "${which}_impl() { builtin print -r -- ${which}-body; }" \
+    "zle -N zi-ownership-widget ${which}_impl" \
+    "bindkey '^X^P' zi-ownership-widget" \
+    > "${temp_root}/${which}/${which}.plugin.zsh" || fail "write the ${which} plug-in"
+done
+
+env \
+  HOME="${temp_root}/home" \
+  XDG_CACHE_HOME="${temp_root}/cache" \
+  XDG_CONFIG_HOME="${temp_root}/config" \
+  XDG_DATA_HOME="${temp_root}/data" \
+  ZDOTDIR="${temp_root}/zdotdir" \
+  ZI_TEST_CHECKOUT="$project_root" \
+  ZI_TEST_ROOT="$temp_root" \
+  zsh -f <<'ZSH' || fail "an unload ownership contract regressed"
+builtin emulate -R zsh
+setopt pipe_fail
+
+builtin source "${ZI_TEST_CHECKOUT}/zi.zsh" || return 1
+.zi-prepare-home || return 1
+
+typeset binding_before="$(bindkey '^X^P')"
+
+# A single load followed by its unload removes everything the plug-in added.
+zi load "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+zi unload "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+(( ${+functions[first_impl]} == 0 )) || {
+  builtin print -u2 -r -- "single load: the function survived unload"
+  return 1
+}
+[[ -z ${widgets[zi-ownership-widget]} ]] || {
+  builtin print -u2 -r -- "single load: the widget survived unload: ${widgets[zi-ownership-widget]}"
+  return 1
+}
+[[ "$(bindkey '^X^P')" == "$binding_before" ]] || {
+  builtin print -u2 -r -- "single load: the key binding was not restored: $(bindkey '^X^P')"
+  return 1
+}
+
+# A second plug-in taking over the same widget and binding, then releasing it,
+# restores the first plug-in as the live owner rather than the original state.
+zi load "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+zi load "${ZI_TEST_ROOT}/second" >/dev/null 2>&1
+[[ ${widgets[zi-ownership-widget]} == *second_impl* ]] || {
+  builtin print -u2 -r -- "chain: the second plug-in did not take the widget"
+  return 1
+}
+zi unload "${ZI_TEST_ROOT}/second" >/dev/null 2>&1
+[[ ${widgets[zi-ownership-widget]} == *first_impl* ]] || {
+  builtin print -u2 -r -- "chain: the previous widget owner was not restored: ${widgets[zi-ownership-widget]}"
+  return 1
+}
+
+# Unloading the remaining plug-in returns the widget and the binding to the
+# state that preceded both loads.
+zi unload "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+[[ -z ${widgets[zi-ownership-widget]} ]] || {
+  builtin print -u2 -r -- "chain: the widget survived the final unload: ${widgets[zi-ownership-widget]}"
+  return 1
+}
+[[ "$(bindkey '^X^P')" == "$binding_before" ]] || {
+  builtin print -u2 -r -- "chain: the binding was not restored: $(bindkey '^X^P')"
+  return 1
+}
+
+# Unloading in a different order than loading removes only the plug-in named,
+# and leaves the other plug-in's state intact.
+zi load "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+zi load "${ZI_TEST_ROOT}/second" >/dev/null 2>&1
+zi unload "${ZI_TEST_ROOT}/first" >/dev/null 2>&1
+(( ${+functions[first_impl]} == 0 )) || {
+  builtin print -u2 -r -- "out-of-order: the unloaded plug-in's function survived"
+  return 1
+}
+(( ${+functions[second_impl]} == 1 )) || {
+  builtin print -u2 -r -- "out-of-order: the still-loaded plug-in's function was removed"
+  return 1
+}
+ZSH
+
+builtin print -r -- "ok - single load, owner chains and out-of-order unload all restore correctly"

--- a/zi.zsh
+++ b/zi.zsh
@@ -2379,7 +2379,7 @@ builtin setopt no_aliases
     "the list of the {cmd}subcommands$bcol.{rst}"
   }
 } # ]]]
-# FUNCTION: +zi-parse-opts. [[[
+# FUNCTION: .zi-parse-opts. [[[
 .zi-parse-opts() {
   builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob typeset_silent no_short_loops rc_quotes no_auto_pushd

--- a/zi.zsh
+++ b/zi.zsh
@@ -1283,6 +1283,49 @@ builtin setopt no_aliases
     ZI_EXTS[ice-mods]="${ZI_EXTS[ice-mods]}${icemods:+|}${(j:|:)${(@)${(@s:|:)icemods}/(#b)(#s)(?)/$index-$match[1]}}"
   }
 } # ]]]
+# FUNCTION: @zi-unregister-annex. [[[
+# Removes the registrations made by @zi-register-annex and @zi-register-hook for
+# one annex and one hook type, so an annex can remove its handler as the Zsh
+# Plugin Standard unload contract expects without leaving Zi dispatching to a
+# function that no longer exists.
+#
+# A stale registration is not inert. The before-load dispatch calls the stored
+# handler unconditionally, a missing function returns 127, and `127 & 1' is true,
+# so Zi folds the error into its return value and shifts its argument list on
+# every later plug-in load in the session.
+#
+# Unregistering something that was never registered is a no-op.
+#
+# Note: the ice-modifier list each registration contributed to
+# ZI_EXTS[ice-mods] and ZI_EXTS2[ice-mods] is not unwound. Registration appends
+# to a joined string without recording which annex contributed which entry, so
+# removing one annex's share would need that association to be recorded first.
+# A leftover ice name is recognised but dispatches to nothing, which is
+# harmless; the dispatch entry removed here is the part that corrupts loads.
+@zi-unregister-annex() {
+  builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+  builtin setopt extended_glob no_bang_hist typeset_silent
+
+  local name="$1" type="$2" ___key
+  local -a ___arr ___doomed
+
+  for ___key in "${(@k)ZI_EXTS}"; do
+    [[ $___key == (seqno|ice-mods) ]] && continue
+    ___arr=( "${(Q)${(z@)ZI_EXTS[$___key]}[@]}" )
+    [[ ${___arr[3]} == $name && ${___arr[4]} == $type ]] && ___doomed+=( "$___key" )
+  done
+  (( ${#___doomed} )) && unset "ZI_EXTS[${^___doomed[@]}]"
+
+  ___doomed=( )
+  for ___key in "${(@k)ZI_EXTS2}"; do
+    [[ $___key == (seqno|ice-mods) ]] && continue
+    ___arr=( "${(Q)${(z@)ZI_EXTS2[$___key]}[@]}" )
+    [[ ${___arr[3]} == $name && ${___arr[4]} == $type ]] && ___doomed+=( "$___key" )
+  done
+  (( ${#___doomed} )) && unset "ZI_EXTS2[${^___doomed[@]}]"
+
+  return 0
+} # ]]]
 # FUNCTION: @zi-register-hook. [[[
 # Registers the z-annex inside Zi.
 @zi-register-hook() {

--- a/zi.zsh
+++ b/zi.zsh
@@ -1406,13 +1406,18 @@ builtin setopt no_aliases
   local ___type="$1" ___id=$2
   local -a ___opt
   ___opt=( ${@[3,-1]} )
+  integer ___object_retval=0
   if [[ $___type == snippet ]] {
     .zi-load-snippet $___opt "$___id"
   } elif [[ $___type == plugin ]] {
     .zi-load "$___id" "" $___opt
   }
-  ___retval+=$?
-  return __retval
+  ___object_retval=$?
+  # Report only this load's status. The sole caller owns aggregation: it stores
+  # the value in ___last_retval, adds it to ___retval once, and gates turbo
+  # scheduling on it. Adding to the caller's ___retval here as well would
+  # double-count every failure.
+  return ___object_retval
 } # ]]]
 # FUNCTION:.zi-set-m-func() [[[
 # Sets and withdraws the temporary, atclone/atpull time function `m`.


### PR DESCRIPTION
# Promotion readiness record

## Candidate identity

- Prior `main` SHA: `9b6ab3502d69c214d58efecb2312b0495211d4b8`
- Candidate `next` SHA: `a3f2e76b23286c8f115009023b897ab039a265df`
- Candidate tree SHA: `69e715a4b3304768c58cef4caa9de0fee78447b0`
- Complete compare:
  [`main...next`](https://github.com/z-shell/zi/compare/9b6ab3502d69c214d58efecb2312b0495211d4b8...a3f2e76b23286c8f115009023b897ab039a265df)

- [x] `git diff --name-only a3f2e76...9b6ab35` produces no output.
- [x] `git rev-parse 'a3f2e76^{tree}'` equals `69e715a4b3304768c58cef4caa9de0fee78447b0`.

`git log --oneline a3f2e76..9b6ab35` contains `9b6ab35` and `8675819`, both prior promotion merges that exist only on `main` by design. The template calls this out. No stable-only content commit is stranded.

## Required validation

| Validation                                | Stable job name             | Result  |
| ----------------------------------------- | --------------------------- | ------- |
| Zsh syntax and compile                    | `Zsh syntax and compile`    | Pass    |
| ZD ZUnit integration                      | `ZD integration`            | Pass    |
| Trunk                                     | `Trunk`                     | Pass    |
| CodeQL                                    | `CodeQL`                    | Pass    |
| Exact-candidate clean install and startup | `Clean install and startup` | Pass    |
| Aggregate                                 | `Promotion gate`            | Pass    |

- [x] The candidate SHA has not changed since every required check completed. Re-fetched at merge time: base `9b6ab35`, head `a3f2e76`.
- [x] The `Guard main branch source` and `Promotion gate` required contexts pass. 175 checks green, none failing or skipped.
- [x] The complete file and commit compare contains only reviewed work: five commits, each from a merged pull request.

## Readiness review

### Contents

Five commits, three of them user-facing.

| Commit | Effect |
| :--- | :--- |
| #500 | `.zi-load-object` returned an undefined parameter, which zsh evaluates as `0`, so **every load reported success**. A failed immediate load counted as successful and turbo scheduling proceeded anyway. |
| #502 | The Plugin Standard unload function was unreachable for hyphenated repositories and for path-loaded plug-ins. |
| #503 | Adds `@zi-unregister-annex`. Annexes previously had no correct way to unload: a handler removed without unregistering leaves a stale `ZI_EXTS` entry, and the resulting 127 shifts the argument list so later plug-ins stop loading entirely. |
| #501 | Removes a duplicate `.zi-at-eval`, corrects two drifted `# FUNCTION:` headers, adds `tests/source-hygiene.zsh`. No behaviour change. |
| #504 | Pins the unload ownership contracts that already hold. Test only. |

### Unresolved issues

None blocking. Open issues are #113, #386, #387, #388, #429, #430, #445, #447, #448, #468, #499, #505. None is a regression introduced by this candidate. #113 and #505 are open on design decisions and both gained measured evidence during this work.

### User-facing and migration notes

No migration required. #500 and #502 restore intended behaviour that was broken. #503 is additive.

One behavioural consequence worth stating plainly: before #500, a failed load reported success, so any caller or user script that inspected `zi load`'s status was reading a constant `0`. After this promotion that status is real, so a load that was always silently failing will now report non-zero. That is the fix working, not a regression, but it can surface pre-existing failures that were invisible.

### Public-contract follow-ups

#503 adds a new public function, `@zi-unregister-annex`. The `Public contract impact` check passed on that pull request. The annex API is documented in the wiki at `ecosystem/annexes/0_overview.mdx`, which has no entry for it yet; that documentation is being prepared separately and does not gate this promotion.

`z-shell/z-a-meta-plugins` currently leaves an inert stub behind on unload as a workaround for the missing API, and can drop that once this reaches `main`.

- [ ] If the candidate introduces monitoring for a contract surface absent from the base, manually inventory that surface across the complete compare.

## Merge contract

Promotion uses **Create a merge commit**. Never squash or rebase.

- [ ] The resulting commit message has no bot, AI-agent, or automation `Co-authored-by` trailer.
- [x] `delete_branch_on_merge` is `false`; remote `next` will survive the merge.
- [ ] The `main` ruleset allows only merge commits and does not require linear history.
- [ ] The `next` ruleset does not require linear history.

## Rollback readiness

- Rollback owner: `@ss-o`
- Observable rollback criteria:
  - A plug-in or annex that loaded on v2.0.1 fails to load at the new `main` head.
  - An unload leaves state behind that v2.0.1 removed, or removes state it kept.
  - Any ZD ZUnit job fails against the new `main`.
- [ ] The owner can open a same-repository `hotfix-*` pull request that reverts the promotion merge through protected `main`.
- [ ] The revert pull request will run `Guard main branch source` and `Promotion gate`.
- [ ] After a revert, clean install and startup will be confirmed at the new `main` head, then the hotfix will be merged forward into `next`.

## Stable consumption boundary

This updates the Git-consumed stable `main` ref. It creates no semantic tag or GitHub release. v2.0.1 remains the newest tag. The open proposal #499 predates these commits and will refresh once `main` moves; any tag is a separately approved action.
