### PR TITLE
docs(contributing): document release authorization and repair the fences

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing! Please follow the guidelines below to keep the proje
 
 ## Branch model
 
-````text
+```text
 main       production and consumable ref
   |-- hotfix-<id>   urgent fixes that may target main
   ^
@@ -12,7 +12,7 @@ next       integration branch; ordinary PRs target here
   ^
   |-- feature-<id>  new features
   `-- bug-<id>      bug fixes
-```text
+```
 
 1. Branch ordinary work from `next`: `git switch -c bug-123 next`.
 2. Target `next` from `feature-<id>` and `bug-<id>` branches.
@@ -38,7 +38,7 @@ Wrap at 72 characters.
 Optional footer(s):
 Fixes #123
 BREAKING CHANGE: description of what breaks
-```text
+```
 
 **Allowed types:** `feat` `fix` `perf` `refactor` `docs` `test` `ci` `chore` `revert`
 
@@ -55,6 +55,41 @@ Repository rules intentionally omit linear-history requirements on both
 persistent branches so promotion and hotfix synchronization can preserve their
 merge commits.
 
+## Releases
+
+A promotion to `main` publishes nothing. It updates the Git-consumed stable ref
+and stops there.
+
+**A signed annotated tag is the sole publication authorization.** Nothing else
+creates a release: not a merge, not a green pipeline, not the automated
+proposal.
+
+1. After a promotion reaches `main`, `Release Prepare` opens or updates a
+   proposal issue with the next semantic version computed from Conventional
+   Commits and a draft changelog. It never creates a tag.
+2. A maintainer reviews the proposed version, adjusts it if the computed bump
+   does not describe the change, and pushes a signed annotated tag:
+
+   ```text
+   git switch main && git pull --ff-only
+   git tag -s vX.Y.Z -F <notes-file>
+   git push origin vX.Y.Z
+   ```
+
+3. `scripts/verify-release-tag.zsh` rejects the tag unless every one of the
+   following holds: it matches `vX.Y.Z`, it is annotated rather than
+   lightweight, GitHub reports its signature as verified, its target is the
+   current `origin/main`, and the `Zsh`, `ZD Integration`, `CodeQL` and
+   `Trunk Code Quality` workflows all succeeded on that exact commit.
+4. Only then is a GitHub release published, idempotently, with generated notes.
+
+The repository stores no version file. `ZI[VERSION]` is derived at runtime from
+`git describe --tags --exact-match`, so the tag is the version and there is
+nothing to keep in step with it.
+
+Closing a proposal issue without tagging skips that release; the next promotion
+opens a new proposal.
+
 ## What not to add
 
 - Root `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, or duplicate agent policy files.
@@ -66,4 +101,3 @@ merge commits.
 Before starting significant work, [open an issue](https://github.com/z-shell/zi/issues/new/choose) to discuss the change.
 
 See also the [community contributing guidelines](https://github.com/z-shell/community/blob/main/docs/CONTRIBUTING_GUIDELINES.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
-````


### PR DESCRIPTION
Closes the last open criterion of #468, and repairs a rendering defect found in the same file.

## #468 was almost complete already

Verified each acceptance criterion against what shipped in #470 and #497:

| Criterion | State |
| :--- | :--- |
| Minimal caller for the org release-preparation workflow | `release-prepare.yml:19` |
| Tag-triggered workflow, explicit permissions, non-cancelling concurrency | `release.yml`: `tags: ["v*.*.*"]`, `contents: write`, `cancel-in-progress: false` |
| Reject malformed, lightweight, unsigned, off-`main`, stale or under-validated tags | 12 rejection checks in `scripts/verify-release-tag.zsh` |
| Keep `main` as the boundary, no stored version file | `ZI[VERSION]` from `git describe --tags --exact-match` |
| Validate with actionlint, YAML parsing, focused tests, `git diff --check` | `tests/release-tag-verification.zsh` passes; actionlint enabled in `.trunk/trunk.yaml` |
| **Document the signed tag as the sole publication authorization** | **missing** |

The flow has also now run end to end in production: **v2.1.0** was published by the workflow itself, after the manual v2.0.1 exposed and fixed the missing Zsh install.

This PR adds the missing documentation: a `## Releases` section covering the proposal step, the maintainer-pushed signed tag as the only authorization, each condition the verifier enforces, and why there is no version file to keep in step.

## The rendering defect, not previously reported

`docs/CONTRIBUTING.md` opened its first fence with **four** backticks:

```text
line  7:  ````text
line 15:  ```text     <- three backticks plus an info string; cannot close it
line 69:  ````         <- the real closer
```

A fence closes only on a line with at least as many backticks and no info string. So lines 7 to 69 were one code block, and `## Commit message format`, `## What not to add` and `## Discussion and issues` all rendered as preformatted text rather than markdown.

Verified by walking the fences before and after:

```text
before:  fence 7 -> 69     58 lines rendered as code
after:   fence 7 -> 15
         fence 32 -> 41    15 lines rendered as code
```

Fifteen is the intended amount: the branch diagram and the commit-message example, plus the new release example.

I found this while looking for where release authorization was documented. Fixing it was unavoidable, since adding a section to a file whose body renders as a code block would have hidden the new section too.

Closes #468
